### PR TITLE
Compatibility for ReflectionParameter

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -109,13 +109,13 @@
 | getDeclaringClass | :heavy_check_mark: Yes |
 | getDeclaringFunction | :heavy_check_mark: Yes |
 | getDefaultValue | :heavy_check_mark: Yes (*some assumptions are made) |
-| getDefaultValueConstantName | todo |
+| getDefaultValueConstantName | :heavy_check_mark: Yes |
 | getName | :heavy_check_mark: Yes |
 | getPosition | :heavy_check_mark: Yes |
 | isArray | :heavy_check_mark: Yes |
 | isCallable | :heavy_check_mark: Yes |
 | isDefaultValueAvailable | :heavy_check_mark: Yes |
-| isDefaultValueConstant | todo |
+| isDefaultValueConstant | :heavy_check_mark: Yes |
 | isOptional | :heavy_check_mark: Yes |
 | isPassedByReference | :heavy_check_mark: Yes |
 | isVariadic | :heavy_check_mark: Yes |

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -111,7 +111,7 @@
 | getDefaultValue | :heavy_check_mark: Yes (*some assumptions are made) |
 | getDefaultValueConstantName | todo |
 | getName | :heavy_check_mark: Yes |
-| getPosition | todo |
+| getPosition | :heavy_check_mark: Yes |
 | isArray | todo |
 | isCallable | todo |
 | isDefaultValueAvailable | todo |

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -114,11 +114,11 @@
 | getPosition | :heavy_check_mark: Yes |
 | isArray | :heavy_check_mark: Yes |
 | isCallable | :heavy_check_mark: Yes |
-| isDefaultValueAvailable | todo |
+| isDefaultValueAvailable | :heavy_check_mark: Yes |
 | isDefaultValueConstant | todo |
 | isOptional | :heavy_check_mark: Yes |
-| isPassedByReference | todo |
-| isVariadic | todo |
+| isPassedByReference | :heavy_check_mark: Yes |
+| isVariadic | :heavy_check_mark: Yes |
 
 ## ReflectionFunction
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -104,8 +104,8 @@
 | Method | Supported |
 |--------|-----------|
 | allowsNull | :heavy_check_mark: Yes |
-| canBePassedByValue | todo |
-| getClass | todo |
+| canBePassedByValue | :heavy_check_mark: Yes |
+| getClass | :x: No - could currently cause recursion |
 | getDeclaringClass | :heavy_check_mark: Yes |
 | getDeclaringFunction | :heavy_check_mark: Yes |
 | getDefaultValue | :heavy_check_mark: Yes (*some assumptions are made) |

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -112,8 +112,8 @@
 | getDefaultValueConstantName | todo |
 | getName | :heavy_check_mark: Yes |
 | getPosition | :heavy_check_mark: Yes |
-| isArray | todo |
-| isCallable | todo |
+| isArray | :heavy_check_mark: Yes |
+| isCallable | :heavy_check_mark: Yes |
 | isDefaultValueAvailable | todo |
 | isDefaultValueConstant | todo |
 | isOptional | :heavy_check_mark: Yes |

--- a/src/ReflectionFunctionAbstract.php
+++ b/src/ReflectionFunctionAbstract.php
@@ -48,6 +48,22 @@ abstract class ReflectionFunctionAbstract
             $this->docBlock = $comment->getReformattedText();
         }
 
+        // We must determine if params are optional or not ahead of time, but
+        // we must do it in reverse...
+        $overallOptionalFlag = true;
+        for ($i = count($node->params) - 1; $i >= 0; $i--) {
+            $hasDefault = !is_null($node->params[$i]->default);
+
+            // When we find the first parameter that does not have a default,
+            // flip the flag as all params for this are no longer optional
+            // EVEN if they have a default value
+            if (!$hasDefault) {
+                $overallOptionalFlag = false;
+            }
+
+            $node->params[$i]->isOptional = $overallOptionalFlag;
+        }
+
         foreach ($node->params as $paramIndex => $paramNode) {
             $this->parameters[] = ReflectionParameter::createFromNode($paramNode, $this, $paramIndex);
         }

--- a/src/ReflectionFunctionAbstract.php
+++ b/src/ReflectionFunctionAbstract.php
@@ -52,7 +52,7 @@ abstract class ReflectionFunctionAbstract
         // we must do it in reverse...
         $overallOptionalFlag = true;
         for ($i = count($node->params) - 1; $i >= 0; $i--) {
-            $hasDefault = !is_null($node->params[$i]->default);
+            $hasDefault = ($node->params[$i]->default !== null);
 
             // When we find the first parameter that does not have a default,
             // flip the flag as all params for this are no longer optional

--- a/src/ReflectionFunctionAbstract.php
+++ b/src/ReflectionFunctionAbstract.php
@@ -51,7 +51,8 @@ abstract class ReflectionFunctionAbstract
         // We must determine if params are optional or not ahead of time, but
         // we must do it in reverse...
         $overallOptionalFlag = true;
-        for ($i = count($node->params) - 1; $i >= 0; $i--) {
+        $lastParamIndex = (count($node->params) - 1);
+        for ($i = $lastParamIndex; $i >= 0; $i--) {
             $hasDefault = ($node->params[$i]->default !== null);
 
             // When we find the first parameter that does not have a default,

--- a/src/ReflectionParameter.php
+++ b/src/ReflectionParameter.php
@@ -2,6 +2,7 @@
 
 namespace BetterReflection;
 
+use phpDocumentor\Reflection\Types;
 use PhpParser\Node\Param as ParamNode;
 use PhpParser\Node;
 use phpDocumentor\Reflection\Type;
@@ -238,5 +239,25 @@ class ReflectionParameter implements \Reflector
     public function getTypeHint()
     {
         return $this->typeHint;
+    }
+
+    /**
+     * Is this parameter an array?
+     *
+     * @return bool
+     */
+    public function isArray()
+    {
+        return ($this->getTypeHint() instanceof Types\Array_);
+    }
+
+    /**
+     * Is this parameter a callable?
+     *
+     * @return bool
+     */
+    public function isCallable()
+    {
+        return ($this->getTypeHint() instanceof Types\Callable_);
     }
 }

--- a/src/ReflectionParameter.php
+++ b/src/ReflectionParameter.php
@@ -54,7 +54,7 @@ class ReflectionParameter implements \Reflector
     private $types;
 
     /**
-     * @var Type
+     * @var Type|null
      */
     private $typeHint;
 

--- a/src/ReflectionParameter.php
+++ b/src/ReflectionParameter.php
@@ -66,23 +66,20 @@ class ReflectionParameter implements \Reflector
     /**
      * @var bool
      */
-    private $isDefaultValueConstant;
+    private $isDefaultValueConstant = false;
 
     /**
      * @var string
      */
-    private $defaultValueConstantName;
+    private $defaultValueConstantName = null;
 
     /**
      * @var int
      */
-    private $defaultValueConstantType;
+    private $defaultValueConstantType = self::CONST_TYPE_NOT_A_CONST;
 
     private function __construct()
     {
-        $this->isDefaultValueConstant = false;
-        $this->defaultValueConstantName = null;
-        $this->defaultValueConstantType = self::CONST_TYPE_NOT_A_CONST;
     }
 
     public static function export()

--- a/src/ReflectionParameter.php
+++ b/src/ReflectionParameter.php
@@ -213,4 +213,14 @@ class ReflectionParameter implements \Reflector
     {
         return $this->types;
     }
+
+    /**
+     * Find the position of the parameter, left to right, starting at zero
+     *
+     * @return int
+     */
+    public function getPosition()
+    {
+        return $this->parameterIndex;
+    }
 }

--- a/src/ReflectionParameter.php
+++ b/src/ReflectionParameter.php
@@ -318,4 +318,12 @@ class ReflectionParameter implements \Reflector
     {
         return $this->isByReference;
     }
+
+    /**
+     * @return bool
+     */
+    public function canBePassedByValue()
+    {
+        return !$this->isPassedByReference();
+    }
 }

--- a/src/ReflectionParameter.php
+++ b/src/ReflectionParameter.php
@@ -287,6 +287,12 @@ class ReflectionParameter implements \Reflector
     }
 
     /**
+     * Get the types defined in the docblocks. This returns an array because
+     * the parameter may have multiple (compound) types specified (for example
+     * when you type hint pipe-separated "string|null", in which case this
+     * would return an array of Type objects, one for string, one for null.
+     *
+     * @see getTypeHint()
      * @return Type[]
      */
     public function getTypes()
@@ -305,8 +311,11 @@ class ReflectionParameter implements \Reflector
     }
 
     /**
-     * Get the type hint declared for the parameter
+     * Get the type hint declared for the parameter. This is the real type hint
+     * for the parameter, e.g. `method(closure $someFunc)` defined by the
+     * method itself, and is separate from the docblock type hints
      *
+     * @see getTypes()
      * @return Type
      */
     public function getTypeHint()

--- a/src/ReflectionParameter.php
+++ b/src/ReflectionParameter.php
@@ -127,25 +127,30 @@ class ReflectionParameter implements \Reflector
         $param->typeHint = TypesFinder::findTypeForAstType($node->type);
 
         if ($param->hasDefaultValue) {
-            $param->defaultValue = Reflector::compileNodeExpression($node->default);
-
-            if ($node->default instanceof Node\Expr\ClassConstFetch) {
-                $param->isDefaultValueConstant = true;
-                $param->defaultValueConstantName = $node->default->name;
-                $param->defaultValueConstantType = self::CONST_TYPE_CLASS;
-            }
-
-            if ($node->default instanceof Node\Expr\ConstFetch
-                && !in_array($node->default->name->parts[0], ['true', 'false', 'null'])) {
-                $param->isDefaultValueConstant = true;
-                $param->defaultValueConstantName = $node->default->name->parts[0];
-                $param->defaultValueConstantType = self::CONST_TYPE_DEFINED;
-            }
+            $param->parseDefaultValueNode($node->default);
         }
 
         $param->types = TypesFinder::findTypeForParameter($function, $node);
 
         return $param;
+    }
+
+    private function parseDefaultValueNode(Node $defaultValueNode)
+    {
+        $this->defaultValue = Reflector::compileNodeExpression($defaultValueNode);
+
+        if ($defaultValueNode instanceof Node\Expr\ClassConstFetch) {
+            $this->isDefaultValueConstant = true;
+            $this->defaultValueConstantName = $defaultValueNode->name;
+            $this->defaultValueConstantType = self::CONST_TYPE_CLASS;
+        }
+
+        if ($defaultValueNode instanceof Node\Expr\ConstFetch
+            && !in_array($defaultValueNode->name->parts[0], ['true', 'false', 'null'])) {
+            $this->isDefaultValueConstant = true;
+            $this->defaultValueConstantName = $defaultValueNode->name->parts[0];
+            $this->defaultValueConstantType = self::CONST_TYPE_DEFINED;
+        }
     }
 
     /**

--- a/src/ReflectionParameter.php
+++ b/src/ReflectionParameter.php
@@ -91,9 +91,9 @@ class ReflectionParameter implements \Reflector
         $param->name = $node->name;
         $param->function = $function;
         $param->isOptional = !is_null($node->default);
-        $param->isVariadic = $node->variadic;
-        $param->isByReference = $node->byRef;
-        $param->parameterIndex = $parameterIndex;
+        $param->isVariadic = (bool)$node->variadic;
+        $param->isByReference = (bool)$node->byRef;
+        $param->parameterIndex = (int)$parameterIndex;
         $param->typeHint = TypesFinder::findTypeForAstType($node->type);
 
         if ($param->isOptional) {
@@ -259,5 +259,15 @@ class ReflectionParameter implements \Reflector
     public function isCallable()
     {
         return ($this->getTypeHint() instanceof Types\Callable_);
+    }
+
+    /**
+     * Is this parameter a variadic (denoted by ...$param)
+     *
+     * @return bool
+     */
+    public function isVariadic()
+    {
+        return $this->isVariadic;
     }
 }

--- a/src/ReflectionParameter.php
+++ b/src/ReflectionParameter.php
@@ -270,4 +270,14 @@ class ReflectionParameter implements \Reflector
     {
         return $this->isVariadic;
     }
+
+    /**
+     * Is this parameter passed by reference (denoted by &$param)
+     *
+     * @return bool
+     */
+    public function isPassedByReference()
+    {
+        return $this->isByReference;
+    }
 }

--- a/src/ReflectionParameter.php
+++ b/src/ReflectionParameter.php
@@ -227,7 +227,15 @@ class ReflectionParameter implements \Reflector
      */
     public function allowsNull()
     {
-        return $this->isOptional() && $this->getDefaultValue() === null;
+        if (null == $this->getTypeHint()) {
+            return true;
+        }
+
+        if (!$this->isDefaultValueAvailable()) {
+            return false;
+        }
+
+        return $this->getDefaultValue() == null;
     }
 
     /**

--- a/src/ReflectionParameter.php
+++ b/src/ReflectionParameter.php
@@ -44,6 +44,11 @@ class ReflectionParameter implements \Reflector
     private $types;
 
     /**
+     * @var Type
+     */
+    private $typeHint;
+
+    /**
      * @var int
      */
     private $parameterIndex;
@@ -88,6 +93,7 @@ class ReflectionParameter implements \Reflector
         $param->isVariadic = $node->variadic;
         $param->isByReference = $node->byRef;
         $param->parameterIndex = $parameterIndex;
+        $param->typeHint = TypesFinder::findTypeForAstType($node->type);
 
         if ($param->isOptional) {
             $param->defaultValue = Reflector::compileNodeExpression($node->default);
@@ -222,5 +228,15 @@ class ReflectionParameter implements \Reflector
     public function getPosition()
     {
         return $this->parameterIndex;
+    }
+
+    /**
+     * Get the type hint declared for the parameter
+     *
+     * @return Type
+     */
+    public function getTypeHint()
+    {
+        return $this->typeHint;
     }
 }

--- a/src/Reflector.php
+++ b/src/Reflector.php
@@ -184,11 +184,17 @@ class Reflector
                 } else if ($node->name->parts[0] == 'true') {
                     return true;
                 } else {
-                    throw new \LogicException('Other ConstFetch types are not implemented yet');
+                    // @todo this should evaluate the VALUE, not the name
+                    return $node->name->parts[0];
                 }
                 break;
+            case Node\Expr\ClassConstFetch::class:
+                // @todo this should evaluate the VALUE, not the name
+                $className = implode('\\', $node->class->parts);
+                $constName = $node->name;
+                return $className . '::' . $constName;
             default:
-                throw new \LogicException('Unable to compile expression');
+                throw new \LogicException('Unable to compile expression: ' . $type);
         }
     }
 }

--- a/src/TypesFinder.php
+++ b/src/TypesFinder.php
@@ -2,6 +2,7 @@
 
 namespace BetterReflection;
 
+use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\Stmt\Property as PropertyNode;
 use PhpParser\Node\Param as ParamNode;
 use phpDocumentor\Reflection\DocBlock;
@@ -59,6 +60,32 @@ class TypesFinder
             }
         }
         return [];
+    }
+
+    /**
+     * Given an AST type, attempt to find a resolved type
+     *
+     * @todo resolve with context
+     * @param $astType
+     * @return \phpDocumentor\Reflection\Type|null
+     */
+    public static function findTypeForAstType($astType)
+    {
+        if (is_string($astType)) {
+            $typeString = $astType;
+        }
+
+        if ($astType instanceof FullyQualified) {
+            $typeString = implode('\\', $astType->parts);
+        }
+
+        if (!isset($typeString)) {
+            return null;
+        }
+
+        $types = self::resolveTypes([$typeString]);
+
+        return reset($types);
     }
 
     /**

--- a/test/Fixture/ClassForHinting.php
+++ b/test/Fixture/ClassForHinting.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace BetterReflectionTest\Fixture;
+
+class ClassForHinting
+{
+}

--- a/test/Fixture/MethodsTest.php
+++ b/test/Fixture/MethodsTest.php
@@ -49,4 +49,13 @@ abstract class MethodsTest
     public function methodWithOptionalParameters($parameter, $optionalParameter = null)
     {
     }
+
+    public function methodWithExplicitTypedParameters(
+        \stdClass $stdClassParameter,
+        ClassForHinting $namespaceClassParameter,
+        \BetterReflectionTest\Fixture\ClassForHinting $fullyQualifiedClassParameter,
+        array $arrayParameter,
+        callable $callableParameter
+    ) {
+    }
 }

--- a/test/Fixture/MethodsTest.php
+++ b/test/Fixture/MethodsTest.php
@@ -62,4 +62,8 @@ abstract class MethodsTest
     public function methodWithVariadic($nonVariadicParameter, ...$variadicParameter)
     {
     }
+
+    public function methodWithReference($nonRefParameter, &$refParameter)
+    {
+    }
 }

--- a/test/Fixture/MethodsTest.php
+++ b/test/Fixture/MethodsTest.php
@@ -2,8 +2,12 @@
 
 namespace BetterReflectionTest\Fixture;
 
+define('SOME_DEFINED_VALUE', 1);
+
 abstract class MethodsTest
 {
+    const SOME_CONST = 1;
+
     public function __construct()
     {
     }
@@ -72,6 +76,10 @@ abstract class MethodsTest
     }
 
     public function methodToCheckAllowsNull($allowsNull, \stdClass $hintDisallowNull, \stdClass $hintAllowNull = null)
+    {
+    }
+
+    public function methodWithConstAsDefault($intDefault = 1, $constDefault = self::SOME_CONST, $definedDefault = SOME_DEFINED_VALUE)
     {
     }
 }

--- a/test/Fixture/MethodsTest.php
+++ b/test/Fixture/MethodsTest.php
@@ -58,4 +58,8 @@ abstract class MethodsTest
         callable $callableParameter
     ) {
     }
+
+    public function methodWithVariadic($nonVariadicParameter, ...$variadicParameter)
+    {
+    }
 }

--- a/test/Fixture/MethodsTest.php
+++ b/test/Fixture/MethodsTest.php
@@ -70,4 +70,8 @@ abstract class MethodsTest
     public function methodWithNonOptionalDefaultValue($firstParameter = 'someValue', $secondParameter)
     {
     }
+
+    public function methodToCheckAllowsNull($allowsNull, \stdClass $hintDisallowNull, \stdClass $hintAllowNull = null)
+    {
+    }
 }

--- a/test/Fixture/MethodsTest.php
+++ b/test/Fixture/MethodsTest.php
@@ -66,4 +66,8 @@ abstract class MethodsTest
     public function methodWithReference($nonRefParameter, &$refParameter)
     {
     }
+
+    public function methodWithNonOptionalDefaultValue($firstParameter = 'someValue', $secondParameter)
+    {
+    }
 }

--- a/test/ReflectionParameterTest.php
+++ b/test/ReflectionParameterTest.php
@@ -69,4 +69,17 @@ class ReflectionParameterTest extends \PHPUnit_Framework_TestCase
         $optionalParam = $method->getParameter('optionalParameter');
         $this->assertSame('Parameter #1 [ <optional> $optionalParameter = null ]', (string)$optionalParam);
     }
+
+    public function testGetPositions()
+    {
+        $classInfo = $this->reflector->reflect('\BetterReflectionTest\Fixture\MethodsTest');
+
+        $method = $classInfo->getMethod('methodWithParameters');
+
+        $param1 = $method->getParameter('parameter1');
+        $this->assertSame(0, $param1->getPosition());
+
+        $param2 = $method->getParameter('parameter2');
+        $this->assertSame(1, $param2->getPosition());
+    }
 }

--- a/test/ReflectionParameterTest.php
+++ b/test/ReflectionParameterTest.php
@@ -169,9 +169,11 @@ class ReflectionParameterTest extends \PHPUnit_Framework_TestCase
 
         $nonRefParam = $method->getParameter('nonRefParameter');
         $this->assertFalse($nonRefParam->isPassedByReference());
+        $this->assertTrue($nonRefParam->canBePassedByValue());
 
         $refParam = $method->getParameter('refParameter');
         $this->assertTrue($refParam->isPassedByReference());
+        $this->assertFalse($refParam->canBePassedByValue());
     }
 
     public function testGetDefaultValueAndIsOptional()

--- a/test/ReflectionParameterTest.php
+++ b/test/ReflectionParameterTest.php
@@ -204,4 +204,21 @@ class ReflectionParameterTest extends \PHPUnit_Framework_TestCase
         $thirdParam = $method->getParameter('hintAllowNull');
         $this->assertTrue($thirdParam->allowsNull());
     }
+
+    public function testIsDefaultValueConstantAndGetDefaultValueConstantName()
+    {
+        $classInfo = $this->reflector->reflect('\BetterReflectionTest\Fixture\MethodsTest');
+        $method = $classInfo->getMethod('methodWithConstAsDefault');
+
+        $intDefault = $method->getParameter('intDefault');
+        $this->assertFalse($intDefault->isDefaultValueConstant());
+
+        $constDefault = $method->getParameter('constDefault');
+        $this->assertTrue($constDefault->isDefaultValueConstant());
+        $this->assertSame('SOME_CONST', $constDefault->getDefaultValueConstantName());
+
+        $definedDefault = $method->getParameter('definedDefault');
+        $this->assertTrue($definedDefault->isDefaultValueConstant());
+        $this->assertSame('SOME_DEFINED_VALUE', $definedDefault->getDefaultValueConstantName());
+    }
 }

--- a/test/ReflectionParameterTest.php
+++ b/test/ReflectionParameterTest.php
@@ -160,4 +160,17 @@ class ReflectionParameterTest extends \PHPUnit_Framework_TestCase
         $variadicParam = $method->getParameter('variadicParameter');
         $this->assertTrue($variadicParam->isVariadic());
     }
+
+    public function testIsPassedByReference()
+    {
+        $classInfo = $this->reflector->reflect('\BetterReflectionTest\Fixture\MethodsTest');
+
+        $method = $classInfo->getMethod('methodWithReference');
+
+        $nonRefParam = $method->getParameter('nonRefParameter');
+        $this->assertFalse($nonRefParam->isPassedByReference());
+
+        $refParam = $method->getParameter('refParameter');
+        $this->assertTrue($refParam->isPassedByReference());
+    }
 }

--- a/test/ReflectionParameterTest.php
+++ b/test/ReflectionParameterTest.php
@@ -147,4 +147,17 @@ class ReflectionParameterTest extends \PHPUnit_Framework_TestCase
         $arrayParam = $method->getParameter('arrayParameter');
         $this->assertTrue($arrayParam->isArray());
     }
+
+    public function testIsVariadic()
+    {
+        $classInfo = $this->reflector->reflect('\BetterReflectionTest\Fixture\MethodsTest');
+
+        $method = $classInfo->getMethod('methodWithVariadic');
+
+        $nonVariadicParam = $method->getParameter('nonVariadicParameter');
+        $this->assertFalse($nonVariadicParam->isVariadic());
+
+        $variadicParam = $method->getParameter('variadicParameter');
+        $this->assertTrue($variadicParam->isVariadic());
+    }
 }

--- a/test/ReflectionParameterTest.php
+++ b/test/ReflectionParameterTest.php
@@ -121,4 +121,30 @@ class ReflectionParameterTest extends \PHPUnit_Framework_TestCase
             $this->assertSame($expectedFqsenName, $type->getFqsen()->getName());
         }
     }
+
+    public function testIsCallable()
+    {
+        $classInfo = $this->reflector->reflect('\BetterReflectionTest\Fixture\MethodsTest');
+
+        $method = $classInfo->getMethod('methodWithExplicitTypedParameters');
+
+        $nonCallableParam = $method->getParameter('stdClassParameter');
+        $this->assertFalse($nonCallableParam->isCallable());
+
+        $callableParam = $method->getParameter('callableParameter');
+        $this->assertTrue($callableParam->isCallable());
+    }
+
+    public function testIsArray()
+    {
+        $classInfo = $this->reflector->reflect('\BetterReflectionTest\Fixture\MethodsTest');
+
+        $method = $classInfo->getMethod('methodWithExplicitTypedParameters');
+
+        $nonArrayParam = $method->getParameter('stdClassParameter');
+        $this->assertFalse($nonArrayParam->isArray());
+
+        $arrayParam = $method->getParameter('arrayParameter');
+        $this->assertTrue($arrayParam->isArray());
+    }
 }

--- a/test/ReflectionParameterTest.php
+++ b/test/ReflectionParameterTest.php
@@ -173,4 +173,18 @@ class ReflectionParameterTest extends \PHPUnit_Framework_TestCase
         $refParam = $method->getParameter('refParameter');
         $this->assertTrue($refParam->isPassedByReference());
     }
+
+    public function testGetDefaultValueAndIsOptional()
+    {
+        $classInfo = $this->reflector->reflect('\BetterReflectionTest\Fixture\MethodsTest');
+        $method = $classInfo->getMethod('methodWithNonOptionalDefaultValue');
+
+        $firstParam = $method->getParameter('firstParameter');
+        $this->assertFalse($firstParam->isOptional());
+        $this->assertTrue($firstParam->isDefaultValueAvailable());
+
+        $secondParam = $method->getParameter('secondParameter');
+        $this->assertFalse($secondParam->isOptional());
+        $this->assertFalse($secondParam->isDefaultValueAvailable());
+    }
 }

--- a/test/ReflectionParameterTest.php
+++ b/test/ReflectionParameterTest.php
@@ -187,4 +187,19 @@ class ReflectionParameterTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($secondParam->isOptional());
         $this->assertFalse($secondParam->isDefaultValueAvailable());
     }
+
+    public function testAllowsNull()
+    {
+        $classInfo = $this->reflector->reflect('\BetterReflectionTest\Fixture\MethodsTest');
+        $method = $classInfo->getMethod('methodToCheckAllowsNull');
+
+        $firstParam = $method->getParameter('allowsNull');
+        $this->assertTrue($firstParam->allowsNull());
+
+        $secondParam = $method->getParameter('hintDisallowNull');
+        $this->assertFalse($secondParam->allowsNull());
+
+        $thirdParam = $method->getParameter('hintAllowNull');
+        $this->assertTrue($thirdParam->allowsNull());
+    }
 }

--- a/test/ReflectionParameterTest.php
+++ b/test/ReflectionParameterTest.php
@@ -3,6 +3,7 @@
 namespace BetterReflectionTest;
 
 use BetterReflection\Reflector;
+use phpDocumentor\Reflection\Types;
 
 class ReflectionParameterTest extends \PHPUnit_Framework_TestCase
 {
@@ -81,5 +82,43 @@ class ReflectionParameterTest extends \PHPUnit_Framework_TestCase
 
         $param2 = $method->getParameter('parameter2');
         $this->assertSame(1, $param2->getPosition());
+    }
+
+    public function typeHintProvider()
+    {
+        return [
+            ['stdClassParameter', Types\Object_::class, '\stdClass', 'stdClass'],
+            ['fullyQualifiedClassParameter', Types\Object_::class, '\BetterReflectionTest\Fixture\ClassForHinting', 'ClassForHinting'],
+            ['arrayParameter', Types\Array_::class],
+            ['callableParameter', Types\Callable_::class],
+
+            // @todo Currently failing as we cannot resolve this properly yet
+            //['namespaceClassParameter', Types\Object__::class, 'ClassForHinting'],
+        ];
+    }
+
+    /**
+     * @dataProvider typeHintProvider
+     * @param string $parameterToTest
+     * @param string $expectedType
+     * @param string|null $expectedFqsen
+     * @param string|null $expectedFqsenName
+     */
+    public function testGetTypeHint($parameterToTest, $expectedType, $expectedFqsen = null, $expectedFqsenName = null)
+    {
+        $classInfo = $this->reflector->reflect('\BetterReflectionTest\Fixture\MethodsTest');
+
+        $method = $classInfo->getMethod('methodWithExplicitTypedParameters');
+
+        $type = $method->getParameter($parameterToTest)->getTypeHint();
+        $this->assertInstanceOf($expectedType, $type);
+
+        if (null !== $expectedFqsen) {
+            $this->assertSame($expectedFqsen, (string)$type->getFqsen());
+        }
+
+        if (null !== $expectedFqsenName) {
+            $this->assertSame($expectedFqsenName, $type->getFqsen()->getName());
+        }
     }
 }


### PR DESCRIPTION
As part of #7, this PR brings full compatibility with `ReflectionParameter` (where possible) 

* [x] isArray
* [x] isCallable
* [x] getPosition
* [x] isDefaultValueAvailable
* [x] canBePassedByValue
* [x] getClass
* [x] getDefaultValueConstantName
* [x] isDefaultValueConstant
* [x] isPassedByReference
* [x] isVariadic