### PR TITLE
ResolveTypes invokable now requires Context always

### DIFF
--- a/src/TypesFinder/FindParameterType.php
+++ b/src/TypesFinder/FindParameterType.php
@@ -2,6 +2,7 @@
 
 namespace BetterReflection\TypesFinder;
 
+use phpDocumentor\Reflection\Types\Context;
 use PhpParser\Node\Param as ParamNode;
 use phpDocumentor\Reflection\DocBlock;
 use phpDocumentor\Reflection\Type;
@@ -26,7 +27,7 @@ class FindParameterType
         foreach ($paramTags as $paramTag) {
             /* @var $paramTag \phpDocumentor\Reflection\DocBlock\Tag\ParamTag */
             if ($paramTag->getVariableName() === '$' . $node->name) {
-                return (new ResolveTypes())->__invoke($paramTag->getTypes());
+                return (new ResolveTypes())->__invoke($paramTag->getTypes(), new Context(''));
             }
         }
         return [];

--- a/src/TypesFinder/FindParameterType.php
+++ b/src/TypesFinder/FindParameterType.php
@@ -27,6 +27,7 @@ class FindParameterType
         foreach ($paramTags as $paramTag) {
             /* @var $paramTag \phpDocumentor\Reflection\DocBlock\Tag\ParamTag */
             if ($paramTag->getVariableName() === '$' . $node->name) {
+                // @todo https://github.com/Roave/BetterReflection/issues/29
                 return (new ResolveTypes())->__invoke($paramTag->getTypes(), new Context(''));
             }
         }

--- a/src/TypesFinder/FindTypeFromAst.php
+++ b/src/TypesFinder/FindTypeFromAst.php
@@ -28,6 +28,7 @@ class FindTypeFromAst
             return null;
         }
 
+        // @todo https://github.com/Roave/BetterReflection/issues/30
         $types = (new ResolveTypes())->__invoke([$typeString], new Context(''));
 
         return reset($types);

--- a/src/TypesFinder/FindTypeFromAst.php
+++ b/src/TypesFinder/FindTypeFromAst.php
@@ -2,6 +2,7 @@
 
 namespace BetterReflection\TypesFinder;
 
+use phpDocumentor\Reflection\Types\Context;
 use PhpParser\Node\Name\FullyQualified;
 
 class FindTypeFromAst
@@ -27,7 +28,7 @@ class FindTypeFromAst
             return null;
         }
 
-        $types = (new ResolveTypes())->__invoke([$typeString]);
+        $types = (new ResolveTypes())->__invoke([$typeString], new Context(''));
 
         return reset($types);
     }

--- a/src/TypesFinder/ResolveTypes.php
+++ b/src/TypesFinder/ResolveTypes.php
@@ -12,7 +12,7 @@ class ResolveTypes
      * @param Context $context
      * @return \phpDocumentor\Reflection\Type[]
      */
-    public function __invoke($stringTypes, Context $context = null)
+    public function __invoke($stringTypes, Context $context)
     {
         $resolvedTypes = [];
         $resolver = new TypeResolver();


### PR DESCRIPTION
Fixes #31. I managed to fix this without requiring #29 and #30 to be done by using a dummy context (which is what phpDocumentor does internally), which means we can fix the API early, and implement #29 and #30 independently (once this is merged at least).