### PR TITLE
Compatibility for ReflectionFunctionAbstract and ReflectionFunction

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -78,7 +78,7 @@ The progress of compatibility can also be tracked in issue [#7](https://github.c
 | isInternal | :heavy_check_mark: Yes - but see issue (#38) |
 | isUserDefined | :heavy_check_mark: Yes |
 | isVariadic | :heavy_check_mark: Yes |
-| returnsReference | todo |
+| returnsReference | :heavy_check_mark: Ye |
 
 ## ReflectionMethod
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -74,7 +74,7 @@ The progress of compatibility can also be tracked in issue [#7](https://github.c
 | inNamespace | :heavy_check_mark: Yes |
 | isClosure | :heavy_check_mark: Yes - but see issue (#37) |
 | isDeprecated | :heavy_check_mark: Yes - but see issue (#38) |
-| isGenerator | todo |
+| isGenerator | :heavy_check_mark: Yes |
 | isInternal | :heavy_check_mark: Yes - but see issue (#38) |
 | isUserDefined | :heavy_check_mark: Yes |
 | isVariadic | :heavy_check_mark: Yes |

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -59,7 +59,7 @@ The progress of compatibility can also be tracked in issue [#7](https://github.c
 | getClosureScopeClass | :x: No - would require loading of the method itself (#14) |
 | getClosureThis | :x: No - would require loading of the method itself (#14) |
 | getDocComment | :heavy_check_mark: Yes |
-| getEndLine | todo |
+| getEndLine | :heavy_check_mark: Yes |
 | getExtension | :x: No - extensions are not supported (#15) |
 | getExtensionName | :x: No - extensions are not supported (#15) |
 | getFileName | :heavy_check_mark: Yes |
@@ -69,7 +69,7 @@ The progress of compatibility can also be tracked in issue [#7](https://github.c
 | getNumberOfRequiredParameters | :heavy_check_mark: Yes |
 | getParameters | :heavy_check_mark: Yes |
 | getShortName | :heavy_check_mark: Yes |
-| getStartLine | todo |
+| getStartLine | :heavy_check_mark: Yes |
 | getStaticVariables | todo |
 | inNamespace | :heavy_check_mark: Yes |
 | isClosure | :heavy_check_mark: Yes - but see issue (#37) |

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -129,7 +129,7 @@ The progress of compatibility can also be tracked in issue [#7](https://github.c
 | getClosure | :x: No - would require actual compilation of the AST (#14) |
 | invoke | :x: No - would require loading of the function itself (#14) |
 | invokeArgs | :x: No - would require loading of the function itself (#14) |
-| isDisabled | todo |
+| isDisabled | :heavy_check_mark: Yes (note - we cannot currently reflect internal functions, so always returns false) |
 | _inherited methods_ | see `ReflectionFunctionAbstract` |
 
 ## ReflectionProperty

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -56,12 +56,12 @@ The progress of compatibility can also be tracked in issue [#7](https://github.c
 
 | Method | Supported |
 |--------|-----------|
-| getClosureScopeClass | todo |
-| getClosureThis | todo |
+| getClosureScopeClass | :x: No - would require loading of the method itself (#14) |
+| getClosureThis | :x: No - would require loading of the method itself (#14) |
 | getDocComment | :heavy_check_mark: Yes |
 | getEndLine | todo |
-| getExtension | todo |
-| getExtensionName | todo |
+| getExtension | :x: No - extensions are not supported (#15) |
+| getExtensionName | :x: No - extensions are not supported (#15) |
 | getFileName | :heavy_check_mark: Yes |
 | getName | :heavy_check_mark: Yes |
 | getNamespaceName | todo |

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -77,7 +77,7 @@ The progress of compatibility can also be tracked in issue [#7](https://github.c
 | isGenerator | todo |
 | isInternal | :heavy_check_mark: Yes - but see issue (#38) |
 | isUserDefined | :heavy_check_mark: Yes |
-| isVariadic | todo |
+| isVariadic | :heavy_check_mark: Yes |
 | returnsReference | todo |
 
 ## ReflectionMethod

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -26,8 +26,8 @@ The progress of compatibility can also be tracked in issue [#7](https://github.c
 | getProperty | :heavy_check_mark: Yes |
 | getShortName | :heavy_check_mark: Yes |
 | getStartLine | todo |
-| getStaticProperties | todo |
-| getStaticPropertyValue | :x: No - would require an instance (#14) |
+| getStaticProperties | :x: No - would require loading (#14) |
+| getStaticPropertyValue | :x: No - would require loading (#14) |
 | getTraitAliases | todo |
 | getTraitNames | todo |
 | getTraits | todo |
@@ -50,7 +50,7 @@ The progress of compatibility can also be tracked in issue [#7](https://github.c
 | newInstance | todo |
 | newInstanceArgs | todo |
 | newInstanceWithoutConstructor | todo |
-| setStaticPropertyValue | :x: No - would require an instance (#14) |
+| setStaticPropertyValue | :x: No - would require loading (#14) |
 
 ## ReflectionFunctionAbstract
 
@@ -70,7 +70,7 @@ The progress of compatibility can also be tracked in issue [#7](https://github.c
 | getParameters | :heavy_check_mark: Yes |
 | getShortName | :heavy_check_mark: Yes |
 | getStartLine | :heavy_check_mark: Yes |
-| getStaticVariables | todo |
+| getStaticVariables | :x: No - would require loading (#14) |
 | inNamespace | :heavy_check_mark: Yes |
 | isClosure | :heavy_check_mark: Yes - but see issue (#37) |
 | isDeprecated | :heavy_check_mark: Yes - but see issue (#38) |

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -72,11 +72,11 @@ The progress of compatibility can also be tracked in issue [#7](https://github.c
 | getStartLine | todo |
 | getStaticVariables | todo |
 | inNamespace | :heavy_check_mark: Yes |
-| isClosure | todo |
-| isDeprecated | todo |
+| isClosure | :heavy_check_mark: Yes - but see issue (#37) |
+| isDeprecated | :heavy_check_mark: Yes - but see issue (#38) |
 | isGenerator | todo |
-| isInternal | todo |
-| isUserDefined | todo |
+| isInternal | :heavy_check_mark: Yes - but see issue (#38) |
+| isUserDefined | :heavy_check_mark: Yes |
 | isVariadic | todo |
 | returnsReference | todo |
 
@@ -129,7 +129,7 @@ The progress of compatibility can also be tracked in issue [#7](https://github.c
 | getClosure | :x: No - would require actual compilation of the AST (#14) |
 | invoke | :x: No - would require loading of the function itself (#14) |
 | invokeArgs | :x: No - would require loading of the function itself (#14) |
-| isDisabled | :heavy_check_mark: Yes (note - we cannot currently reflect internal functions, so always returns false) |
+| isDisabled | :heavy_check_mark: Yes - but see issue (#38) |
 | _inherited methods_ | see `ReflectionFunctionAbstract` |
 
 ## ReflectionProperty

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -64,14 +64,14 @@ The progress of compatibility can also be tracked in issue [#7](https://github.c
 | getExtensionName | :x: No - extensions are not supported (#15) |
 | getFileName | :heavy_check_mark: Yes |
 | getName | :heavy_check_mark: Yes |
-| getNamespaceName | todo |
+| getNamespaceName | :heavy_check_mark: Yes |
 | getNumberOfParameters | :heavy_check_mark: Yes |
 | getNumberOfRequiredParameters | :heavy_check_mark: Yes |
 | getParameters | :heavy_check_mark: Yes |
-| getShortName | todo |
+| getShortName | :heavy_check_mark: Yes |
 | getStartLine | todo |
 | getStaticVariables | todo |
-| inNamespace | todo |
+| inNamespace | :heavy_check_mark: Yes |
 | isClosure | todo |
 | isDeprecated | todo |
 | isGenerator | todo |

--- a/src/Identifier/IdentifierType.php
+++ b/src/Identifier/IdentifierType.php
@@ -60,8 +60,6 @@ class IdentifierType
             return ($reflector instanceof ReflectionFunction);
         }
 
-        // @todo add more type checks
-
         return false;
     }
 }

--- a/src/Identifier/IdentifierType.php
+++ b/src/Identifier/IdentifierType.php
@@ -4,17 +4,20 @@ namespace BetterReflection\Identifier;
 
 use PhpParser\Node;
 use BetterReflection\Reflection\ReflectionClass;
+use BetterReflection\Reflection\ReflectionFunction;
 use BetterReflection\Reflection\Reflection;
 
 class IdentifierType
 {
     const IDENTIFIER_CLASS = ReflectionClass::class;
+    const IDENTIFIER_FUNCTION = ReflectionFunction::class;
 
     /**
      * @var string[]
      */
     private $validTypes = [
         self::IDENTIFIER_CLASS,
+        self::IDENTIFIER_FUNCTION,
     ];
 
     /**
@@ -50,7 +53,11 @@ class IdentifierType
     public function isMatchingReflector(Reflection $reflector)
     {
         if ($this->name == self::IDENTIFIER_CLASS) {
-            return $reflector instanceof ReflectionClass;
+            return ($reflector instanceof ReflectionClass);
+        }
+
+        if ($this->name == self::IDENTIFIER_FUNCTION) {
+            return ($reflector instanceof ReflectionFunction);
         }
 
         // @todo add more type checks

--- a/src/Identifier/IdentifierType.php
+++ b/src/Identifier/IdentifierType.php
@@ -53,11 +53,11 @@ class IdentifierType
     public function isMatchingReflector(Reflection $reflector)
     {
         if ($this->name == self::IDENTIFIER_CLASS) {
-            return ($reflector instanceof ReflectionClass);
+            return $reflector instanceof ReflectionClass;
         }
 
         if ($this->name == self::IDENTIFIER_FUNCTION) {
-            return ($reflector instanceof ReflectionFunction);
+            return $reflector instanceof ReflectionFunction;
         }
 
         return false;

--- a/src/Reflection/ReflectionClass.php
+++ b/src/Reflection/ReflectionClass.php
@@ -52,8 +52,8 @@ class ReflectionClass implements Reflection
      * Create from a Class Node
      *
      * @param ClassNode $node
-     * @param NamespaceNode $namespace optional - if omitted, we assume it is global namespaced class
-     * @param string $filename If set, this is the filename the class was declared in
+     * @param NamespaceNode|null $namespace optional - if omitted, we assume it is global namespaced class
+     * @param string|null $filename If set, this is the filename the class was declared in
      * @return ReflectionClass
      */
     public static function createFromNode(

--- a/src/Reflection/ReflectionFunction.php
+++ b/src/Reflection/ReflectionFunction.php
@@ -33,6 +33,7 @@ class ReflectionFunction extends ReflectionFunctionAbstract implements Reflectio
      * code we can access. This means, at present, we can only EVER return false
      * from this function, because you cannot disable user-defined functions.
      *
+     * @todo https://github.com/Roave/BetterReflection/issues/14
      * @see http://php.net/manual/en/ini.core.php#ini.disable-functions
      * @return bool
      */

--- a/src/Reflection/ReflectionFunction.php
+++ b/src/Reflection/ReflectionFunction.php
@@ -24,4 +24,20 @@ class ReflectionFunction extends ReflectionFunctionAbstract implements Reflectio
 
         return $method;
     }
+
+    /**
+     * Check to see if this function has been disabled (by the PHP INI file
+     * directive `disable_functions`)
+     *
+     * Note - we cannot reflect on internal functions (as there is no PHP source
+     * code we can access. This means, at present, we can only EVER return false
+     * from this function, because you cannot disable user-defined functions.
+     *
+     * @see http://php.net/manual/en/ini.core.php#ini.disable-functions
+     * @return bool
+     */
+    public function isDisabled()
+    {
+        return false;
+    }
 }

--- a/src/Reflection/ReflectionFunction.php
+++ b/src/Reflection/ReflectionFunction.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace BetterReflection\Reflection;
+
+use PhpParser\Node\Stmt\Function_ as FunctionNode;
+use PhpParser\Node\Stmt\Namespace_ as NamespaceNode;
+
+class ReflectionFunction extends ReflectionFunctionAbstract implements Reflection
+{
+    /**
+     * @param FunctionNode $node
+     * @param NamespaceNode|null $namespaceNode
+     * @param string|null $filename
+     * @return ReflectionMethod
+     */
+    public static function createFromNode(
+        FunctionNode $node,
+        NamespaceNode $namespaceNode = null,
+        $filename = null
+    ) {
+        $method = new self($node);
+
+        $method->populateFunctionAbstract($node, $namespaceNode, $filename);
+
+        return $method;
+    }
+}

--- a/src/Reflection/ReflectionFunctionAbstract.php
+++ b/src/Reflection/ReflectionFunctionAbstract.php
@@ -258,4 +258,22 @@ abstract class ReflectionFunctionAbstract
     {
         return !$this->isInternal();
     }
+
+    /**
+     * Check if the function has a variadic parameter
+     *
+     * @return bool
+     */
+    public function isVariadic()
+    {
+        $parameters = $this->getParameters();
+
+        foreach ($parameters as $parameter) {
+            if ($parameter->isVariadic()) {
+                return true;
+            }
+        }
+
+        return false;
+    }
 }

--- a/src/Reflection/ReflectionFunctionAbstract.php
+++ b/src/Reflection/ReflectionFunctionAbstract.php
@@ -293,18 +293,17 @@ abstract class ReflectionFunctionAbstract
      */
     private function checkStatementsForYield(array $statements)
     {
-        $yieldFound = false;
         foreach ($statements as $stmt) {
             if ($stmt instanceof YieldNode) {
-                $yieldFound = true;
+                return true;
             }
             if (isset($stmt->stmts) && is_array($stmt->stmts) && count($stmt->stmts)) {
                 if ($this->checkStatementsForYield($stmt->stmts)) {
-                    $yieldFound = true;
+                    return true;
                 }
             }
         }
-        return $yieldFound;
+        return false;
     }
 
     /**

--- a/src/Reflection/ReflectionFunctionAbstract.php
+++ b/src/Reflection/ReflectionFunctionAbstract.php
@@ -340,4 +340,14 @@ abstract class ReflectionFunctionAbstract
     {
         return (int)$this->node->getAttribute('endLine', -1);
     }
+
+    /**
+     * Is this function declared as a reference
+     *
+     * @return bool
+     */
+    public function returnsReference()
+    {
+        return (bool)$this->node->byRef;
+    }
 }

--- a/src/Reflection/ReflectionFunctionAbstract.php
+++ b/src/Reflection/ReflectionFunctionAbstract.php
@@ -203,4 +203,59 @@ abstract class ReflectionFunctionAbstract
     {
         return $this->filename;
     }
+
+    /**
+     * Is this function a closure?
+     *
+     * Note - we cannot reflect on closures at the moment (as there is no PHP
+     * source code we can access).
+     *
+     * @see https://github.com/Roave/BetterReflection/issues/37
+     * @return bool
+     */
+    public function isClosure()
+    {
+        return false;
+    }
+
+    /**
+     * Is this function deprecated?
+     *
+     * Note - we cannot reflect on internal functions (as there is no PHP source
+     * code we can access. This means, at present, we can only EVER return false
+     * from this function.
+     *
+     * @see https://github.com/Roave/BetterReflection/issues/38
+     * @return bool
+     */
+    public function isDeprecated()
+    {
+        return false;
+    }
+
+    /**
+     * Is this an internal function?
+     *
+     * Note - we cannot reflect on internal functions (as there is no PHP source
+     * code we can access. This means, at present, we can only EVER return false
+     * from this function.
+     *
+     * @see https://github.com/Roave/BetterReflection/issues/38
+     * @return bool
+     */
+    public function isInternal()
+    {
+        return false;
+    }
+
+    /**
+     * Is this a user-defined function (will always return the opposite of
+     * whatever isInternal returns).
+     *
+     * @return bool
+     */
+    public function isUserDefined()
+    {
+        return !$this->isInternal();
+    }
 }

--- a/src/Reflection/ReflectionFunctionAbstract.php
+++ b/src/Reflection/ReflectionFunctionAbstract.php
@@ -320,4 +320,24 @@ abstract class ReflectionFunctionAbstract
         }
         return $this->checkStatementsForYield($this->node->stmts);
     }
+
+    /**
+     * Get the line number that this function starts on
+     *
+     * @return int
+     */
+    public function getStartLine()
+    {
+       return (int)$this->node->getAttribute('startLine', -1);
+    }
+
+    /**
+     * Get the line number that this function ends on
+     *
+     * @return int
+     */
+    public function getEndLine()
+    {
+        return (int)$this->node->getAttribute('endLine', -1);
+    }
 }

--- a/src/Reflection/ReflectionMethod.php
+++ b/src/Reflection/ReflectionMethod.php
@@ -34,8 +34,10 @@ class ReflectionMethod extends ReflectionFunctionAbstract
     ) {
         $method = new self($node);
         $method->declaringClass = $declaringClass;
-        
-        $method->populateFunctionAbstract($node, $declaringClass->getFileName());
+
+        // Compat with core reflection means we should NOT pass namespace info
+        // for ReflectionMethod
+        $method->populateFunctionAbstract($node, null, $declaringClass->getFileName());
 
         $method->flags |= $node->isAbstract() ? self::IS_ABSTRACT : 0;
         $method->flags |= $node->isFinal() ? self::IS_FINAL : 0;

--- a/src/Reflector/FunctionReflector.php
+++ b/src/Reflector/FunctionReflector.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace BetterReflection\Reflector;
+
+use BetterReflection\Identifier\Identifier;
+use BetterReflection\Identifier\IdentifierType;
+use BetterReflection\Reflector\Generic as GenericReflector;
+use BetterReflection\SourceLocator\SourceLocator;
+
+class FunctionReflector implements Reflector
+{
+    /**
+     * @var GenericReflector
+     */
+    private $reflector;
+
+    public function __construct(SourceLocator $sourceLocator)
+    {
+        $this->reflector = new GenericReflector($sourceLocator);
+    }
+
+    /**
+     * Create a ReflectionClass for the specified $className
+     *
+     * @param string $functionName
+     * @return \BetterReflection\Reflection\ReflectionClass
+     */
+    public function reflect($functionName)
+    {
+        return $this->reflector->reflect(
+            new Identifier($functionName, new IdentifierType(IdentifierType::IDENTIFIER_FUNCTION))
+        );
+    }
+}

--- a/src/Reflector/FunctionReflector.php
+++ b/src/Reflector/FunctionReflector.php
@@ -23,7 +23,7 @@ class FunctionReflector implements Reflector
      * Create a ReflectionClass for the specified $className
      *
      * @param string $functionName
-     * @return \BetterReflection\Reflection\ReflectionClass
+     * @return \BetterReflection\Reflection\ReflectionFunction
      */
     public function reflect($functionName)
     {

--- a/src/Reflector/Generic.php
+++ b/src/Reflector/Generic.php
@@ -4,6 +4,7 @@ namespace BetterReflection\Reflector;
 
 use BetterReflection\Identifier\Identifier;
 use BetterReflection\Identifier\IdentifierType;
+use BetterReflection\Reflection\ReflectionFunction;
 use BetterReflection\SourceLocator\LocatedSource;
 use BetterReflection\SourceLocator\SourceLocator;
 use BetterReflection\Reflection\ReflectionClass;
@@ -100,6 +101,14 @@ class Generic
             );
         }
 
+        if ($node instanceof Node\Stmt\Function_) {
+            return ReflectionFunction::createFromNode(
+                $node,
+                $namespace,
+                $filename
+            );
+        }
+
         return null;
     }
 
@@ -146,6 +155,11 @@ class Generic
                     $this->reflectFromNamespace($node, $identifier, $filename)
                 );
             } elseif ($node instanceof Node\Stmt\Class_) {
+                $reflection = $this->reflectNode($node, null, $filename);
+                if ($identifier->getType()->isMatchingReflector($reflection)) {
+                    $reflections[] = $reflection;
+                }
+            } elseif ($node instanceof Node\Stmt\Function_) {
                 $reflection = $this->reflectNode($node, null, $filename);
                 if ($identifier->getType()->isMatchingReflector($reflection)) {
                     $reflections[] = $reflection;

--- a/test/unit/Reflection/ReflectionFunctionAbstractTest.php
+++ b/test/unit/Reflection/ReflectionFunctionAbstractTest.php
@@ -82,4 +82,28 @@ class ReflectionFunctionAbstractTest extends \PHPUnit_Framework_TestCase
 
         $this->assertSame($expectingGenerator, $function->isGenerator());
     }
+
+    public function startEndLineProvider()
+    {
+        return [
+            ["<?php\n\nfunction foo() {\n}\n", 3, 4],
+            ["<?php\n\nfunction foo() {\n\n}\n", 3, 5],
+            ["<?php\n\n\nfunction foo() {\n}\n", 4, 5],
+        ];
+    }
+
+    /**
+     * @param string $php
+     * @param int $expectedStart
+     * @param int $expectedEnd
+     * @dataProvider startEndLineProvider
+     */
+    public function testStartEndLine($php, $expectedStart, $expectedEnd)
+    {
+        $reflector = new FunctionReflector(new StringSourceLocator($php));
+        $function = $reflector->reflect('foo');
+
+        $this->assertSame($expectedStart, $function->getStartLine());
+        $this->assertSame($expectedEnd, $function->getEndLine());
+    }
 }

--- a/test/unit/Reflection/ReflectionFunctionAbstractTest.php
+++ b/test/unit/Reflection/ReflectionFunctionAbstractTest.php
@@ -62,11 +62,32 @@ class ReflectionFunctionAbstractTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($expectingVariadic, $function->isVariadic());
     }
 
+    /**
+     * These generator tests were taken from nikic/php-parser - so a big thank
+     * you and credit to @nikic for this (and the awesome PHP-Parser library)
+     *
+     * @see https://github.com/nikic/PHP-Parser/blob/1.x/test/code/parser/stmt/function/generator.test
+     * @return array
+     */
     public function generatorProvider()
     {
         return [
             ['<?php function foo() { return [1, 2, 3]; }', false],
-            ['<?php function foo() { for ($i = 1; $i <= 3; $i++) { yield $i; } }', true],
+            ['<?php function foo() { yield; }', true],
+            ['<?php function foo() { yield $value; }', true],
+            ['<?php function foo() { yield $key => $value; }', true],
+            ['<?php function foo() { $data = yield; }', true],
+            ['<?php function foo() { $data = (yield $value); }', true],
+            ['<?php function foo() { $data = (yield $key => $value); }', true],
+            ['<?php function foo() { if (yield $foo); elseif (yield $foo); }', true],
+            ['<?php function foo() { if (yield $foo): elseif (yield $foo): endif; }', true],
+            ['<?php function foo() { while (yield $foo); }', true],
+            ['<?php function foo() { do {} while (yield $foo); }', true],
+            ['<?php function foo() { switch (yield $foo) {} }', true],
+            ['<?php function foo() { die(yield $foo); }', true],
+            ['<?php function foo() { func(yield $foo); }', true],
+            ['<?php function foo() { $foo->func(yield $foo); }', true],
+            ['<?php function foo() { new Foo(yield $foo); }', true],
         ];
     }
 

--- a/test/unit/Reflection/ReflectionFunctionAbstractTest.php
+++ b/test/unit/Reflection/ReflectionFunctionAbstractTest.php
@@ -61,4 +61,25 @@ class ReflectionFunctionAbstractTest extends \PHPUnit_Framework_TestCase
 
         $this->assertSame($expectingVariadic, $function->isVariadic());
     }
+
+    public function generatorProvider()
+    {
+        return [
+            ['<?php function foo() { return [1, 2, 3]; }', false],
+            ['<?php function foo() { for ($i = 1; $i <= 3; $i++) { yield $i; } }', true],
+        ];
+    }
+
+    /**
+     * @param string $php
+     * @param bool $expectingGenerator
+     * @dataProvider generatorProvider
+     */
+    public function testIsGenerator($php, $expectingGenerator)
+    {
+        $reflector = new FunctionReflector(new StringSourceLocator($php));
+        $function = $reflector->reflect('foo');
+
+        $this->assertSame($expectingGenerator, $function->isGenerator());
+    }
 }

--- a/test/unit/Reflection/ReflectionFunctionAbstractTest.php
+++ b/test/unit/Reflection/ReflectionFunctionAbstractTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace BetterReflectionTest\Reflection;
+use BetterReflection\Reflector\FunctionReflector;
+use BetterReflectionTest\SourceLocator\StringSourceLocatorTest;
+use BetterReflection\SourceLocator\StringSourceLocator;
+
+/**
+ * @covers \BetterReflection\Reflection\ReflectionFunctionAbstract
+ */
+class ReflectionFunctionAbstractTest extends \PHPUnit_Framework_TestCase
+{
+    public function testIsClosure()
+    {
+        $php = '<?php function foo() {}';
+
+        $reflector = new FunctionReflector(new StringSourceLocator($php));
+        $function = $reflector->reflect('foo');
+
+        $this->assertFalse($function->isClosure());
+    }
+
+    public function testIsDeprecated()
+    {
+        $php = '<?php function foo() {}';
+
+        $reflector = new FunctionReflector(new StringSourceLocator($php));
+        $function = $reflector->reflect('foo');
+
+        $this->assertFalse($function->isDeprecated());
+    }
+
+    public function testIsInternal()
+    {
+        $php = '<?php function foo() {}';
+
+        $reflector = new FunctionReflector(new StringSourceLocator($php));
+        $function = $reflector->reflect('foo');
+
+        $this->assertFalse($function->isInternal());
+    }
+}

--- a/test/unit/Reflection/ReflectionFunctionAbstractTest.php
+++ b/test/unit/Reflection/ReflectionFunctionAbstractTest.php
@@ -106,4 +106,25 @@ class ReflectionFunctionAbstractTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($expectedStart, $function->getStartLine());
         $this->assertSame($expectedEnd, $function->getEndLine());
     }
+
+    public function returnsReferenceProvider()
+    {
+        return [
+            ['<?php function foo() {}', false],
+            ['<?php function &foo() {}', true],
+        ];
+    }
+
+    /**
+     * @param string $php
+     * @param bool $expectingReturnsReference
+     * @dataProvider returnsReferenceProvider
+     */
+    public function testReturnsReference($php, $expectingReturnsReference)
+    {
+        $reflector = new FunctionReflector(new StringSourceLocator($php));
+        $function = $reflector->reflect('foo');
+
+        $this->assertSame($expectingReturnsReference, $function->returnsReference());
+    }
 }

--- a/test/unit/Reflection/ReflectionFunctionAbstractTest.php
+++ b/test/unit/Reflection/ReflectionFunctionAbstractTest.php
@@ -39,4 +39,26 @@ class ReflectionFunctionAbstractTest extends \PHPUnit_Framework_TestCase
 
         $this->assertFalse($function->isInternal());
     }
+
+    public function variadicProvider()
+    {
+        return [
+            ['<?php function foo($notVariadic) {}', false],
+            ['<?php function foo(...$isVariadic) {}', true],
+            ['<?php function foo($notVariadic, ...$isVariadic) {}', true],
+        ];
+    }
+
+    /**
+     * @param string $php
+     * @param bool $expectingVariadic
+     * @dataProvider variadicProvider
+     */
+    public function testIsVariadic($php, $expectingVariadic)
+    {
+        $reflector = new FunctionReflector(new StringSourceLocator($php));
+        $function = $reflector->reflect('foo');
+
+        $this->assertSame($expectingVariadic, $function->isVariadic());
+    }
 }

--- a/test/unit/Reflection/ReflectionFunctionTest.php
+++ b/test/unit/Reflection/ReflectionFunctionTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace BetterReflectionTest\Reflection;
+use BetterReflection\Reflector\FunctionReflector;
+use BetterReflectionTest\SourceLocator\StringSourceLocatorTest;
+use BetterReflection\SourceLocator\StringSourceLocator;
+
+/**
+ * @covers \BetterReflection\Reflection\ReflectionClass
+ */
+class ReflectionFunctionTest extends \PHPUnit_Framework_TestCase
+{
+    public function testNameMethodsWithNoNamespace()
+    {
+        $php = '<?php function foo() {}';
+
+        $reflector = new FunctionReflector(new StringSourceLocator($php));
+        $function = $reflector->reflect('foo');
+
+        $this->assertFalse($function->inNamespace());
+        $this->assertSame('foo', $function->getName());
+        $this->assertSame('', $function->getNamespaceName());
+        $this->assertSame('foo', $function->getShortName());
+    }
+
+    public function testNameMethodsInNamespace()
+    {
+        $php = '<?php namespace A\B { function foo() {} }';
+
+        $reflector = new FunctionReflector(new StringSourceLocator($php));
+        $function = $reflector->reflect('A\B\foo');
+
+        $this->assertTrue($function->inNamespace());
+        $this->assertSame('A\B\foo', $function->getName());
+        $this->assertSame('A\B', $function->getNamespaceName());
+        $this->assertSame('foo', $function->getShortName());
+    }
+
+    public function testNameMethodsInExplicitGlobalNamespace()
+    {
+        $php = '<?php namespace { function foo() {} }';
+
+        $reflector = new FunctionReflector(new StringSourceLocator($php));
+        $function = $reflector->reflect('foo');
+
+        $this->assertFalse($function->inNamespace());
+        $this->assertSame('foo', $function->getName());
+        $this->assertSame('', $function->getNamespaceName());
+        $this->assertSame('foo', $function->getShortName());
+    }
+}

--- a/test/unit/Reflection/ReflectionFunctionTest.php
+++ b/test/unit/Reflection/ReflectionFunctionTest.php
@@ -48,4 +48,14 @@ class ReflectionFunctionTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('', $function->getNamespaceName());
         $this->assertSame('foo', $function->getShortName());
     }
+
+    public function testIsDisabled()
+    {
+        $php = '<?php function foo() {}';
+
+        $reflector = new FunctionReflector(new StringSourceLocator($php));
+        $function = $reflector->reflect('foo');
+
+        $this->assertFalse($function->isDisabled());
+    }
 }

--- a/test/unit/Reflection/ReflectionFunctionTest.php
+++ b/test/unit/Reflection/ReflectionFunctionTest.php
@@ -6,7 +6,7 @@ use BetterReflectionTest\SourceLocator\StringSourceLocatorTest;
 use BetterReflection\SourceLocator\StringSourceLocator;
 
 /**
- * @covers \BetterReflection\Reflection\ReflectionClass
+ * @covers \BetterReflection\Reflection\ReflectionFunction
  */
 class ReflectionFunctionTest extends \PHPUnit_Framework_TestCase
 {
@@ -57,5 +57,15 @@ class ReflectionFunctionTest extends \PHPUnit_Framework_TestCase
         $function = $reflector->reflect('foo');
 
         $this->assertFalse($function->isDisabled());
+    }
+
+    public function testIsUserDefined()
+    {
+        $php = '<?php function foo() {}';
+
+        $reflector = new FunctionReflector(new StringSourceLocator($php));
+        $function = $reflector->reflect('foo');
+
+        $this->assertTrue($function->isUserDefined());
     }
 }

--- a/test/unit/Reflection/ReflectionMethodTest.php
+++ b/test/unit/Reflection/ReflectionMethodTest.php
@@ -117,4 +117,15 @@ class ReflectionMethodTest extends \PHPUnit_Framework_TestCase
 
         $this->assertSame('Methods.php', basename($detectedFilename));
     }
+
+    public function testMethodNameWithNamespace()
+    {
+        $classInfo = $this->reflector->reflect('\BetterReflectionTest\Fixture\ExampleClass');
+        $methodInfo = $classInfo->getMethod('someMethod');
+
+        $this->assertFalse($methodInfo->inNamespace());
+        $this->assertSame('someMethod', $methodInfo->getName());
+        $this->assertSame('', $methodInfo->getNamespaceName());
+        $this->assertSame('someMethod', $methodInfo->getShortName());
+    }
 }

--- a/test/unit/Reflector/FunctionReflectorTest.php
+++ b/test/unit/Reflector/FunctionReflectorTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace BetterReflectionTest\Reflector;
+
+use BetterReflection\Reflection\ReflectionFunction;
+use BetterReflection\Reflector\FunctionReflector;
+use BetterReflection\Reflector\Generic;
+use BetterReflection\SourceLocator\StringSourceLocator;
+
+/**
+ * @covers \BetterReflection\Reflector\FunctionReflector
+ */
+class FunctionReflectorTest extends \PHPUnit_Framework_TestCase
+{
+    public function testReflectProxiesToGenericReflectMethod()
+    {
+        $php = '<?php function foo() {}';
+
+        $reflector = new FunctionReflector(new StringSourceLocator($php));
+
+        $reflectionMock = $this->getMockBuilder(ReflectionFunction::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $genericReflectorMock = $this->getMockBuilder(Generic::class)
+            ->setMethods(['reflect'])
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $genericReflectorMock->expects($this->once())
+            ->method('reflect')
+            ->will($this->returnValue($reflectionMock));
+
+        $reflectorReflection = new \ReflectionObject($reflector);
+        $reflectorReflectorReflection = $reflectorReflection->getProperty('reflector');
+        $reflectorReflectorReflection->setAccessible(true);
+        $reflectorReflectorReflection->setValue($reflector, $genericReflectorMock);
+
+        $reflector->reflect('foo');
+    }
+}


### PR DESCRIPTION
~~Depends on #32 being merged first, possibly rebase after etc.~~

This introduces compatibility for #7 items `ReflectionFunction` and `ReflectionFunctionAbstract` where possible. Some items are not implement, but marked accordingly in the compatibility list (with corresponding GitHub issues)