### PR TITLE
Add AutoloadSourceLocator enabling ReflectionClass and ReflectionFunction instantiation

### DIFF
--- a/src/Identifier/Identifier.php
+++ b/src/Identifier/Identifier.php
@@ -40,4 +40,20 @@ class Identifier
     {
         return $this->type;
     }
+
+    /**
+     * @return bool
+     */
+    public function isClass()
+    {
+        return $this->type->isClass();
+    }
+
+    /**
+     * @return bool
+     */
+    public function isFunction()
+    {
+        return $this->type->isFunction();
+    }
 }

--- a/src/Identifier/Identifier.php
+++ b/src/Identifier/Identifier.php
@@ -40,13 +40,4 @@ class Identifier
     {
         return $this->type;
     }
-
-    /**
-     * @todo implement this
-     * @return bool
-     */
-    public function isLoaded()
-    {
-        return false;
-    }
 }

--- a/src/Identifier/IdentifierType.php
+++ b/src/Identifier/IdentifierType.php
@@ -45,6 +45,22 @@ class IdentifierType
     }
 
     /**
+     * @return bool
+     */
+    public function isClass()
+    {
+        return $this->name === self::IDENTIFIER_CLASS;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isFunction()
+    {
+        return $this->name === self::IDENTIFIER_FUNCTION;
+    }
+
+    /**
      * Check to see if a reflector is of a valid type specified by this identifier
      *
      * @param Reflection $reflector
@@ -52,11 +68,11 @@ class IdentifierType
      */
     public function isMatchingReflector(Reflection $reflector)
     {
-        if ($this->name == self::IDENTIFIER_CLASS) {
+        if ($this->name === self::IDENTIFIER_CLASS) {
             return $reflector instanceof ReflectionClass;
         }
 
-        if ($this->name == self::IDENTIFIER_FUNCTION) {
+        if ($this->name === self::IDENTIFIER_FUNCTION) {
             return $reflector instanceof ReflectionFunction;
         }
 

--- a/src/Reflection/ReflectionClass.php
+++ b/src/Reflection/ReflectionClass.php
@@ -3,6 +3,8 @@
 namespace BetterReflection\Reflection;
 
 use BetterReflection\NodeCompiler\CompileNodeToValue;
+use BetterReflection\Reflector\ClassReflector;
+use BetterReflection\SourceLocator\AutoloadSourceLocator;
 use PhpParser\Node\Stmt\Namespace_ as NamespaceNode;
 use PhpParser\Node\Stmt\Class_ as ClassNode;
 use PhpParser\Node\Stmt\ClassConst as ConstNode;
@@ -18,34 +20,39 @@ class ReflectionClass implements Reflection
     /**
      * @var NamespaceNode
      */
-    private $declaringNamespace;
+    private $declaringNamespace = null;
 
     /**
      * @var ReflectionMethod[]
      */
-    private $methods;
+    private $methods = [];
 
     /**
      * @var mixed[]
      */
-    private $constants;
+    private $constants = [];
 
     /**
      * @var ReflectionProperty[]
      */
-    private $properties;
+    private $properties = [];
 
     /**
      * @var string
      */
     private $filename;
 
-    private function __construct()
+    public function __construct($className = null)
     {
-        $this->declaringNamespace = null;
-        $this->methods = [];
-        $this->constants = [];
-        $this->properties = [];
+        if ($className) {
+            $reflection = (new ClassReflector(new AutoloadSourceLocator()))->reflect($className);
+            $this->name = $reflection->name;
+            $this->declaringNamespace = $reflection->declaringNamespace;
+            $this->methods = $reflection->methods;
+            $this->constants = $reflection->constants;
+            $this->properties = $reflection->properties;
+            $this->filename = $reflection->filename;
+        }
     }
 
     /**

--- a/src/Reflection/ReflectionClass.php
+++ b/src/Reflection/ReflectionClass.php
@@ -42,17 +42,13 @@ class ReflectionClass implements Reflection
      */
     private $filename;
 
-    public function __construct($className = null)
+    private function __construct()
     {
-        if ($className) {
-            $reflection = (new ClassReflector(new AutoloadSourceLocator()))->reflect($className);
-            $this->name = $reflection->name;
-            $this->declaringNamespace = $reflection->declaringNamespace;
-            $this->methods = $reflection->methods;
-            $this->constants = $reflection->constants;
-            $this->properties = $reflection->properties;
-            $this->filename = $reflection->filename;
-        }
+    }
+
+    public static function createFromName($className)
+    {
+        return (new ClassReflector(new AutoloadSourceLocator()))->reflect($className);
     }
 
     /**

--- a/src/Reflection/ReflectionFunction.php
+++ b/src/Reflection/ReflectionFunction.php
@@ -2,11 +2,26 @@
 
 namespace BetterReflection\Reflection;
 
+use BetterReflection\Reflector\FunctionReflector;
+use BetterReflection\SourceLocator\AutoloadSourceLocator;
 use PhpParser\Node\Stmt\Function_ as FunctionNode;
 use PhpParser\Node\Stmt\Namespace_ as NamespaceNode;
 
 class ReflectionFunction extends ReflectionFunctionAbstract implements Reflection
 {
+    public function __construct($functionName = null)
+    {
+        if ($functionName) {
+            $reflection = (new FunctionReflector(new AutoloadSourceLocator()))->reflect($functionName);
+            $this->parameters = $reflection->parameters;
+            $this->name = $reflection->name;
+            $this->declaringNamespace = $reflection->declaringNamespace;
+            $this->docBlock = $reflection->docBlock;
+            $this->filename = $reflection->filename;
+            $this->node = $reflection->node;
+        }
+    }
+
     /**
      * @param FunctionNode $node
      * @param NamespaceNode|null $namespaceNode
@@ -18,7 +33,7 @@ class ReflectionFunction extends ReflectionFunctionAbstract implements Reflectio
         NamespaceNode $namespaceNode = null,
         $filename = null
     ) {
-        $method = new self($node);
+        $method = new self();
 
         $method->populateFunctionAbstract($node, $namespaceNode, $filename);
 

--- a/src/Reflection/ReflectionFunction.php
+++ b/src/Reflection/ReflectionFunction.php
@@ -9,35 +9,31 @@ use PhpParser\Node\Stmt\Namespace_ as NamespaceNode;
 
 class ReflectionFunction extends ReflectionFunctionAbstract implements Reflection
 {
-    public function __construct($functionName = null)
+    /**
+     * @param string $functionName
+     * @return ReflectionFunction
+     */
+    public static function createFromName($functionName)
     {
-        if ($functionName) {
-            $reflection = (new FunctionReflector(new AutoloadSourceLocator()))->reflect($functionName);
-            $this->parameters = $reflection->parameters;
-            $this->name = $reflection->name;
-            $this->declaringNamespace = $reflection->declaringNamespace;
-            $this->docBlock = $reflection->docBlock;
-            $this->filename = $reflection->filename;
-            $this->node = $reflection->node;
-        }
+        return (new FunctionReflector(new AutoloadSourceLocator()))->reflect($functionName);
     }
 
     /**
      * @param FunctionNode $node
      * @param NamespaceNode|null $namespaceNode
      * @param string|null $filename
-     * @return ReflectionMethod
+     * @return ReflectionFunction
      */
     public static function createFromNode(
         FunctionNode $node,
         NamespaceNode $namespaceNode = null,
         $filename = null
     ) {
-        $method = new self();
+        $function = new self();
 
-        $method->populateFunctionAbstract($node, $namespaceNode, $filename);
+        $function->populateFunctionAbstract($node, $namespaceNode, $filename);
 
-        return $method;
+        return $function;
     }
 
     /**

--- a/src/Reflection/ReflectionFunctionAbstract.php
+++ b/src/Reflection/ReflectionFunctionAbstract.php
@@ -12,32 +12,32 @@ abstract class ReflectionFunctionAbstract
     /**
      * @var ReflectionParameter[]
      */
-    protected $parameters = [];
+    private $parameters = [];
 
     /**
      * @var string
      */
-    protected $name;
+    private $name;
 
     /**
      * @var NamespaceNode
      */
-    protected $declaringNamespace;
+    private $declaringNamespace;
 
     /**
      * @var string
      */
-    protected $docBlock;
+    private $docBlock;
 
     /**
      * @var string|null
      */
-    protected $filename;
+    private $filename;
 
     /**
      * @var MethodOrFunctionNode
      */
-    protected $node;
+    private $node;
 
     protected function __construct()
     {

--- a/src/Reflection/ReflectionFunctionAbstract.php
+++ b/src/Reflection/ReflectionFunctionAbstract.php
@@ -12,36 +12,35 @@ abstract class ReflectionFunctionAbstract
     /**
      * @var ReflectionParameter[]
      */
-    private $parameters;
+    protected $parameters = [];
 
     /**
      * @var string
      */
-    private $name;
+    protected $name;
 
     /**
      * @var NamespaceNode
      */
-    private $declaringNamespace;
+    protected $declaringNamespace;
 
     /**
      * @var string
      */
-    private $docBlock;
+    protected $docBlock;
 
     /**
      * @var string|null
      */
-    private $filename;
+    protected $filename;
 
     /**
      * @var MethodOrFunctionNode
      */
-    private $node;
+    protected $node;
 
     protected function __construct()
     {
-        $this->parameters = [];
     }
 
     /**

--- a/src/Reflector/Generic.php
+++ b/src/Reflector/Generic.php
@@ -34,14 +34,6 @@ class Generic
      */
     public function reflect(Identifier $identifier)
     {
-        if ($identifier->isLoaded()) {
-            throw new \LogicException(sprintf(
-                '%s "%s" is already loaded',
-                $identifier->getType()->getName(),
-                $identifier->getName()
-            ));
-        }
-
         return $this->reflectFromLocatedSource(
             $identifier,
             $this->sourceLocator->__invoke($identifier)

--- a/src/SourceLocator/AutoloadSourceLocator.php
+++ b/src/SourceLocator/AutoloadSourceLocator.php
@@ -31,14 +31,21 @@ class AutoloadSourceLocator implements SourceLocator
                 stream_wrapper_restore('file');
                 set_error_handler($previousErrorHandler);
             }
+        } elseif ($identifier->getType()->getName() == IdentifierType::IDENTIFIER_FUNCTION) {
+            if (function_exists($identifier->getName())) {
+                $reflection = new \ReflectionFunction($identifier->getName());
+                self::$autoloadLocatedFile = $reflection->getFileName();
+            } else {
+                throw new \RuntimeException('Function ' . $identifier->getName() . ' was not already defined');
+            }
         } else {
-            throw new \LogicException('AutoloadSourceLocator can only locate classes, you asked for: ' . $identifier->getType()->getName());
+            throw new \LogicException('AutoloadSourceLocator cannot locate ' . $identifier->getType()->getName());
         }
 
         if (null == self::$autoloadLocatedFile) {
             throw new \RuntimeException(sprintf(
                 'Unable to autoload the %s called %s',
-                $identifier->getType()->getDisplayName(),
+                $identifier->getType()->getName(),
                 $identifier->getName()
             ));
         }

--- a/src/SourceLocator/AutoloadSourceLocator.php
+++ b/src/SourceLocator/AutoloadSourceLocator.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace BetterReflection\SourceLocator;
+
+use BetterReflection\Identifier\Identifier;
+use BetterReflection\Identifier\IdentifierType;
+
+/**
+ * Use PHP's built in autoloader to locate a class, without actually loading.
+ *
+ * There are some prerequisites...
+ *   - we expect the autoloader to load classes from a file (i.e. using require/include)
+ */
+class AutoloadSourceLocator implements SourceLocator
+{
+    private static $autoloadLocatedFile;
+
+    public function __invoke(Identifier $identifier)
+    {
+        self::$autoloadLocatedFile = null;
+
+        if ($identifier->getType()->getName() == IdentifierType::IDENTIFIER_CLASS) {
+            if (class_exists($identifier->getName(), false)) {
+                $reflection = new \ReflectionClass($identifier->getName());
+                self::$autoloadLocatedFile = $reflection->getFileName();
+            } else {
+                $previousErrorHandler = set_error_handler(function () {});
+                stream_wrapper_unregister('file');
+                stream_wrapper_register('file', '\BetterReflection\SourceLocator\AutoloadSourceLocator');
+                class_exists($identifier->getName());
+                stream_wrapper_restore('file');
+                set_error_handler($previousErrorHandler);
+            }
+        } else {
+            throw new \LogicException('AutoloadSourceLocator can only locate classes, you asked for: ' . $identifier->getType()->getName());
+        }
+
+        if (null == self::$autoloadLocatedFile) {
+            throw new \RuntimeException(sprintf(
+                'Unable to autoload the %s called %s',
+                $identifier->getType()->getDisplayName(),
+                $identifier->getName()
+            ));
+        }
+
+        return new LocatedSource(
+            file_get_contents(self::$autoloadLocatedFile),
+            self::$autoloadLocatedFile
+        );
+    }
+
+    /**
+     * Our wrapper simply records which file we tried to load and returns
+     * boolean false indicating failure
+     *
+     * @param string $path
+     * @param string $mode
+     * @param int $options
+     * @param string $opened_path
+     * @return bool
+     */
+    public function stream_open($path, $mode, $options, &$opened_path)
+    {
+        self::$autoloadLocatedFile = $path;
+        return false;
+    }
+
+    /**
+     * Must be implemented to return some data so that calls like is_file will work
+     *
+     * @param $path
+     * @param $flags
+     * @return mixed[]
+     */
+    public function url_stat($path, $flags)
+    {
+        $assoc = [
+            'dev' => 2056,
+            'ino' => 19679399,
+            'mode' => 33204,
+            'nlink' => 1,
+            'uid' => 1000,
+            'gid' => 1000,
+            'rdev' => 0,
+            'size' => 1,
+            'atime' => time(),
+            'mtime' => time(),
+            'ctime' => time(),
+            'blksize' => 4096,
+            'blocks' => 8,
+        ];
+
+        $x = array_merge(array_values($assoc), $assoc);
+        return $x;
+    }
+}

--- a/src/SourceLocator/AutoloadSourceLocator.php
+++ b/src/SourceLocator/AutoloadSourceLocator.php
@@ -36,7 +36,7 @@ class AutoloadSourceLocator implements SourceLocator
                 $reflection = new \ReflectionFunction($identifier->getName());
                 self::$autoloadLocatedFile = $reflection->getFileName();
             } else {
-                throw new \RuntimeException('Function ' . $identifier->getName() . ' was not already defined');
+                throw new Exception\FunctionUndefined('Function ' . $identifier->getName() . ' was not already defined');
             }
         } else {
             throw new \LogicException('AutoloadSourceLocator cannot locate ' . $identifier->getType()->getName());

--- a/src/SourceLocator/AutoloadSourceLocator.php
+++ b/src/SourceLocator/AutoloadSourceLocator.php
@@ -39,11 +39,11 @@ class AutoloadSourceLocator implements SourceLocator
                 throw new Exception\FunctionUndefined('Function ' . $identifier->getName() . ' was not already defined');
             }
         } else {
-            throw new \LogicException('AutoloadSourceLocator cannot locate ' . $identifier->getType()->getName());
+            throw new Exception\UnloadableIdentifierType('AutoloadSourceLocator cannot locate ' . $identifier->getType()->getName());
         }
 
         if (null == self::$autoloadLocatedFile) {
-            throw new \RuntimeException(sprintf(
+            throw new Exception\AutoloadFailure(sprintf(
                 'Unable to autoload the %s called %s',
                 $identifier->getType()->getName(),
                 $identifier->getName()

--- a/src/SourceLocator/AutoloadSourceLocator.php
+++ b/src/SourceLocator/AutoloadSourceLocator.php
@@ -26,7 +26,7 @@ class AutoloadSourceLocator implements SourceLocator
             } else {
                 $previousErrorHandler = set_error_handler(function () {});
                 stream_wrapper_unregister('file');
-                stream_wrapper_register('file', '\BetterReflection\SourceLocator\AutoloadSourceLocator');
+                stream_wrapper_register('file', self::class);
                 class_exists($identifier->getName());
                 stream_wrapper_restore('file');
                 set_error_handler($previousErrorHandler);

--- a/src/SourceLocator/Exception/AutoloadFailure.php
+++ b/src/SourceLocator/Exception/AutoloadFailure.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace BetterReflection\SourceLocator\Exception;
+
+class AutoloadFailure extends \RuntimeException
+{
+}

--- a/src/SourceLocator/Exception/FunctionUndefined.php
+++ b/src/SourceLocator/Exception/FunctionUndefined.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace BetterReflection\SourceLocator\Exception;
+
+class FunctionUndefined extends \RuntimeException
+{
+}

--- a/src/SourceLocator/Exception/UnloadableIdentifierType.php
+++ b/src/SourceLocator/Exception/UnloadableIdentifierType.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace BetterReflection\SourceLocator\Exception;
+
+class UnloadableIdentifierType extends \InvalidArgumentException
+{
+}

--- a/test/unit/Fixture/Functions.php
+++ b/test/unit/Fixture/Functions.php
@@ -1,0 +1,6 @@
+<?php
+
+namespace BetterReflectionTest\Fixture;
+
+function myFunction() {
+}

--- a/test/unit/Reflection/ReflectionClassTest.php
+++ b/test/unit/Reflection/ReflectionClassTest.php
@@ -137,7 +137,7 @@ class ReflectionClassTest extends \PHPUnit_Framework_TestCase
 
     public function testStaticCreation()
     {
-        $reflection = new ReflectionClass('BetterReflectionTest\Fixture\ExampleClass');
+        $reflection = ReflectionClass::createFromName('BetterReflectionTest\Fixture\ExampleClass');
         $this->assertSame('ExampleClass', $reflection->getShortName());
     }
 }

--- a/test/unit/Reflection/ReflectionClassTest.php
+++ b/test/unit/Reflection/ReflectionClassTest.php
@@ -2,6 +2,7 @@
 
 namespace BetterReflectionTest\Reflection;
 
+use BetterReflection\Reflection\ReflectionClass;
 use BetterReflection\Reflection\ReflectionProperty;
 use BetterReflection\Reflection\ReflectionMethod;
 use BetterReflection\Reflector\ClassReflector;
@@ -132,5 +133,11 @@ class ReflectionClassTest extends \PHPUnit_Framework_TestCase
         $detectedFilename = $classInfo->getFileName();
 
         $this->assertSame('ExampleClass.php', basename($detectedFilename));
+    }
+
+    public function testStaticCreation()
+    {
+        $reflection = new ReflectionClass('BetterReflectionTest\Fixture\ExampleClass');
+        $this->assertSame('ExampleClass', $reflection->getShortName());
     }
 }

--- a/test/unit/Reflection/ReflectionFunctionTest.php
+++ b/test/unit/Reflection/ReflectionFunctionTest.php
@@ -1,8 +1,8 @@
 <?php
 
 namespace BetterReflectionTest\Reflection;
+use BetterReflection\Reflection\ReflectionFunction;
 use BetterReflection\Reflector\FunctionReflector;
-use BetterReflectionTest\SourceLocator\StringSourceLocatorTest;
 use BetterReflection\SourceLocator\StringSourceLocator;
 
 /**
@@ -67,5 +67,12 @@ class ReflectionFunctionTest extends \PHPUnit_Framework_TestCase
         $function = $reflector->reflect('foo');
 
         $this->assertTrue($function->isUserDefined());
+    }
+
+    public function testStaticCreation()
+    {
+        require_once(__DIR__ . '/../Fixture/Functions.php');
+        $reflection = new ReflectionFunction('BetterReflectionTest\Fixture\myFunction');
+        $this->assertSame('myFunction', $reflection->getShortName());
     }
 }

--- a/test/unit/Reflection/ReflectionFunctionTest.php
+++ b/test/unit/Reflection/ReflectionFunctionTest.php
@@ -72,7 +72,7 @@ class ReflectionFunctionTest extends \PHPUnit_Framework_TestCase
     public function testStaticCreation()
     {
         require_once(__DIR__ . '/../Fixture/Functions.php');
-        $reflection = new ReflectionFunction('BetterReflectionTest\Fixture\myFunction');
+        $reflection = ReflectionFunction::createFromName('BetterReflectionTest\Fixture\myFunction');
         $this->assertSame('myFunction', $reflection->getShortName());
     }
 }

--- a/test/unit/SourceLocator/AutoloadSourceLocatorTest.php
+++ b/test/unit/SourceLocator/AutoloadSourceLocatorTest.php
@@ -49,7 +49,7 @@ class AutoloadSourceLocatorTest extends \PHPUnit_Framework_TestCase
         $prop->setAccessible(true);
         $prop->setValue($type, 'nonsense');
 
-        $this->setExpectedException(\LogicException::class, 'AutoloadSourceLocator can only locate classes, you asked for: nonsense');
+        $this->setExpectedException(\LogicException::class, 'AutoloadSourceLocator cannot locate nonsense');
         $identifier = new Identifier('foo', $type);
         $locator->__invoke($identifier);
     }

--- a/test/unit/SourceLocator/AutoloadSourceLocatorTest.php
+++ b/test/unit/SourceLocator/AutoloadSourceLocatorTest.php
@@ -7,7 +7,9 @@ use BetterReflection\Identifier\IdentifierType;
 use BetterReflection\Reflector\ClassReflector;
 use BetterReflection\Reflector\FunctionReflector;
 use BetterReflection\SourceLocator\AutoloadSourceLocator;
+use BetterReflection\SourceLocator\Exception\AutoloadFailure;
 use BetterReflection\SourceLocator\Exception\FunctionUndefined;
+use BetterReflection\SourceLocator\Exception\UnloadableIdentifierType;
 use BetterReflectionTest\Fixture\ClassForHinting;
 
 /**
@@ -69,8 +71,16 @@ class AutoloadSourceLocatorTest extends \PHPUnit_Framework_TestCase
         $prop->setAccessible(true);
         $prop->setValue($type, 'nonsense');
 
-        $this->setExpectedException(\LogicException::class, 'AutoloadSourceLocator cannot locate nonsense');
+        $this->setExpectedException(UnloadableIdentifierType::class, 'AutoloadSourceLocator cannot locate nonsense');
         $identifier = new Identifier('foo', $type);
         $locator->__invoke($identifier);
+    }
+
+    public function testExceptionThrownWhenUnableToAutoload()
+    {
+        $reflector = new ClassReflector(new AutoloadSourceLocator());
+
+        $this->setExpectedException(AutoloadFailure::class);
+        $reflector->reflect('Some\Class\That\Cannot\Exist');
     }
 }

--- a/test/unit/SourceLocator/AutoloadSourceLocatorTest.php
+++ b/test/unit/SourceLocator/AutoloadSourceLocatorTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace BetterReflectionTest\SourceLocator;
+
+use BetterReflection\Identifier\Identifier;
+use BetterReflection\Identifier\IdentifierType;
+use BetterReflection\Reflector\ClassReflector;
+use BetterReflection\SourceLocator\AutoloadSourceLocator;
+use BetterReflectionTest\Fixture\ClassForHinting;
+
+/**
+ * @covers \BetterReflection\SourceLocator\AutoloadSourceLocator
+ */
+class AutoloadSourceLocatorTest extends \PHPUnit_Framework_TestCase
+{
+    public function testClassLoads()
+    {
+        $reflector = new ClassReflector(new AutoloadSourceLocator());
+
+        $className = 'BetterReflectionTest\Fixture\ExampleClass';
+        $this->assertFalse(class_exists($className, false));
+        $classInfo = $reflector->reflect($className);
+        $this->assertFalse(class_exists($className, false));
+
+        $this->assertSame('ExampleClass', $classInfo->getShortName());
+    }
+
+    public function testClassLoadsWorksWithExistingClass()
+    {
+        $reflector = new ClassReflector(new AutoloadSourceLocator());
+
+        // Ensure class is loaded first
+        new ClassForHinting();
+        $className = 'BetterReflectionTest\Fixture\ClassForHinting';
+        $this->assertTrue(class_exists($className, false));
+
+        $classInfo = $reflector->reflect($className);
+
+        $this->assertSame('ClassForHinting', $classInfo->getShortName());
+    }
+
+    public function testExceptionThrownWhenInvalidTypeGiven()
+    {
+        $locator = new AutoloadSourceLocator();
+
+        $type = new IdentifierType();
+        $typeReflection = new \ReflectionObject($type);
+        $prop = $typeReflection->getProperty('name');
+        $prop->setAccessible(true);
+        $prop->setValue($type, 'nonsense');
+
+        $this->setExpectedException(\LogicException::class, 'AutoloadSourceLocator can only locate classes, you asked for: nonsense');
+        $identifier = new Identifier('foo', $type);
+        $locator->__invoke($identifier);
+    }
+}

--- a/test/unit/SourceLocator/AutoloadSourceLocatorTest.php
+++ b/test/unit/SourceLocator/AutoloadSourceLocatorTest.php
@@ -5,7 +5,9 @@ namespace BetterReflectionTest\SourceLocator;
 use BetterReflection\Identifier\Identifier;
 use BetterReflection\Identifier\IdentifierType;
 use BetterReflection\Reflector\ClassReflector;
+use BetterReflection\Reflector\FunctionReflector;
 use BetterReflection\SourceLocator\AutoloadSourceLocator;
+use BetterReflection\SourceLocator\Exception\FunctionUndefined;
 use BetterReflectionTest\Fixture\ClassForHinting;
 
 /**
@@ -37,6 +39,24 @@ class AutoloadSourceLocatorTest extends \PHPUnit_Framework_TestCase
         $classInfo = $reflector->reflect($className);
 
         $this->assertSame('ClassForHinting', $classInfo->getShortName());
+    }
+
+    public function testFunctionLoads()
+    {
+        $reflector = new FunctionReflector(new AutoloadSourceLocator());
+
+        require_once(__DIR__ . '/../Fixture/Functions.php');
+        $classInfo = $reflector->reflect('BetterReflectionTest\Fixture\myFunction');
+
+        $this->assertSame('myFunction', $classInfo->getShortName());
+    }
+
+    public function testFunctionReflectionFailsWhenFunctionNotDefined()
+    {
+        $reflector = new FunctionReflector(new AutoloadSourceLocator());
+
+        $this->setExpectedException(FunctionUndefined::class);
+        $reflector->reflect('this function does not exist, hopefully');
     }
 
     public function testExceptionThrownWhenInvalidTypeGiven()


### PR DESCRIPTION
Implemented the `AutoloadSourceLocator` which means we can now use "static" creation of `ReflectionClass` objects, e.g.:

```php
$reflection = ReflectionClass::createFromName('BetterReflectionTest\Fixture\ExampleClass');
```

There are caveats (we expect the autoloader to load classes from a file, i.e. using require/include), but it does actually work.

~~It also means this can actually implement the `LoadSafeSourceLocator` (to be implemented)~~

Merging this would fix #36 and would be a better solution that I initially proposed actually :grinning: 

### Todo

* [x] Rebase onto `master` when #40 is merged
* [x] Complete implementation for `ReflectionFunction`
* [x] Use static constructor not dodgy `__construct` nullable nonsense
* ~~Create a `LoadSafeSourceLocator` and write the logic to do checking~~
* ~~Implement the @todo in [Identifier.php#L45](https://github.com/Roave/BetterReflection/blob/master/src/Identifier/Identifier.php#L45)~~