### PR TITLE
Use LocatedSource better

### DIFF
--- a/src/Reflection/ReflectionClass.php
+++ b/src/Reflection/ReflectionClass.php
@@ -5,6 +5,7 @@ namespace BetterReflection\Reflection;
 use BetterReflection\NodeCompiler\CompileNodeToValue;
 use BetterReflection\Reflector\ClassReflector;
 use BetterReflection\SourceLocator\AutoloadSourceLocator;
+use BetterReflection\SourceLocator\LocatedSource;
 use PhpParser\Node\Stmt\Namespace_ as NamespaceNode;
 use PhpParser\Node\Stmt\Class_ as ClassNode;
 use PhpParser\Node\Stmt\ClassConst as ConstNode;
@@ -38,9 +39,9 @@ class ReflectionClass implements Reflection
     private $properties = [];
 
     /**
-     * @var string
+     * @var LocatedSource
      */
-    private $filename;
+    private $locatedSource;
 
     private function __construct()
     {
@@ -55,18 +56,18 @@ class ReflectionClass implements Reflection
      * Create from a Class Node
      *
      * @param ClassNode $node
+     * @param LocatedSource $locatedSource
      * @param NamespaceNode|null $namespace optional - if omitted, we assume it is global namespaced class
-     * @param string|null $filename If set, this is the filename the class was declared in
      * @return ReflectionClass
      */
     public static function createFromNode(
         ClassNode $node,
-        NamespaceNode $namespace = null,
-        $filename = null
+        LocatedSource $locatedSource,
+        NamespaceNode $namespace = null
     ) {
         $class = new self();
 
-        $class->filename = $filename;
+        $class->locatedSource = $locatedSource;
         $class->name = $node->name;
 
         if (null !== $namespace) {
@@ -249,6 +250,14 @@ class ReflectionClass implements Reflection
      */
     public function getFileName()
     {
-        return $this->filename;
+        return $this->locatedSource->getFileName();
+    }
+
+    /**
+     * @return LocatedSource
+     */
+    public function getLocatedSource()
+    {
+        return $this->locatedSource;
     }
 }

--- a/src/Reflection/ReflectionFunction.php
+++ b/src/Reflection/ReflectionFunction.php
@@ -4,6 +4,7 @@ namespace BetterReflection\Reflection;
 
 use BetterReflection\Reflector\FunctionReflector;
 use BetterReflection\SourceLocator\AutoloadSourceLocator;
+use BetterReflection\SourceLocator\LocatedSource;
 use PhpParser\Node\Stmt\Function_ as FunctionNode;
 use PhpParser\Node\Stmt\Namespace_ as NamespaceNode;
 
@@ -21,17 +22,17 @@ class ReflectionFunction extends ReflectionFunctionAbstract implements Reflectio
     /**
      * @param FunctionNode $node
      * @param NamespaceNode|null $namespaceNode
-     * @param string|null $filename
+     * @param LocatedSource $locatedSource
      * @return ReflectionFunction
      */
     public static function createFromNode(
         FunctionNode $node,
-        NamespaceNode $namespaceNode = null,
-        $filename = null
+        LocatedSource $locatedSource,
+        NamespaceNode $namespaceNode = null
     ) {
         $function = new self();
 
-        $function->populateFunctionAbstract($node, $namespaceNode, $filename);
+        $function->populateFunctionAbstract($node, $locatedSource, $namespaceNode);
 
         return $function;
     }

--- a/src/Reflection/ReflectionFunctionAbstract.php
+++ b/src/Reflection/ReflectionFunctionAbstract.php
@@ -2,6 +2,7 @@
 
 namespace BetterReflection\Reflection;
 
+use BetterReflection\SourceLocator\LocatedSource;
 use PhpParser\Node;
 use PhpParser\Node\Stmt as MethodOrFunctionNode;
 use PhpParser\Node\Stmt\Namespace_ as NamespaceNode;
@@ -30,9 +31,9 @@ abstract class ReflectionFunctionAbstract
     private $docBlock;
 
     /**
-     * @var string|null
+     * @var LocatedSource
      */
-    private $filename;
+    private $locatedSource;
 
     /**
      * @var MethodOrFunctionNode
@@ -47,14 +48,14 @@ abstract class ReflectionFunctionAbstract
      * Populate the common elements of the function abstract
      *
      * @param MethodOrFunctionNode $node
+     * @param LocatedSource $locatedSource
      * @param NamespaceNode|null $declaringNamespace
-     * @param string|null $filename
      */
-    protected function populateFunctionAbstract(MethodOrFunctionNode $node, NamespaceNode $declaringNamespace = null, $filename = null)
+    protected function populateFunctionAbstract(MethodOrFunctionNode $node, LocatedSource $locatedSource, NamespaceNode $declaringNamespace = null)
     {
         $this->node = $node;
         $this->name = $node->name;
-        $this->filename = $filename;
+        $this->locatedSource = $locatedSource;
         $this->declaringNamespace = $declaringNamespace;
 
         if ($node->hasAttribute('comments')) {
@@ -208,7 +209,15 @@ abstract class ReflectionFunctionAbstract
      */
     public function getFileName()
     {
-        return $this->filename;
+        return $this->locatedSource->getFileName();
+    }
+
+    /**
+     * @return LocatedSource
+     */
+    public function getLocatedSource()
+    {
+        return $this->locatedSource;
     }
 
     /**

--- a/src/Reflection/ReflectionMethod.php
+++ b/src/Reflection/ReflectionMethod.php
@@ -37,7 +37,7 @@ class ReflectionMethod extends ReflectionFunctionAbstract
 
         // Compat with core reflection means we should NOT pass namespace info
         // for ReflectionMethod
-        $method->populateFunctionAbstract($node, null, $declaringClass->getFileName());
+        $method->populateFunctionAbstract($node, $declaringClass->getLocatedSource(), null);
 
         $method->flags |= $node->isAbstract() ? self::IS_ABSTRACT : 0;
         $method->flags |= $node->isFinal() ? self::IS_FINAL : 0;


### PR DESCRIPTION
Previously we were passing around $filename which may or may not be null or
the filename, but now we have a nicely contained LocatedSource object passed
around so we also have access to source code if we need ;)

* [x] Depends on #41 being merged first and rebase
* Required to be merged for #45