### PR TITLE
Context for FindParameterType

### DIFF
--- a/test/unit/TypesFinder/FindParameterTypeTest.php
+++ b/test/unit/TypesFinder/FindParameterTypeTest.php
@@ -2,7 +2,9 @@
 
 namespace BetterReflectionTest\TypesFinder;
 
-use BetterReflection\Reflection\ReflectionFunctionAbstract;
+use BetterReflection\Reflection\ReflectionClass;
+use BetterReflection\Reflection\ReflectionFunction;
+use BetterReflection\Reflection\ReflectionMethod;
 use BetterReflection\SourceLocator\LocatedSource;
 use BetterReflection\TypesFinder\FindParameterType;
 use PhpParser\Node\Param as ParamNode;
@@ -33,15 +35,15 @@ class FindParameterTypeTest extends \PHPUnit_Framework_TestCase
      * @param string[] $expectedInstances
      * @dataProvider parameterTypeProvider
      */
-    public function testFindParameterType($docBlock, $nodeName, $expectedInstances)
+    public function testFindParameterTypeForFunction($docBlock, $nodeName, $expectedInstances)
     {
         $node = new ParamNode($nodeName);
         $docBlock = "/**\n * $docBlock\n */";
 
-        $function = $this->getMockBuilder(ReflectionFunctionAbstract::class)
+        $function = $this->getMockBuilder(ReflectionFunction::class)
             ->setMethods(['getDocComment', 'getLocatedSource'])
             ->disableOriginalConstructor()
-            ->getMockForAbstractClass();
+            ->getMock();
 
         $function
             ->expects($this->once())
@@ -53,8 +55,54 @@ class FindParameterTypeTest extends \PHPUnit_Framework_TestCase
             ->method('getLocatedSource')
             ->will($this->returnValue(new LocatedSource('<?php', null)));
 
-        /* @var ReflectionFunctionAbstract $function */
+        /* @var ReflectionFunction $function */
         $foundTypes = (new FindParameterType())->__invoke($function, $node);
+
+        $this->assertCount(count($expectedInstances), $foundTypes);
+
+        foreach ($expectedInstances as $i => $expectedInstance) {
+            $this->assertInstanceOf($expectedInstance, $foundTypes[$i]);
+        }
+    }
+
+    /**
+     * @param string $docBlock
+     * @param string $nodeName
+     * @param string[] $expectedInstances
+     * @dataProvider parameterTypeProvider
+     */
+    public function testFindParameterTypeForMethod($docBlock, $nodeName, $expectedInstances)
+    {
+        $node = new ParamNode($nodeName);
+        $docBlock = "/**\n * $docBlock\n */";
+
+        $class = $this->getMockBuilder(ReflectionClass::class)
+            ->setMethods(['getLocatedSource'])
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $class
+            ->expects($this->once())
+            ->method('getLocatedSource')
+            ->will($this->returnValue(new LocatedSource('<?php', null)));
+
+        $method = $this->getMockBuilder(ReflectionMethod::class)
+            ->setMethods(['getDocComment', 'getDeclaringClass'])
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $method
+            ->expects($this->once())
+            ->method('getDocComment')
+            ->will($this->returnValue($docBlock));
+
+        $method
+            ->expects($this->once())
+            ->method('getDeclaringClass')
+            ->will($this->returnValue($class));
+
+        /* @var ReflectionMethod $method */
+        $foundTypes = (new FindParameterType())->__invoke($method, $node);
 
         $this->assertCount(count($expectedInstances), $foundTypes);
 

--- a/test/unit/TypesFinder/FindParameterTypeTest.php
+++ b/test/unit/TypesFinder/FindParameterTypeTest.php
@@ -3,6 +3,7 @@
 namespace BetterReflectionTest\TypesFinder;
 
 use BetterReflection\Reflection\ReflectionFunctionAbstract;
+use BetterReflection\SourceLocator\LocatedSource;
 use BetterReflection\TypesFinder\FindParameterType;
 use PhpParser\Node\Param as ParamNode;
 use phpDocumentor\Reflection\Types;
@@ -38,7 +39,7 @@ class FindParameterTypeTest extends \PHPUnit_Framework_TestCase
         $docBlock = "/**\n * $docBlock\n */";
 
         $function = $this->getMockBuilder(ReflectionFunctionAbstract::class)
-            ->setMethods(['getDocComment'])
+            ->setMethods(['getDocComment', 'getLocatedSource'])
             ->disableOriginalConstructor()
             ->getMockForAbstractClass();
 
@@ -46,6 +47,11 @@ class FindParameterTypeTest extends \PHPUnit_Framework_TestCase
             ->expects($this->once())
             ->method('getDocComment')
             ->will($this->returnValue($docBlock));
+
+        $function
+            ->expects($this->once())
+            ->method('getLocatedSource')
+            ->will($this->returnValue(new LocatedSource('<?php', null)));
 
         /* @var ReflectionFunctionAbstract $function */
         $foundTypes = (new FindParameterType())->__invoke($function, $node);


### PR DESCRIPTION
By using the better availability of `LocatedSource` from PR #44, we are able to now determine parameter types with context, thus resolving #29 

* [x] Depends on #44 being merged - require rebase
* Required for #46 to be merged