### PR TITLE
Context for FindTypeFromAst

### DIFF
--- a/src/Reflection/ReflectionParameter.php
+++ b/src/Reflection/ReflectionParameter.php
@@ -126,7 +126,15 @@ class ReflectionParameter implements \Reflector
         $param->isVariadic = (bool)$node->variadic;
         $param->isByReference = (bool)$node->byRef;
         $param->parameterIndex = (int)$parameterIndex;
-        $param->typeHint = (new FindTypeFromAst())->__invoke($node->type);
+        $param->typeHint = (new FindTypeFromAst())->__invoke(
+            $node->type,
+            $function->getLocatedSource(),
+            (
+                $function instanceof ReflectionMethod
+                ? $function->getDeclaringClass()->getNamespaceName()
+                : $function->getNamespaceName()
+            )
+        );
 
         if ($param->hasDefaultValue) {
             $param->parseDefaultValueNode($node->default);

--- a/test/unit/Reflection/ReflectionParameterTest.php
+++ b/test/unit/Reflection/ReflectionParameterTest.php
@@ -105,9 +105,7 @@ class ReflectionParameterTest extends \PHPUnit_Framework_TestCase
             ['fullyQualifiedClassParameter', Types\Object_::class, '\BetterReflectionTest\Fixture\ClassForHinting', 'ClassForHinting'],
             ['arrayParameter', Types\Array_::class],
             ['callableParameter', Types\Callable_::class],
-
-            // @todo Currently failing as we cannot resolve this properly yet
-            //['namespaceClassParameter', Types\Object__::class, 'ClassForHinting'],
+            ['namespaceClassParameter', Types\Object_::class, '\BetterReflectionTest\Fixture\ClassForHinting', 'ClassForHinting'],
         ];
     }
 


### PR DESCRIPTION
By using the better availability of `LocatedSource` from PR #44, we are able to now determine parameter types with context, thus resolving #30 

* [x] Depends on #45 being merged - require rebase