### PR TITLE
Fix resolution of imported namespaces within docblocks in params and properties

### DIFF
--- a/src/TypesFinder/FindParameterType.php
+++ b/src/TypesFinder/FindParameterType.php
@@ -23,7 +23,13 @@ class FindParameterType
     {
         $context = $this->createContextForFunction($function);
 
-        $docBlock = new DocBlock($function->getDocComment());
+        $docBlock = new DocBlock(
+            $function->getDocComment(),
+            new DocBlock\Context(
+                $context->getNamespace(),
+                $context->getNamespaceAliases()
+            )
+        );
 
         $paramTags = $docBlock->getTagsByName('param');
 

--- a/src/TypesFinder/FindPropertyType.php
+++ b/src/TypesFinder/FindPropertyType.php
@@ -20,7 +20,10 @@ class FindPropertyType
     public function __invoke(PropertyNode $node, ReflectionProperty $reflectionProperty)
     {
         $contextFactory = new ContextFactory();
-        $context = $contextFactory->createFromReflector($reflectionProperty);
+        $context = $contextFactory->createForNamespace(
+            $reflectionProperty->getDeclaringClass()->getNamespaceName(),
+            $reflectionProperty->getDeclaringClass()->getLocatedSource()->getSource()
+        );
 
         /* @var \PhpParser\Comment\Doc $comment */
         if (!$node->hasAttribute('comments')) {
@@ -30,7 +33,8 @@ class FindPropertyType
         $docBlock = new DocBlock(
             $comment->getReformattedText(),
             new DocBlock\Context(
-                $reflectionProperty->getDeclaringClass()->getNamespaceName()
+                $context->getNamespace(),
+                $context->getNamespaceAliases()
             )
         );
 


### PR DESCRIPTION
This resolves bug #5 with test cases and code updates

This also resolves bug #47