### PR TITLE
Adds compatibility for ReflectionProperty

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -138,7 +138,7 @@ The progress of compatibility can also be tracked in issue [#7](https://github.c
 |--------|-----------|
 | getDeclaringClass | :heavy_check_mark: Yes |
 | getDocComment | :heavy_check_mark: Yes |
-| getModifiers | todo |
+| getModifiers | :heavy_check_mark: Yes |
 | getName | :heavy_check_mark: Yes |
 | getValue | :x: No - would require an instance of an object (#14) |
 | isDefault | todo |

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -141,7 +141,7 @@ The progress of compatibility can also be tracked in issue [#7](https://github.c
 | getModifiers | :heavy_check_mark: Yes |
 | getName | :heavy_check_mark: Yes |
 | getValue | :x: No - would require an instance of an object (#14) |
-| isDefault | todo |
+| isDefault | :heavy_check_mark: Yes |
 | isPrivate | :heavy_check_mark: Yes |
 | isProtected | :heavy_check_mark: Yes |
 | isPublic | :heavy_check_mark: Yes |

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -137,7 +137,7 @@ The progress of compatibility can also be tracked in issue [#7](https://github.c
 | Method | Supported |
 |--------|-----------|
 | getDeclaringClass | :heavy_check_mark: Yes |
-| getDocComment | todo |
+| getDocComment | :heavy_check_mark: Yes |
 | getModifiers | todo |
 | getName | :heavy_check_mark: Yes |
 | getValue | :x: No - would require an instance of an object (#14) |

--- a/src/Reflection/ReflectionProperty.php
+++ b/src/Reflection/ReflectionProperty.php
@@ -43,11 +43,6 @@ class ReflectionProperty implements \Reflector
      */
     private $docBlock = '';
 
-    /**
-     * @var bool
-     */
-    private $isRuntimeDeclared = false;
-
     private function __construct()
     {
     }
@@ -123,7 +118,11 @@ class ReflectionProperty implements \Reflector
     }
 
     /**
-     * Has the property been declared at runtime (rather than compile-time?)
+     * Has the property been declared at compile-time?
+     *
+     * Note that unless the property is static, this is hard coded to return
+     * true, because we are unable to reflect instances of classes, therefore
+     * we can be sure that all properties are always declared at compile-time.
      *
      * @return bool
      */
@@ -133,7 +132,7 @@ class ReflectionProperty implements \Reflector
             return false;
         }
 
-        return !$this->isRuntimeDeclared;
+        return true;
     }
 
     /**

--- a/src/Reflection/ReflectionProperty.php
+++ b/src/Reflection/ReflectionProperty.php
@@ -116,6 +116,21 @@ class ReflectionProperty implements \Reflector
     }
 
     /**
+     * Get the core-reflection-compatible modifier values
+     *
+     * @return int
+     */
+    public function getModifiers()
+    {
+        $val = 0;
+        $val += $this->isStatic() ? \ReflectionProperty::IS_STATIC : 0;
+        $val += $this->isPublic() ? \ReflectionProperty::IS_PUBLIC : 0;
+        $val += $this->isProtected() ? \ReflectionProperty::IS_PROTECTED : 0;
+        $val += $this->isPrivate() ? \ReflectionProperty::IS_PRIVATE : 0;
+        return $val;
+    }
+
+    /**
      * Get the name of the property
      *
      * @return string

--- a/src/Reflection/ReflectionProperty.php
+++ b/src/Reflection/ReflectionProperty.php
@@ -43,6 +43,11 @@ class ReflectionProperty implements \Reflector
      */
     private $docBlock = '';
 
+    /**
+     * @var bool
+     */
+    private $isRuntimeDeclared = false;
+
     private function __construct()
     {
     }
@@ -60,8 +65,10 @@ class ReflectionProperty implements \Reflector
     public function __toString()
     {
         return sprintf(
-            'Property [ <default> %s $%s ]',
+            'Property [%s %s%s $%s ]',
+            $this->isStatic() ? '' : ($this->isDefault() ? ' <default>' : ' <implicit>'),
             $this->getVisibilityAsString(),
+            $this->isStatic() ? ' static' : '',
             $this->getName()
         );
     }
@@ -113,6 +120,20 @@ class ReflectionProperty implements \Reflector
             default:
                 return 'public';
         }
+    }
+
+    /**
+     * Has the property been declared at runtime (rather than compile-time?)
+     *
+     * @return bool
+     */
+    public function isDefault()
+    {
+        if ($this->isStatic()) {
+            return false;
+        }
+
+        return !$this->isRuntimeDeclared;
     }
 
     /**

--- a/src/Reflection/ReflectionProperty.php
+++ b/src/Reflection/ReflectionProperty.php
@@ -38,6 +38,11 @@ class ReflectionProperty implements \Reflector
      */
     private $declaringClass;
 
+    /**
+     * @var string
+     */
+    private $docBlock = '';
+
     private function __construct()
     {
     }
@@ -74,6 +79,12 @@ class ReflectionProperty implements \Reflector
         $prop->name = $node->props[0]->name;
         $prop->declaringClass = $declaringClass;
 
+        if ($node->hasAttribute('comments')) {
+            /* @var \PhpParser\Comment\Doc $comment */
+            $comment = $node->getAttribute('comments')[0];
+            $prop->docBlock = $comment->getReformattedText();
+        }
+
         if ($node->isPrivate()) {
             $prop->visibility = self::IS_PRIVATE;
         } elseif ($node->isProtected()) {
@@ -84,7 +95,7 @@ class ReflectionProperty implements \Reflector
 
         $prop->isStatic = $node->isStatic();
 
-        $prop->docBlockTypes = (new FindPropertyType())->__invoke($node, $prop);
+        $prop->docBlockTypes = (new FindPropertyType())->__invoke($prop);
 
         return $prop;
     }
@@ -188,5 +199,13 @@ class ReflectionProperty implements \Reflector
     public function getDeclaringClass()
     {
         return $this->declaringClass;
+    }
+
+    /**
+     * @return string
+     */
+    public function getDocComment()
+    {
+        return $this->docBlock;
     }
 }

--- a/src/TypesFinder/FindPropertyType.php
+++ b/src/TypesFinder/FindPropertyType.php
@@ -13,11 +13,10 @@ class FindPropertyType
     /**
      * Given a property, attempt to find the type of the property
      *
-     * @param PropertyNode $node
      * @param ReflectionProperty $reflectionProperty
      * @return Type[]
      */
-    public function __invoke(PropertyNode $node, ReflectionProperty $reflectionProperty)
+    public function __invoke(ReflectionProperty $reflectionProperty)
     {
         $contextFactory = new ContextFactory();
         $context = $contextFactory->createForNamespace(
@@ -25,13 +24,8 @@ class FindPropertyType
             $reflectionProperty->getDeclaringClass()->getLocatedSource()->getSource()
         );
 
-        /* @var \PhpParser\Comment\Doc $comment */
-        if (!$node->hasAttribute('comments')) {
-            return [];
-        }
-        $comment = $node->getAttribute('comments')[0];
         $docBlock = new DocBlock(
-            $comment->getReformattedText(),
+            $reflectionProperty->getDocComment(),
             new DocBlock\Context(
                 $context->getNamespace(),
                 $context->getNamespaceAliases()

--- a/test/unit/Reflection/ReflectionPropertyTest.php
+++ b/test/unit/Reflection/ReflectionPropertyTest.php
@@ -88,4 +88,32 @@ class ReflectionPropertyTest extends \PHPUnit_Framework_TestCase
         $this->setExpectedException(\Exception::class);
         ReflectionProperty::export();
     }
+
+    public function modifierProvider()
+    {
+        return [
+            ['publicProperty', 256, ['public']],
+            ['protectedProperty', 512, ['protected']],
+            ['privateProperty', 1024, ['private']],
+            ['publicStaticProperty', 257, ['public', 'static']],
+        ];
+    }
+
+    /**
+     * @param string $propertyName
+     * @param int $expectedModifier
+     * @param string[] $expectedModifierNames
+     * @dataProvider modifierProvider
+     */
+    public function testGetModifiers($propertyName, $expectedModifier, array $expectedModifierNames)
+    {
+        $classInfo = $this->reflector->reflect('\BetterReflectionTest\Fixture\ExampleClass');
+        $property = $classInfo->getProperty($propertyName);
+
+        $this->assertSame($expectedModifier, $property->getModifiers());
+        $this->assertSame(
+            $expectedModifierNames,
+            \Reflection::getModifierNames($property->getModifiers())
+        );
+    }
 }

--- a/test/unit/Reflection/ReflectionPropertyTest.php
+++ b/test/unit/Reflection/ReflectionPropertyTest.php
@@ -2,6 +2,7 @@
 
 namespace BetterReflectionTest\Reflection;
 
+use BetterReflection\Reflection\ReflectionProperty;
 use BetterReflection\Reflector\ClassReflector;
 use BetterReflection\SourceLocator\ComposerSourceLocator;
 
@@ -70,5 +71,21 @@ class ReflectionPropertyTest extends \PHPUnit_Framework_TestCase
         $property = $classInfo->getProperty($propertyName);
 
         $this->assertSame($expectedTypes, $property->getDocBlockTypeStrings());
+    }
+
+    public function testGetDocComment()
+    {
+        $expectedDoc = "/**\n * @var string\n */";
+
+        $classInfo = $this->reflector->reflect('\BetterReflectionTest\Fixture\ExampleClass');
+        $property = $classInfo->getProperty('publicProperty');
+
+        $this->assertSame($expectedDoc, $property->getDocComment());
+    }
+
+    public function testExportThrowsException()
+    {
+        $this->setExpectedException(\Exception::class);
+        ReflectionProperty::export();
     }
 }

--- a/test/unit/Reflection/ReflectionPropertyTest.php
+++ b/test/unit/Reflection/ReflectionPropertyTest.php
@@ -116,4 +116,33 @@ class ReflectionPropertyTest extends \PHPUnit_Framework_TestCase
             \Reflection::getModifierNames($property->getModifiers())
         );
     }
+
+    public function testIsDefault()
+    {
+        $classInfo = $this->reflector->reflect('\BetterReflectionTest\Fixture\ExampleClass');
+
+        $this->assertTrue($classInfo->getProperty('publicProperty')->isDefault());
+        $this->assertFalse($classInfo->getProperty('publicStaticProperty')->isDefault());
+    }
+
+    public function castToStringProvider()
+    {
+        return [
+            ['publicProperty', 'Property [ <default> public $publicProperty ]'],
+            ['protectedProperty', 'Property [ <default> protected $protectedProperty ]'],
+            ['privateProperty', 'Property [ <default> private $privateProperty ]'],
+            ['publicStaticProperty', 'Property [ public static $publicStaticProperty ]'],
+        ];
+    }
+
+    /**
+     * @param string $propertyName
+     * @param string $expectedString
+     * @dataProvider castToStringProvider
+     */
+    public function testCastingToString($propertyName, $expectedString)
+    {
+        $classInfo = $this->reflector->reflect('\BetterReflectionTest\Fixture\ExampleClass');
+        $this->assertSame($expectedString, (string)$classInfo->getProperty($propertyName));
+    }
 }

--- a/test/unit/Reflection/ReflectionPropertyTest.php
+++ b/test/unit/Reflection/ReflectionPropertyTest.php
@@ -5,6 +5,7 @@ namespace BetterReflectionTest\Reflection;
 use BetterReflection\Reflection\ReflectionProperty;
 use BetterReflection\Reflector\ClassReflector;
 use BetterReflection\SourceLocator\ComposerSourceLocator;
+use phpDocumentor\Reflection\Types;
 
 /**
  * @covers \BetterReflection\Reflection\ReflectionProperty
@@ -50,7 +51,7 @@ class ReflectionPropertyTest extends \PHPUnit_Framework_TestCase
     /**
      * @return array
      */
-    public function typesDataProvider()
+    public function stringTypesDataProvider()
     {
         return [
             ['privateProperty', ['int', 'float', '\stdClass']],
@@ -62,7 +63,7 @@ class ReflectionPropertyTest extends \PHPUnit_Framework_TestCase
     /**
      * @param string $propertyName
      * @param string[] $expectedTypes
-     * @dataProvider typesDataProvider
+     * @dataProvider stringTypesDataProvider
      */
     public function testGetDocBlockTypeStrings($propertyName, $expectedTypes)
     {
@@ -71,6 +72,36 @@ class ReflectionPropertyTest extends \PHPUnit_Framework_TestCase
         $property = $classInfo->getProperty($propertyName);
 
         $this->assertSame($expectedTypes, $property->getDocBlockTypeStrings());
+    }
+
+    /**
+     * @return array
+     */
+    public function typesDataProvider()
+    {
+        return [
+            ['privateProperty', [Types\Integer::class, Types\Float_::class, Types\Object_::class]],
+            ['protectedProperty', [Types\Boolean::class, Types\Array_::class, Types\Array_::class]],
+            ['publicProperty', [Types\String_::class]],
+        ];
+    }
+
+    /**
+     * @param string $propertyName
+     * @param string[] $expectedTypes
+     * @dataProvider typesDataProvider
+     */
+    public function testGetDocBlockTypes($propertyName, $expectedTypes)
+    {
+        $classInfo = $this->reflector->reflect('\BetterReflectionTest\Fixture\ExampleClass');
+
+        $foundTypes = $classInfo->getProperty($propertyName)->getDocBlockTypes();
+
+        $this->assertCount(count($expectedTypes), $foundTypes);
+
+        foreach ($expectedTypes as $i => $expectedType) {
+            $this->assertInstanceOf($expectedType, $foundTypes[$i]);
+        }
     }
 
     public function testGetDocComment()


### PR DESCRIPTION
As part of #7, this PR completes method compatibility for the `ReflectionProperty` class, including test coverage.

Note that the API for the `FindPropertyType` invokable has changed, because we no longer need the AST node, due to implementing the `getDocComment()` method in `ReflectionProperty`.