### PR TITLE
Compatibility for ReflectionClass

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
         "php": ">= 5.6",
         "nikic/php-parser": "^1.3",
         "phpdocumentor/reflection-docblock": "^2.0",
-        "phpdocumentor/type-resolver": "dev-ignore-class-trait-usage"
+        "phpdocumentor/type-resolver": "dev-master"
     },
     "require-dev": {
         "fabpot/php-cs-fixer": "^1.8",
@@ -20,12 +20,6 @@
     "suggest": {
         "composer/composer": "Required to use the ComposerSourceLocator thing"
     },
-    "repositories": [
-        {
-            "type": "vcs",
-            "url": "git@github.com:asgrim/TypeResolver.git"
-        }
-    ],
     "minimum-stability": "dev",
     "prefer-stable": true
 }

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
         "php": ">= 5.6",
         "nikic/php-parser": "^1.3",
         "phpdocumentor/reflection-docblock": "^2.0",
-        "phpdocumentor/type-resolver": "^1.0@dev"
+        "phpdocumentor/type-resolver": "dev-ignore-class-trait-usage"
     },
     "require-dev": {
         "fabpot/php-cs-fixer": "^1.8",
@@ -20,6 +20,12 @@
     "suggest": {
         "composer/composer": "Required to use the ComposerSourceLocator thing"
     },
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "git@github.com:asgrim/TypeResolver.git"
+        }
+    ],
     "minimum-stability": "dev",
     "prefer-stable": true
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "8f0b12c5303fcf0293c83d292bc93012",
+    "hash": "f67df423b712b0d5ffe903c55bfaef1e",
     "packages": [
         {
             "name": "nikic/php-parser",
-            "version": "v1.3.0",
+            "version": "v1.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "dff239267fd1befa1cd40430c9ed12591aa720ca"
+                "reference": "196f177cfefa0f1f7166c0a05d8255889be12418"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/dff239267fd1befa1cd40430c9ed12591aa720ca",
-                "reference": "dff239267fd1befa1cd40430c9ed12591aa720ca",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/196f177cfefa0f1f7166c0a05d8255889be12418",
+                "reference": "196f177cfefa0f1f7166c0a05d8255889be12418",
                 "shasum": ""
             },
             "require": {
@@ -27,7 +27,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.3-dev"
+                    "dev-master": "1.4-dev"
                 }
             },
             "autoload": {
@@ -49,7 +49,7 @@
                 "parser",
                 "php"
             ],
-            "time": "2015-05-02 15:40:40"
+            "time": "2015-07-14 17:31:05"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -156,16 +156,16 @@
         },
         {
             "name": "phpdocumentor/type-resolver",
-            "version": "dev-master",
+            "version": "dev-ignore-class-trait-usage",
             "source": {
                 "type": "git",
-                "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "14bb2da6387c6a58648b4a87ff02d4c971050309"
+                "url": "https://github.com/asgrim/TypeResolver.git",
+                "reference": "0c11dd904d5caa4a3e889bb54d0b31d1ef314189"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/14bb2da6387c6a58648b4a87ff02d4c971050309",
-                "reference": "14bb2da6387c6a58648b4a87ff02d4c971050309",
+                "url": "https://api.github.com/repos/asgrim/TypeResolver/zipball/0c11dd904d5caa4a3e889bb54d0b31d1ef314189",
+                "reference": "0c11dd904d5caa4a3e889bb54d0b31d1ef314189",
                 "shasum": ""
             },
             "require": {
@@ -189,7 +189,13 @@
                     ]
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": [
+                        "tests/unit"
+                    ]
+                }
+            },
             "license": [
                 "MIT"
             ],
@@ -199,7 +205,10 @@
                     "email": "me@mikevanriel.com"
                 }
             ],
-            "time": "2015-07-02 17:28:34"
+            "support": {
+                "source": "https://github.com/asgrim/TypeResolver/tree/ignore-class-trait-usage"
+            },
+            "time": "2015-07-14 18:26:42"
         }
     ],
     "packages-dev": [
@@ -259,16 +268,16 @@
         },
         {
             "name": "fabpot/php-cs-fixer",
-            "version": "v1.9",
+            "version": "v1.9.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/FriendsOfPHP/PHP-CS-Fixer.git",
-                "reference": "ef528b9d3f1dd66197baabf8f77c8402c62bb9fc"
+                "reference": "f2c2c5527113f346d77eb790e62395fe8de58c4f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/ef528b9d3f1dd66197baabf8f77c8402c62bb9fc",
-                "reference": "ef528b9d3f1dd66197baabf8f77c8402c62bb9fc",
+                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/f2c2c5527113f346d77eb790e62395fe8de58c4f",
+                "reference": "f2c2c5527113f346d77eb790e62395fe8de58c4f",
                 "shasum": ""
             },
             "require": {
@@ -309,7 +318,7 @@
                 }
             ],
             "description": "A tool to automatically fix PHP code style",
-            "time": "2015-06-13 09:30:19"
+            "time": "2015-07-08 21:03:30"
         },
         {
             "name": "phpspec/prophecy",
@@ -373,16 +382,16 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "2.1.7",
+            "version": "2.1.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "07e27765596d72c378a6103e80da5d84e802f1e4"
+                "reference": "6044546998c7627ab997501a3d0db972b3db9790"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/07e27765596d72c378a6103e80da5d84e802f1e4",
-                "reference": "07e27765596d72c378a6103e80da5d84e802f1e4",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/6044546998c7627ab997501a3d0db972b3db9790",
+                "reference": "6044546998c7627ab997501a3d0db972b3db9790",
                 "shasum": ""
             },
             "require": {
@@ -431,7 +440,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2015-06-30 06:52:35"
+            "time": "2015-07-13 11:25:58"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -613,16 +622,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "4.7.6",
+            "version": "4.7.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "0ebabb4cda7d066be8391dfdbaf57fe70ac9a99b"
+                "reference": "9b97f9d807b862c2de2a36e86690000801c85724"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/0ebabb4cda7d066be8391dfdbaf57fe70ac9a99b",
-                "reference": "0ebabb4cda7d066be8391dfdbaf57fe70ac9a99b",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/9b97f9d807b862c2de2a36e86690000801c85724",
+                "reference": "9b97f9d807b862c2de2a36e86690000801c85724",
                 "shasum": ""
             },
             "require": {
@@ -681,20 +690,20 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2015-06-30 06:53:57"
+            "time": "2015-07-13 11:28:34"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
-            "version": "2.3.4",
+            "version": "2.3.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
-                "reference": "92408bb1968a81b3217a6fdf6c1a198da83caa35"
+                "reference": "1c330b1b6e1ea8fd15f2fbea46770576e366855c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/92408bb1968a81b3217a6fdf6c1a198da83caa35",
-                "reference": "92408bb1968a81b3217a6fdf6c1a198da83caa35",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/1c330b1b6e1ea8fd15f2fbea46770576e366855c",
+                "reference": "1c330b1b6e1ea8fd15f2fbea46770576e366855c",
                 "shasum": ""
             },
             "require": {
@@ -736,7 +745,7 @@
                 "mock",
                 "xunit"
             ],
-            "time": "2015-06-11 15:55:48"
+            "time": "2015-07-04 05:41:32"
         },
         {
             "name": "sebastian/comparator",
@@ -1111,16 +1120,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v2.7.1",
+            "version": "v2.7.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/Console.git",
-                "reference": "564398bc1f33faf92fc2ec86859983d30eb81806"
+                "reference": "8cf484449130cabfd98dcb4694ca9945802a21ed"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Console/zipball/564398bc1f33faf92fc2ec86859983d30eb81806",
-                "reference": "564398bc1f33faf92fc2ec86859983d30eb81806",
+                "url": "https://api.github.com/repos/symfony/Console/zipball/8cf484449130cabfd98dcb4694ca9945802a21ed",
+                "reference": "8cf484449130cabfd98dcb4694ca9945802a21ed",
                 "shasum": ""
             },
             "require": {
@@ -1164,20 +1173,20 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2015-06-10 15:30:22"
+            "time": "2015-07-09 16:07:40"
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v2.7.1",
+            "version": "v2.7.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/EventDispatcher.git",
-                "reference": "be3c5ff8d503c46768aeb78ce6333051aa6f26d9"
+                "reference": "9310b5f9a87ec2ea75d20fec0b0017c77c66dac3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/EventDispatcher/zipball/be3c5ff8d503c46768aeb78ce6333051aa6f26d9",
-                "reference": "be3c5ff8d503c46768aeb78ce6333051aa6f26d9",
+                "url": "https://api.github.com/repos/symfony/EventDispatcher/zipball/9310b5f9a87ec2ea75d20fec0b0017c77c66dac3",
+                "reference": "9310b5f9a87ec2ea75d20fec0b0017c77c66dac3",
                 "shasum": ""
             },
             "require": {
@@ -1222,20 +1231,20 @@
             ],
             "description": "Symfony EventDispatcher Component",
             "homepage": "https://symfony.com",
-            "time": "2015-06-08 09:37:21"
+            "time": "2015-06-18 19:21:56"
         },
         {
             "name": "symfony/filesystem",
-            "version": "v2.7.1",
+            "version": "v2.7.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/Filesystem.git",
-                "reference": "a0d43eb3e17d4f4c6990289805a488a0482a07f3"
+                "reference": "2d7b2ddaf3f548f4292df49a99d19c853d43f0b8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Filesystem/zipball/a0d43eb3e17d4f4c6990289805a488a0482a07f3",
-                "reference": "a0d43eb3e17d4f4c6990289805a488a0482a07f3",
+                "url": "https://api.github.com/repos/symfony/Filesystem/zipball/2d7b2ddaf3f548f4292df49a99d19c853d43f0b8",
+                "reference": "2d7b2ddaf3f548f4292df49a99d19c853d43f0b8",
                 "shasum": ""
             },
             "require": {
@@ -1271,20 +1280,20 @@
             ],
             "description": "Symfony Filesystem Component",
             "homepage": "https://symfony.com",
-            "time": "2015-06-08 09:37:21"
+            "time": "2015-07-09 16:07:40"
         },
         {
             "name": "symfony/finder",
-            "version": "v2.7.1",
+            "version": "v2.7.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/Finder.git",
-                "reference": "c13a40d638aeede1e8400f8c956c7f9246c05f75"
+                "reference": "ae0f363277485094edc04c9f3cbe595b183b78e4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Finder/zipball/c13a40d638aeede1e8400f8c956c7f9246c05f75",
-                "reference": "c13a40d638aeede1e8400f8c956c7f9246c05f75",
+                "url": "https://api.github.com/repos/symfony/Finder/zipball/ae0f363277485094edc04c9f3cbe595b183b78e4",
+                "reference": "ae0f363277485094edc04c9f3cbe595b183b78e4",
                 "shasum": ""
             },
             "require": {
@@ -1320,20 +1329,20 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
-            "time": "2015-06-04 20:11:48"
+            "time": "2015-07-09 16:07:40"
         },
         {
             "name": "symfony/process",
-            "version": "v2.7.1",
+            "version": "v2.7.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/Process.git",
-                "reference": "552d8efdc80980cbcca50b28d626ac8e36e3cdd1"
+                "reference": "48aeb0e48600321c272955132d7606ab0a49adb3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Process/zipball/552d8efdc80980cbcca50b28d626ac8e36e3cdd1",
-                "reference": "552d8efdc80980cbcca50b28d626ac8e36e3cdd1",
+                "url": "https://api.github.com/repos/symfony/Process/zipball/48aeb0e48600321c272955132d7606ab0a49adb3",
+                "reference": "48aeb0e48600321c272955132d7606ab0a49adb3",
                 "shasum": ""
             },
             "require": {
@@ -1369,20 +1378,20 @@
             ],
             "description": "Symfony Process Component",
             "homepage": "https://symfony.com",
-            "time": "2015-06-08 09:37:21"
+            "time": "2015-07-01 11:25:50"
         },
         {
             "name": "symfony/stopwatch",
-            "version": "v2.7.1",
+            "version": "v2.7.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/Stopwatch.git",
-                "reference": "c653f1985f6c2b7dbffd04d48b9c0a96aaef814b"
+                "reference": "b07a866719bbac5294c67773340f97b871733310"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Stopwatch/zipball/c653f1985f6c2b7dbffd04d48b9c0a96aaef814b",
-                "reference": "c653f1985f6c2b7dbffd04d48b9c0a96aaef814b",
+                "url": "https://api.github.com/repos/symfony/Stopwatch/zipball/b07a866719bbac5294c67773340f97b871733310",
+                "reference": "b07a866719bbac5294c67773340f97b871733310",
                 "shasum": ""
             },
             "require": {
@@ -1418,20 +1427,20 @@
             ],
             "description": "Symfony Stopwatch Component",
             "homepage": "https://symfony.com",
-            "time": "2015-06-04 20:11:48"
+            "time": "2015-07-01 18:23:16"
         },
         {
             "name": "symfony/yaml",
-            "version": "v2.7.1",
+            "version": "v2.7.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/Yaml.git",
-                "reference": "9808e75c609a14f6db02f70fccf4ca4aab53c160"
+                "reference": "4bfbe0ed3909bfddd75b70c094391ec1f142f860"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Yaml/zipball/9808e75c609a14f6db02f70fccf4ca4aab53c160",
-                "reference": "9808e75c609a14f6db02f70fccf4ca4aab53c160",
+                "url": "https://api.github.com/repos/symfony/Yaml/zipball/4bfbe0ed3909bfddd75b70c094391ec1f142f860",
+                "reference": "4bfbe0ed3909bfddd75b70c094391ec1f142f860",
                 "shasum": ""
             },
             "require": {
@@ -1467,7 +1476,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2015-06-10 15:30:22"
+            "time": "2015-07-01 11:25:50"
         }
     ],
     "aliases": [],

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "f67df423b712b0d5ffe903c55bfaef1e",
+    "hash": "adff438cea0b94105ee46e3611c7af34",
     "packages": [
         {
             "name": "nikic/php-parser",
@@ -156,16 +156,16 @@
         },
         {
             "name": "phpdocumentor/type-resolver",
-            "version": "dev-ignore-class-trait-usage",
+            "version": "dev-master",
             "source": {
                 "type": "git",
-                "url": "https://github.com/asgrim/TypeResolver.git",
-                "reference": "0c11dd904d5caa4a3e889bb54d0b31d1ef314189"
+                "url": "https://github.com/phpDocumentor/TypeResolver.git",
+                "reference": "83e31258fb03b9a27884a83b81501cb4cb297a81"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/asgrim/TypeResolver/zipball/0c11dd904d5caa4a3e889bb54d0b31d1ef314189",
-                "reference": "0c11dd904d5caa4a3e889bb54d0b31d1ef314189",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/83e31258fb03b9a27884a83b81501cb4cb297a81",
+                "reference": "83e31258fb03b9a27884a83b81501cb4cb297a81",
                 "shasum": ""
             },
             "require": {
@@ -189,13 +189,7 @@
                     ]
                 }
             },
-            "autoload-dev": {
-                "psr-4": {
-                    "phpDocumentor\\Reflection\\": [
-                        "tests/unit"
-                    ]
-                }
-            },
+            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
             ],
@@ -205,10 +199,7 @@
                     "email": "me@mikevanriel.com"
                 }
             ],
-            "support": {
-                "source": "https://github.com/asgrim/TypeResolver/tree/ignore-class-trait-usage"
-            },
-            "time": "2015-07-14 18:26:42"
+            "time": "2015-07-18 13:58:32"
         }
     ],
     "packages-dev": [

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -9,7 +9,7 @@ The progress of compatibility can also be tracked in issue [#7](https://github.c
 | getConstant | :heavy_check_mark: Yes |
 | getConstants | :heavy_check_mark: Yes |
 | getConstructor | :heavy_check_mark: Yes |
-| getDefaultProperties | todo |
+| getDefaultProperties | :heavy_check_mark: Yes |
 | getDocComment | :heavy_check_mark: Yes |
 | getEndLine | :heavy_check_mark: Yes |
 | getExtension | :x: No - extensions are not supported ([#15](https://github.com/Roave/BetterReflection/issues/15)) |

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -21,7 +21,7 @@ The progress of compatibility can also be tracked in issue [#7](https://github.c
 | getModifiers | todo |
 | getName | :heavy_check_mark: Yes |
 | getNamespaceName | :heavy_check_mark: Yes |
-| getParentClass | todo |
+| getParentClass | :heavy_check_mark: Yes |
 | getProperties | :heavy_check_mark: Yes |
 | getProperty | :heavy_check_mark: Yes |
 | getShortName | :heavy_check_mark: Yes |

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -45,7 +45,7 @@ The progress of compatibility can also be tracked in issue [#7](https://github.c
 | isInternal | :heavy_check_mark: Yes |
 | isIterateable | todo |
 | isSubclassOf | todo |
-| isTrait | todo |
+| isTrait | :heavy_check_mark: Yes |
 | isUserDefined | :heavy_check_mark: Yes |
 | newInstance | todo |
 | newInstanceArgs | todo |

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -36,9 +36,9 @@ The progress of compatibility can also be tracked in issue [#7](https://github.c
 | hasProperty | :heavy_check_mark: Yes |
 | implementsInterface | todo |
 | inNamespace | :heavy_check_mark: Yes |
-| isAbstract | todo |
+| isAbstract | :heavy_check_mark: Yes |
 | isCloneable | todo |
-| isFinal | todo |
+| isFinal | :heavy_check_mark: Yes |
 | isInstance | todo |
 | isInstantiable | todo |
 | isInterface | todo |

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -42,11 +42,11 @@ The progress of compatibility can also be tracked in issue [#7](https://github.c
 | isInstance | todo |
 | isInstantiable | todo |
 | isInterface | todo |
-| isInternal | todo |
+| isInternal | :heavy_check_mark: Yes |
 | isIterateable | todo |
 | isSubclassOf | todo |
 | isTrait | todo |
-| isUserDefined | todo |
+| isUserDefined | :heavy_check_mark: Yes |
 | newInstance | todo |
 | newInstanceArgs | todo |
 | newInstanceWithoutConstructor | todo |

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -41,7 +41,7 @@ The progress of compatibility can also be tracked in issue [#7](https://github.c
 | isFinal | :heavy_check_mark: Yes |
 | isInstance | todo |
 | isInstantiable | todo |
-| isInterface | todo |
+| isInterface | :heavy_check_mark: Yes |
 | isInternal | :heavy_check_mark: Yes |
 | isIterateable | todo |
 | isSubclassOf | todo |

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -30,7 +30,7 @@ The progress of compatibility can also be tracked in issue [#7](https://github.c
 | getStaticPropertyValue | :x: No - would require loading ([#14](https://github.com/Roave/BetterReflection/issues/14)) |
 | getTraitAliases | todo |
 | getTraitNames | todo |
-| getTraits | todo |
+| getTraits | :heavy_check_mark: Yes |
 | hasConstant | :heavy_check_mark: Yes |
 | hasMethod | :heavy_check_mark: Yes |
 | hasProperty | :heavy_check_mark: Yes |

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -10,7 +10,7 @@ The progress of compatibility can also be tracked in issue [#7](https://github.c
 | getConstants | :heavy_check_mark: Yes |
 | getConstructor | :heavy_check_mark: Yes |
 | getDefaultProperties | todo |
-| getDocComment | todo |
+| getDocComment | :heavy_check_mark: Yes |
 | getEndLine | :heavy_check_mark: Yes |
 | getExtension | :x: No - extensions are not supported ([#15](https://github.com/Roave/BetterReflection/issues/15)) |
 | getFileName | :heavy_check_mark: Yes |

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -31,9 +31,9 @@ The progress of compatibility can also be tracked in issue [#7](https://github.c
 | getTraitAliases | todo |
 | getTraitNames | todo |
 | getTraits | todo |
-| hasConstant | todo |
-| hasMethod | todo |
-| hasProperty | todo |
+| hasConstant | :heavy_check_mark: Yes |
+| hasMethod | :heavy_check_mark: Yes |
+| hasProperty | :heavy_check_mark: Yes |
 | implementsInterface | todo |
 | inNamespace | :heavy_check_mark: Yes |
 | isAbstract | todo |

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -18,7 +18,7 @@ The progress of compatibility can also be tracked in issue [#7](https://github.c
 | getInterfaces | todo |
 | getMethod | :heavy_check_mark: Yes |
 | getMethods | :heavy_check_mark: Yes |
-| getModifiers | todo |
+| getModifiers | :heavy_check_mark: Yes |
 | getName | :heavy_check_mark: Yes |
 | getNamespaceName | :heavy_check_mark: Yes |
 | getParentClass | :heavy_check_mark: Yes |

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -11,7 +11,7 @@ The progress of compatibility can also be tracked in issue [#7](https://github.c
 | getConstructor | :heavy_check_mark: Yes |
 | getDefaultProperties | todo |
 | getDocComment | todo |
-| getEndLine | todo |
+| getEndLine | :heavy_check_mark: Yes |
 | getExtension | :x: No - extensions are not supported ([#15](https://github.com/Roave/BetterReflection/issues/15)) |
 | getFileName | :heavy_check_mark: Yes |
 | getInterfaceNames | todo |
@@ -25,7 +25,7 @@ The progress of compatibility can also be tracked in issue [#7](https://github.c
 | getProperties | :heavy_check_mark: Yes |
 | getProperty | :heavy_check_mark: Yes |
 | getShortName | :heavy_check_mark: Yes |
-| getStartLine | todo |
+| getStartLine | :heavy_check_mark: Yes |
 | getStaticProperties | :x: No - would require loading ([#14](https://github.com/Roave/BetterReflection/issues/14)) |
 | getStaticPropertyValue | :x: No - would require loading ([#14](https://github.com/Roave/BetterReflection/issues/14)) |
 | getTraitAliases | todo |

--- a/src/Reflection/Exception/NoParent.php
+++ b/src/Reflection/Exception/NoParent.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace BetterReflection\Reflection\Exception;
+
+class NoParent extends \LogicException
+{
+}

--- a/src/Reflection/Exception/NotAClassReflection.php
+++ b/src/Reflection/Exception/NotAClassReflection.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace BetterReflection\Reflection\Exception;
+
+use BetterReflection\Reflection\ReflectionClass;
+
+class NotAClassReflection extends \UnexpectedValueException
+{
+    /**
+     * @param ReflectionClass $class
+     *
+     * @return self
+     */
+    public static function fromReflectionClass(ReflectionClass $class)
+    {
+        $type = 'interface';
+
+        if ($class->isTrait()) {
+            $type = 'trait';
+        }
+
+        return new self(sprintf('Provided node "%s" is not class, but "%s"', $class->getName(), $type));
+    }
+}

--- a/src/Reflection/Exception/NotAString.php
+++ b/src/Reflection/Exception/NotAString.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace BetterReflection\Reflection\Exception;
+
+class NotAString extends \InvalidArgumentException
+{
+    /**
+     * @param mixed $nonString
+     *
+     * @return self
+     */
+    public static function fromNonString($nonString)
+    {
+        return new self(sprintf(
+            'Provided "%s" is not a string',
+            is_object($nonString) ? get_class($nonString) : gettype($nonString)
+        ));
+    }
+}

--- a/src/Reflection/Exception/NotAnInterfaceReflection.php
+++ b/src/Reflection/Exception/NotAnInterfaceReflection.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace BetterReflection\Reflection\Exception;
+
+use BetterReflection\Reflection\ReflectionClass;
+
+class NotAnInterfaceReflection extends \UnexpectedValueException
+{
+    /**
+     * @param ReflectionClass $class
+     *
+     * @return self
+     */
+    public static function fromReflectionClass(ReflectionClass $class)
+    {
+        $type = 'class';
+
+        if ($class->isTrait()) {
+            $type = 'trait';
+        }
+
+        return new self(sprintf('Provided node "%s" is not interface, but "%s"', $class->getName(), $type));
+    }
+}

--- a/src/Reflection/Exception/NotAnObject.php
+++ b/src/Reflection/Exception/NotAnObject.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace BetterReflection\Reflection\Exception;
+
+class NotAnObject extends \InvalidArgumentException
+{
+    /**
+     * @param mixed $nonObject
+     *
+     * @return self
+     */
+    public static function fromNonObject($nonObject)
+    {
+        return new self(sprintf('Provided "%s" is not an object', gettype($nonObject)));
+    }
+}

--- a/src/Reflection/ReflectionClass.php
+++ b/src/Reflection/ReflectionClass.php
@@ -205,6 +205,22 @@ class ReflectionClass implements Reflection
     }
 
     /**
+     * Does the class have the specified method method?
+     *
+     * @param $methodName
+     * @return bool
+     */
+    public function hasMethod($methodName)
+    {
+        try {
+            $this->getMethod($methodName);
+            return true;
+        } catch (\OutOfBoundsException $exception) {
+            return false;
+        }
+    }
+
+    /**
      * Get an array of the defined constants in this class.
      *
      * @return mixed[]
@@ -224,11 +240,22 @@ class ReflectionClass implements Reflection
      */
     public function getConstant($name)
     {
-        if (!isset($this->constants[$name])) {
+        if (!$this->hasConstant($name)) {
             return null;
         }
 
         return $this->constants[$name];
+    }
+
+    /**
+     * Does this class have the specified constant?
+     *
+     * @param $name
+     * @return bool
+     */
+    public function hasConstant($name)
+    {
+        return isset($this->constants[$name]);
     }
 
     /**
@@ -261,11 +288,22 @@ class ReflectionClass implements Reflection
      */
     public function getProperty($name)
     {
-        if (!isset($this->properties[$name])) {
+        if (!$this->hasProperty($name)) {
             return null;
         }
 
         return $this->properties[$name];
+    }
+
+    /**
+     * Does this class have the specified property?
+     *
+     * @param $name
+     * @return bool
+     */
+    public function hasProperty($name)
+    {
+        return isset($this->properties[$name]);
     }
 
     /**

--- a/src/Reflection/ReflectionClass.php
+++ b/src/Reflection/ReflectionClass.php
@@ -425,4 +425,24 @@ class ReflectionClass implements Reflection
     {
         return !$this->isInternal();
     }
+
+    /**
+     * Is this class an abstract class
+     *
+     * @return bool
+     */
+    public function isAbstract()
+    {
+        return $this->node->isAbstract();
+    }
+
+    /**
+     * Is this class a final class
+     *
+     * @return bool
+     */
+    public function isFinal()
+    {
+        return $this->node->isFinal();
+    }
 }

--- a/src/Reflection/ReflectionClass.php
+++ b/src/Reflection/ReflectionClass.php
@@ -445,4 +445,17 @@ class ReflectionClass implements Reflection
     {
         return $this->node->isFinal();
     }
+
+    /**
+     * Get the core-reflection-compatible modifier values
+     *
+     * @return int
+     */
+    public function getModifiers()
+    {
+        $val = 0;
+        $val += $this->isAbstract() ? \ReflectionClass::IS_EXPLICIT_ABSTRACT : 0;
+        $val += $this->isFinal() ? \ReflectionClass::IS_FINAL : 0;
+        return $val;
+    }
 }

--- a/src/Reflection/ReflectionClass.php
+++ b/src/Reflection/ReflectionClass.php
@@ -332,4 +332,18 @@ class ReflectionClass implements Reflection
 
         return self::createFromName($fqsen);
     }
+
+    /**
+     * @return string
+     */
+    public function getDocComment()
+    {
+        if (!$this->node->hasAttribute('comments')) {
+            return '';
+        }
+
+        /* @var \PhpParser\Comment\Doc $comment */
+        $comment = $this->node->getAttribute('comments')[0];
+        return $comment->getReformattedText();
+    }
 }

--- a/src/Reflection/ReflectionClass.php
+++ b/src/Reflection/ReflectionClass.php
@@ -548,4 +548,25 @@ class ReflectionClass implements Reflection
 
         return self::createFromName($fqsen);
     }
+
+    /**
+     * Get the names of the traits used as an array of strings, if any are
+     * defined. If this class does not have any defined traits, this will
+     * return an empty array.
+     *
+     * You may optionally specify a source locator that will be used to locate
+     * the traits. If no source locator is given, a default will be used.
+     *
+     * @param SourceLocator|null $sourceLocator
+     * @return string[]
+     */
+    public function getTraitNames(SourceLocator $sourceLocator = null)
+    {
+        return array_map(
+            function (ReflectionClass $trait) {
+                return $trait->getName();
+            },
+            $this->getTraits($sourceLocator)
+        );
+    }
 }

--- a/src/Reflection/ReflectionClass.php
+++ b/src/Reflection/ReflectionClass.php
@@ -12,7 +12,9 @@ use BetterReflection\TypesFinder\FindTypeFromAst;
 use phpDocumentor\Reflection\Fqsen;
 use phpDocumentor\Reflection\Types\Object_;
 use PhpParser\Node\Stmt\Namespace_ as NamespaceNode;
+use PhpParser\Node\Stmt\ClassLike as ClassLikeNode;
 use PhpParser\Node\Stmt\Class_ as ClassNode;
+use PhpParser\Node\Stmt\Trait_ as TraitNode;
 use PhpParser\Node\Stmt\ClassConst as ConstNode;
 use PhpParser\Node\Stmt\Property as PropertyNode;
 
@@ -54,7 +56,7 @@ class ReflectionClass implements Reflection
     private $extendsClassType;
 
     /**
-     * @var ClassNode
+     * @var ClassLikeNode
      */
     private $node;
 
@@ -70,13 +72,13 @@ class ReflectionClass implements Reflection
     /**
      * Create from a Class Node.
      *
-     * @param ClassNode $node
+     * @param ClassLikeNode $node
      * @param LocatedSource $locatedSource
      * @param NamespaceNode|null $namespace optional - if omitted, we assume it is global namespaced class
      * @return ReflectionClass
      */
     public static function createFromNode(
-        ClassNode $node,
+        ClassLikeNode $node,
         LocatedSource $locatedSource,
         NamespaceNode $namespace = null
     ) {
@@ -90,7 +92,7 @@ class ReflectionClass implements Reflection
             $class->declaringNamespace = $namespace;
         }
 
-        if (null !== $node->extends) {
+        if ($node instanceof ClassNode && null !== $node->extends) {
             $objectType = (new FindTypeFromAst())->__invoke($node->extends, $locatedSource, $class->getNamespaceName());
             if (null !== $objectType && $objectType instanceof Object_) {
                 $class->extendsClassType = $objectType->getFqsen();
@@ -457,5 +459,15 @@ class ReflectionClass implements Reflection
         $val += $this->isAbstract() ? \ReflectionClass::IS_EXPLICIT_ABSTRACT : 0;
         $val += $this->isFinal() ? \ReflectionClass::IS_FINAL : 0;
         return $val;
+    }
+
+    /**
+     * Is this reflection a trait?
+     *
+     * @return bool
+     */
+    public function isTrait()
+    {
+        return $this->node instanceof TraitNode;
     }
 }

--- a/src/Reflection/ReflectionClass.php
+++ b/src/Reflection/ReflectionClass.php
@@ -212,7 +212,7 @@ class ReflectionClass implements Reflection
     /**
      * Does the class have the specified method method?
      *
-     * @param $methodName
+     * @param string $methodName
      * @return bool
      */
     public function hasMethod($methodName)
@@ -255,7 +255,7 @@ class ReflectionClass implements Reflection
     /**
      * Does this class have the specified constant?
      *
-     * @param $name
+     * @param string $name
      * @return bool
      */
     public function hasConstant($name)
@@ -303,7 +303,7 @@ class ReflectionClass implements Reflection
     /**
      * Does this class have the specified property?
      *
-     * @param $name
+     * @param string $name
      * @return bool
      */
     public function hasProperty($name)

--- a/src/Reflection/ReflectionClass.php
+++ b/src/Reflection/ReflectionClass.php
@@ -436,7 +436,7 @@ class ReflectionClass implements Reflection
      */
     public function isAbstract()
     {
-        return $this->node->isAbstract();
+        return $this->node instanceof ClassNode && $this->node->isAbstract();
     }
 
     /**
@@ -446,7 +446,7 @@ class ReflectionClass implements Reflection
      */
     public function isFinal()
     {
-        return $this->node->isFinal();
+        return $this->node instanceof ClassNode && $this->node->isFinal();
     }
 
     /**

--- a/src/Reflection/ReflectionClass.php
+++ b/src/Reflection/ReflectionClass.php
@@ -717,6 +717,25 @@ class ReflectionClass implements Reflection
     }
 
     /**
+     * Checks whether this class implements the given interface
+     *
+     * @link http://php.net/manual/en/reflectionclass.implementsinterface.php
+     *
+     * @param string        $interfaceName
+     * @param SourceLocator $sourceLocator
+     *
+     * @return bool
+     */
+    public function implementsInterface($interfaceName, SourceLocator $sourceLocator)
+    {
+        if (! is_string($interfaceName)) {
+            throw NotAString::fromNonString($interfaceName);
+        }
+
+        return in_array(ltrim($interfaceName, '\\'), $this->getInterfaceNames($sourceLocator), true);
+    }
+
+    /**
      * @param SourceLocator $sourceLocator
      *
      * @return ReflectionClass[] indexed by interface name

--- a/src/Reflection/ReflectionClass.php
+++ b/src/Reflection/ReflectionClass.php
@@ -53,6 +53,11 @@ class ReflectionClass implements Reflection
      */
     private $extendsClassType;
 
+    /**
+     * @var ClassNode
+     */
+    private $node;
+
     private function __construct()
     {
     }
@@ -76,6 +81,7 @@ class ReflectionClass implements Reflection
         NamespaceNode $namespace = null
     ) {
         $class = new self();
+        $class->node = $node;
 
         $class->locatedSource = $locatedSource;
         $class->name = $node->name;
@@ -276,6 +282,26 @@ class ReflectionClass implements Reflection
     public function getLocatedSource()
     {
         return $this->locatedSource;
+    }
+
+    /**
+     * Get the line number that this class starts on
+     *
+     * @return int
+     */
+    public function getStartLine()
+    {
+        return (int)$this->node->getAttribute('startLine', -1);
+    }
+
+    /**
+     * Get the line number that this class ends on
+     *
+     * @return int
+     */
+    public function getEndLine()
+    {
+        return (int)$this->node->getAttribute('endLine', -1);
     }
 
     /**

--- a/src/Reflection/ReflectionClass.php
+++ b/src/Reflection/ReflectionClass.php
@@ -397,4 +397,32 @@ class ReflectionClass implements Reflection
         $comment = $this->node->getAttribute('comments')[0];
         return $comment->getReformattedText();
     }
+
+
+
+    /**
+     * Is this an internal class?
+     *
+     * Note - we cannot reflect on internal classes (as there is no PHP source
+     * code we can access. This means, at present, we can only EVER return false
+     * from this function.
+     *
+     * @see https://github.com/Roave/BetterReflection/issues/38
+     * @return bool
+     */
+    public function isInternal()
+    {
+        return false;
+    }
+
+    /**
+     * Is this a user-defined function (will always return the opposite of
+     * whatever isInternal returns).
+     *
+     * @return bool
+     */
+    public function isUserDefined()
+    {
+        return !$this->isInternal();
+    }
 }

--- a/src/Reflection/ReflectionClass.php
+++ b/src/Reflection/ReflectionClass.php
@@ -4,6 +4,7 @@ namespace BetterReflection\Reflection;
 
 use BetterReflection\NodeCompiler\CompileNodeToValue;
 use BetterReflection\Reflection\Exception\NoParent;
+use BetterReflection\Reflection\Exception\NotAnObject;
 use BetterReflection\Reflector\ClassReflector;
 use BetterReflection\SourceLocator\AutoloadSourceLocator;
 use BetterReflection\SourceLocator\LocatedSource;
@@ -660,6 +661,30 @@ class ReflectionClass implements Reflection
             },
             $this->getInterfaces($sourceLocator)
         ));
+    }
+
+    /**
+     * Checks whether the given object is an instance
+     *
+     * @link http://php.net/manual/en/reflectionclass.isinstance.php
+     *
+     * @param object $object
+     *
+     * @return bool
+     *
+     * @throws NotAnObject
+     */
+    public function isInstance($object)
+    {
+        if (! is_object($object)) {
+            throw NotAnObject::fromNonObject($object);
+        }
+
+        $className = $this->getName();
+
+        // note: since $object was loaded, we can safely assume that $className is available in the current
+        //       php script execution context
+        return $object instanceof $className;
     }
 
     /**

--- a/src/Reflection/ReflectionClass.php
+++ b/src/Reflection/ReflectionClass.php
@@ -307,6 +307,19 @@ class ReflectionClass implements Reflection
     }
 
     /**
+     * Return an array with default properties (properties that were defined at
+     * compile-time rather than at run time)
+     *
+     * @return ReflectionProperty[]
+     */
+    public function getDefaultProperties()
+    {
+        return array_filter($this->getProperties(), function (ReflectionProperty $property) {
+            return $property->isDefault();
+        });
+    }
+
+    /**
      * @return string
      */
     public function getFileName()

--- a/src/Reflection/ReflectionClass.php
+++ b/src/Reflection/ReflectionClass.php
@@ -15,6 +15,7 @@ use PhpParser\Node\Stmt\Namespace_ as NamespaceNode;
 use PhpParser\Node\Stmt\ClassLike as ClassLikeNode;
 use PhpParser\Node\Stmt\Class_ as ClassNode;
 use PhpParser\Node\Stmt\Trait_ as TraitNode;
+use PhpParser\Node\Stmt\Interface_ as InterfaceNode;
 use PhpParser\Node\Stmt\ClassConst as ConstNode;
 use PhpParser\Node\Stmt\Property as PropertyNode;
 
@@ -469,5 +470,15 @@ class ReflectionClass implements Reflection
     public function isTrait()
     {
         return $this->node instanceof TraitNode;
+    }
+
+    /**
+     * Is this reflection an interface?
+     *
+     * @return bool
+     */
+    public function isInterface()
+    {
+        return $this->node instanceof InterfaceNode;
     }
 }

--- a/src/Reflection/ReflectionClass.php
+++ b/src/Reflection/ReflectionClass.php
@@ -571,7 +571,7 @@ class ReflectionClass implements Reflection
 
     /**
      * Return a list of the aliases used when importing traits for this class.
-     * The returned array is in key/value pair in this format:
+     * The returned array is in key/value pair in this format:.
      *
      *   'aliasedMethodName' => 'ActualClass::actualMethod'
      *
@@ -624,7 +624,7 @@ class ReflectionClass implements Reflection
     }
 
     /**
-     * Gets the interfaces
+     * Gets the interfaces.
      *
      * @link http://php.net/manual/en/reflectionclass.getinterfaces.php
      *
@@ -645,7 +645,7 @@ class ReflectionClass implements Reflection
     }
 
     /**
-     * Gets the interface names
+     * Gets the interface names.
      *
      * @link http://php.net/manual/en/reflectionclass.getinterfacenames.php
      *
@@ -665,7 +665,7 @@ class ReflectionClass implements Reflection
     }
 
     /**
-     * Checks whether the given object is an instance
+     * Checks whether the given object is an instance.
      *
      * @link http://php.net/manual/en/reflectionclass.isinstance.php
      *
@@ -689,7 +689,7 @@ class ReflectionClass implements Reflection
     }
 
     /**
-     * Checks whether the given class string is a subclass of this class
+     * Checks whether the given class string is a subclass of this class.
      *
      * @link http://php.net/manual/en/reflectionclass.isinstance.php
      *
@@ -717,7 +717,7 @@ class ReflectionClass implements Reflection
     }
 
     /**
-     * Checks whether this class implements the given interface
+     * Checks whether this class implements the given interface.
      *
      * @link http://php.net/manual/en/reflectionclass.implementsinterface.php
      *

--- a/src/Reflector/Generic.php
+++ b/src/Reflector/Generic.php
@@ -146,7 +146,7 @@ class Generic
                     $reflections,
                     $this->reflectFromNamespace($node, $identifier, $locatedSource)
                 );
-            } elseif ($node instanceof Node\Stmt\Class_) {
+            } elseif ($node instanceof Node\Stmt\ClassLike) {
                 $reflection = $this->reflectNode($node, $locatedSource, null);
                 if ($identifier->getType()->isMatchingReflector($reflection)) {
                     $reflections[] = $reflection;

--- a/src/Reflector/Generic.php
+++ b/src/Reflector/Generic.php
@@ -85,7 +85,7 @@ class Generic
      */
     private function reflectNode(Node $node, LocatedSource $locatedSource, Node\Stmt\Namespace_ $namespace = null)
     {
-        if ($node instanceof Node\Stmt\Class_) {
+        if ($node instanceof Node\Stmt\ClassLike) {
             return ReflectionClass::createFromNode(
                 $node,
                 $locatedSource,

--- a/src/Reflector/Generic.php
+++ b/src/Reflector/Generic.php
@@ -87,6 +87,7 @@ class Generic
     {
         if ($node instanceof Node\Stmt\ClassLike) {
             return ReflectionClass::createFromNode(
+                new ClassReflector($this->sourceLocator),
                 $node,
                 $locatedSource,
                 $namespace
@@ -94,11 +95,7 @@ class Generic
         }
 
         if ($node instanceof Node\Stmt\Function_) {
-            return ReflectionFunction::createFromNode(
-                $node,
-                $locatedSource,
-                $namespace
-            );
+            return ReflectionFunction::createFromNode($node, $locatedSource, $namespace);
         }
 
         return null;

--- a/test/unit/Fixture/ClassWithInterfaces.php
+++ b/test/unit/Fixture/ClassWithInterfaces.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace BetterReflectionTest\ClassWithInterfaces {
+    use BetterReflectionTest\ClassWithInterfacesOther\B as ImportedB;
+    use BetterReflectionTest\ClassWithInterfacesOther;
+
+    interface A {}
+    interface B {}
+
+    class ExampleClass implements A, ImportedB, C, ClassWithInterfacesOther\D, \E
+    {
+    }
+
+    interface C {}
+
+    class SubExampleClass extends ExampleClass {}
+    class SubSubExampleClass extends SubExampleClass implements ImportedB, B {}
+}
+
+namespace BetterReflectionTest\ClassWithInterfacesOther {
+    interface B
+    {
+    }
+
+    interface D
+    {
+    }
+}
+
+namespace {
+    interface E
+    {
+    }
+}

--- a/test/unit/Fixture/ClassWithInterfaces.php
+++ b/test/unit/Fixture/ClassWithInterfaces.php
@@ -3,6 +3,7 @@
 namespace BetterReflectionTest\ClassWithInterfaces {
     use BetterReflectionTest\ClassWithInterfacesOther\B as ImportedB;
     use BetterReflectionTest\ClassWithInterfacesOther;
+    use BetterReflectionTest\ClassWithInterfacesExtendingInterfaces;
 
     interface A {}
     interface B {}
@@ -15,6 +16,7 @@ namespace BetterReflectionTest\ClassWithInterfaces {
 
     class SubExampleClass extends ExampleClass {}
     class SubSubExampleClass extends SubExampleClass implements ImportedB, B {}
+    class ExampleImplementingCompositeInterface implements ClassWithInterfacesExtendingInterfaces\D {}
 }
 
 namespace BetterReflectionTest\ClassWithInterfacesOther {
@@ -23,6 +25,24 @@ namespace BetterReflectionTest\ClassWithInterfacesOther {
     }
 
     interface D
+    {
+    }
+}
+
+namespace BetterReflectionTest\ClassWithInterfacesExtendingInterfaces {
+    interface A
+    {
+    }
+
+    interface B
+    {
+    }
+
+    interface C extends B
+    {
+    }
+
+    interface D extends C, A
     {
     }
 }

--- a/test/unit/Fixture/ClassesImplementingIterators.php
+++ b/test/unit/Fixture/ClassesImplementingIterators.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace
+{
+    // note: this will crash if loaded in PHP, as the Traversable interface is already in core
+    interface Traversable {}
+}
+
+namespace BetterReflectionTest\ClassesImplementingIterators
+{
+    class TraversableImplementation implements \Traversable
+    {
+    }
+
+    class NonTraversableImplementation
+    {
+    }
+
+    abstract class AbstractTraversableImplementation implements \Traversable
+    {
+    }
+
+    interface TraversableExtension extends \Traversable
+    {
+    }
+}

--- a/test/unit/Fixture/ClassesWithCloneMethod.php
+++ b/test/unit/Fixture/ClassesWithCloneMethod.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace BetterReflectionTest\ClassesWithCloneMethod {
+    class WithPublicClone
+    {
+        public function __clone() {}
+    }
+
+    class WithProtectedClone
+    {
+        protected function __clone() {}
+    }
+
+    class WithPrivateClone
+    {
+        private function __clone() {}
+    }
+}

--- a/test/unit/Fixture/ExampleClass.php
+++ b/test/unit/Fixture/ExampleClass.php
@@ -46,6 +46,10 @@ namespace BetterReflectionTest\Fixture {
     final class FinalClass
     {
     }
+
+    trait ExampleTrait
+    {
+    }
 }
 
 namespace BetterReflectionTest\FixtureOther {

--- a/test/unit/Fixture/ExampleClass.php
+++ b/test/unit/Fixture/ExampleClass.php
@@ -1,6 +1,9 @@
 <?php
 
 namespace BetterReflectionTest\Fixture {
+    /**
+     * Some comments here
+     */
     class ExampleClass
     {
         const MY_CONST_1 = 123;

--- a/test/unit/Fixture/ExampleClass.php
+++ b/test/unit/Fixture/ExampleClass.php
@@ -31,6 +31,10 @@ namespace BetterReflectionTest\Fixture {
         {
         }
     }
+
+    class ClassWithParent extends ExampleClass
+    {
+    }
 }
 
 namespace BetterReflectionTest\FixtureOther {

--- a/test/unit/Fixture/ExampleClass.php
+++ b/test/unit/Fixture/ExampleClass.php
@@ -50,6 +50,10 @@ namespace BetterReflectionTest\Fixture {
     trait ExampleTrait
     {
     }
+
+    interface ExampleInterface
+    {
+    }
 }
 
 namespace BetterReflectionTest\FixtureOther {

--- a/test/unit/Fixture/ExampleClass.php
+++ b/test/unit/Fixture/ExampleClass.php
@@ -38,6 +38,14 @@ namespace BetterReflectionTest\Fixture {
     class ClassWithParent extends ExampleClass
     {
     }
+
+    abstract class AbstractClass
+    {
+    }
+
+    final class FinalClass
+    {
+    }
 }
 
 namespace BetterReflectionTest\FixtureOther {

--- a/test/unit/Fixture/InvalidInheritances.php
+++ b/test/unit/Fixture/InvalidInheritances.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace BetterReflectionTest\Fixture\InvalidInheritances
+{
+    interface AInterface {}
+    class AClass {}
+    trait ATrait {}
+
+    interface InterfaceExtendingClass extends AClass {}
+    interface InterfaceExtendingTrait extends ATrait {}
+    class ClassExtendingInterface extends AInterface {}
+    class ClassExtendingTrait extends ATrait {}
+}

--- a/test/unit/Fixture/TraitFixture.php
+++ b/test/unit/Fixture/TraitFixture.php
@@ -1,0 +1,20 @@
+<?php
+
+trait TraitFixtureTraitA
+{
+    public function foo() {}
+}
+
+trait TraitFixtureTraitB
+{
+    public function foo() {}
+}
+
+class TraitFixtureA
+{
+    use TraitFixtureTraitA;
+}
+
+class TraitFixtureB
+{
+}

--- a/test/unit/Fixture/TraitFixture.php
+++ b/test/unit/Fixture/TraitFixture.php
@@ -28,9 +28,6 @@ class TraitFixtureC
         b as b_renamed;
         c as private;
     }
-    use TraitFixtureTraitD1 {
-        foo as blah;
-    }
 }
 
 // Conflict resolution

--- a/test/unit/Fixture/TraitFixture.php
+++ b/test/unit/Fixture/TraitFixture.php
@@ -1,20 +1,50 @@
 <?php
 
+// Simple trait usage
 trait TraitFixtureTraitA
 {
     public function foo() {}
 }
-
-trait TraitFixtureTraitB
-{
-    public function foo() {}
-}
-
 class TraitFixtureA
 {
     use TraitFixtureTraitA;
 }
 
+// No trait usage
 class TraitFixtureB
 {
+}
+// Aliasing 1
+trait TraitFixtureTraitC
+{
+    public function a() {}
+    public function b() {}
+    public function c() {}
+}
+class TraitFixtureC
+{
+    use TraitFixtureTraitC {
+        a as protected a_protected;
+        b as b_renamed;
+        c as private;
+    }
+    use TraitFixtureTraitD1 {
+        foo as blah;
+    }
+}
+
+// Conflict resolution
+trait TraitFixtureTraitD1
+{
+    public function foo() {}
+}
+trait TraitFixtureTraitD2
+{
+    public function foo() {}
+}
+class TraitFixtureD
+{
+    use TraitFixtureTraitD1, TraitFixtureTraitD2 {
+        TraitFixtureTraitD1::foo insteadof TraitFixtureTraitD2;
+    }
 }

--- a/test/unit/Reflection/Exception/NotAClassReflectionTest.php
+++ b/test/unit/Reflection/Exception/NotAClassReflectionTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace BetterReflectionTest\Reflection\Exception;
+
+use BetterReflection\Reflection\Exception\NotAClassReflection;
+use BetterReflection\Reflector\ClassReflector;
+use BetterReflection\SourceLocator\SingleFileSourceLocator;
+use BetterReflectionTest\ClassWithInterfaces;
+use BetterReflectionTest\ClassWithInterfacesOther;
+use BetterReflectionTest\Fixture;
+use PHPUnit_Framework_TestCase;
+
+/**
+ * @covers \BetterReflection\Reflection\Exception\NotAClassReflection
+ */
+class NotAClassReflectionTest extends PHPUnit_Framework_TestCase
+{
+    public function testFromInterface()
+    {
+        $sourceLocator = new SingleFileSourceLocator(__DIR__ . '/../../Fixture/ExampleClass.php');
+        $reflector     = new ClassReflector($sourceLocator);
+
+        $exception = NotAClassReflection::fromReflectionClass($reflector->reflect(Fixture\ExampleInterface::class));
+
+        $this->assertInstanceOf(NotAClassReflection::class, $exception);
+        $this->assertSame(
+            'Provided node "' . Fixture\ExampleInterface::class . '" is not class, but "interface"',
+            $exception->getMessage()
+        );
+    }
+
+    public function testFromTrait()
+    {
+        $sourceLocator = new SingleFileSourceLocator(__DIR__ . '/../../Fixture/ExampleClass.php');
+        $reflector     = new ClassReflector($sourceLocator);
+
+        $exception = NotAClassReflection::fromReflectionClass($reflector->reflect(Fixture\ExampleTrait::class));
+
+        $this->assertInstanceOf(NotAClassReflection::class, $exception);
+        $this->assertSame(
+            'Provided node "' . Fixture\ExampleTrait::class . '" is not class, but "trait"',
+            $exception->getMessage()
+        );
+    }
+}

--- a/test/unit/Reflection/Exception/NotAStringTest.php
+++ b/test/unit/Reflection/Exception/NotAStringTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace BetterReflectionTest\Reflection\Exception;
+
+use BetterReflection\Reflection\Exception\NotAString;
+use BetterReflectionTest\ClassWithInterfaces;
+use BetterReflectionTest\ClassWithInterfacesOther;
+use PHPUnit_Framework_TestCase;
+
+/**
+ * @covers \BetterReflection\Reflection\Exception\NotAString
+ */
+class NotAStringTest extends PHPUnit_Framework_TestCase
+{
+    public function testFromNonStringWithInteger()
+    {
+        $exception = NotAString::fromNonString(123);
+
+        $this->assertInstanceOf(NotAString::class, $exception);
+        $this->assertSame('Provided "integer" is not a string', $exception->getMessage());
+    }
+
+    public function testFromNonStringWithObject()
+    {
+        $exception = NotAString::fromNonString($this);
+
+        $this->assertInstanceOf(NotAString::class, $exception);
+        $this->assertSame(sprintf('Provided "%s" is not a string', __CLASS__), $exception->getMessage());
+    }
+}

--- a/test/unit/Reflection/Exception/NotAStringTest.php
+++ b/test/unit/Reflection/Exception/NotAStringTest.php
@@ -3,8 +3,6 @@
 namespace BetterReflectionTest\Reflection\Exception;
 
 use BetterReflection\Reflection\Exception\NotAString;
-use BetterReflectionTest\ClassWithInterfaces;
-use BetterReflectionTest\ClassWithInterfacesOther;
 use PHPUnit_Framework_TestCase;
 
 /**

--- a/test/unit/Reflection/Exception/NotAnInterfaceReflectionTest.php
+++ b/test/unit/Reflection/Exception/NotAnInterfaceReflectionTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace BetterReflectionTest\Reflection\Exception;
+
+use BetterReflection\Reflection\Exception\NotAnInterfaceReflection;
+use BetterReflection\Reflector\ClassReflector;
+use BetterReflection\SourceLocator\SingleFileSourceLocator;
+use BetterReflectionTest\ClassWithInterfaces;
+use BetterReflectionTest\ClassWithInterfacesOther;
+use BetterReflectionTest\Fixture;
+use PHPUnit_Framework_TestCase;
+
+/**
+ * @covers \BetterReflection\Reflection\Exception\NotAnInterfaceReflection
+ */
+class NotAnInterfaceReflectionTest extends PHPUnit_Framework_TestCase
+{
+    public function testFromClass()
+    {
+        $sourceLocator = new SingleFileSourceLocator(__DIR__ . '/../../Fixture/ExampleClass.php');
+        $reflector     = new ClassReflector($sourceLocator);
+
+        $exception = NotAnInterfaceReflection::fromReflectionClass($reflector->reflect(Fixture\ExampleClass::class));
+
+        $this->assertInstanceOf(NotAnInterfaceReflection::class, $exception);
+        $this->assertSame(
+            'Provided node "' . Fixture\ExampleClass::class . '" is not interface, but "class"',
+            $exception->getMessage()
+        );
+    }
+
+    public function testFromTrait()
+    {
+        $sourceLocator = new SingleFileSourceLocator(__DIR__ . '/../../Fixture/ExampleClass.php');
+        $reflector     = new ClassReflector($sourceLocator);
+
+        $exception = NotAnInterfaceReflection::fromReflectionClass($reflector->reflect(Fixture\ExampleTrait::class));
+
+        $this->assertInstanceOf(NotAnInterfaceReflection::class, $exception);
+        $this->assertSame(
+            'Provided node "' . Fixture\ExampleTrait::class . '" is not interface, but "trait"',
+            $exception->getMessage()
+        );
+    }
+}

--- a/test/unit/Reflection/Exception/NotAnObjectTest.php
+++ b/test/unit/Reflection/Exception/NotAnObjectTest.php
@@ -3,8 +3,6 @@
 namespace BetterReflectionTest\Reflection\Exception;
 
 use BetterReflection\Reflection\Exception\NotAnObject;
-use BetterReflectionTest\ClassWithInterfaces;
-use BetterReflectionTest\ClassWithInterfacesOther;
 use PHPUnit_Framework_TestCase;
 
 /**

--- a/test/unit/Reflection/Exception/NotAnObjectTest.php
+++ b/test/unit/Reflection/Exception/NotAnObjectTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace BetterReflectionTest\Reflection\Exception;
+
+use BetterReflection\Reflection\Exception\NotAnObject;
+use BetterReflectionTest\ClassWithInterfaces;
+use BetterReflectionTest\ClassWithInterfacesOther;
+use PHPUnit_Framework_TestCase;
+
+/**
+ * @covers \BetterReflection\Reflection\Exception\NotAnObject
+ */
+class NotAnObjectTest extends PHPUnit_Framework_TestCase
+{
+    public function testFromNonObject()
+    {
+        $exception = NotAnObject::fromNonObject(123);
+
+        $this->assertInstanceOf(NotAnObject::class, $exception);
+        $this->assertSame('Provided "integer" is not an object', $exception->getMessage());
+    }
+}

--- a/test/unit/Reflection/ReflectionClassTest.php
+++ b/test/unit/Reflection/ReflectionClassTest.php
@@ -341,4 +341,28 @@ class ReflectionClassTest extends \PHPUnit_Framework_TestCase
         $classInfo = $reflector->reflect('\BetterReflectionTest\Fixture\ExampleClass');
         $this->assertFalse($classInfo->isInterface());
     }
+
+    public function testGetTraits()
+    {
+        $sourceLocator = new SingleFileSourceLocator(__DIR__ . '/../Fixture/TraitFixture.php');
+        $reflector = new ClassReflector($sourceLocator);
+
+        $classInfo = $reflector->reflect('TraitFixtureA');
+        $traits = $classInfo->getTraits($sourceLocator);
+
+        $this->assertCount(1, $traits);
+        $this->assertInstanceOf(ReflectionClass::class, $traits[0]);
+        $this->assertTrue($traits[0]->isTrait());
+    }
+
+    public function testGetTraitsReturnsEmptyArrayWhenNoTraitsUsed()
+    {
+        $sourceLocator = new SingleFileSourceLocator(__DIR__ . '/../Fixture/TraitFixture.php');
+        $reflector = new ClassReflector($sourceLocator);
+
+        $classInfo = $reflector->reflect('TraitFixtureB');
+        $traits = $classInfo->getTraits($sourceLocator);
+
+        $this->assertCount(0, $traits);
+    }
 }

--- a/test/unit/Reflection/ReflectionClassTest.php
+++ b/test/unit/Reflection/ReflectionClassTest.php
@@ -3,6 +3,7 @@
 namespace BetterReflectionTest\Reflection;
 
 use BetterReflection\Reflection\Exception\NotAnObject;
+use BetterReflection\Reflection\Exception\NotAString;
 use BetterReflection\Reflection\ReflectionClass;
 use BetterReflection\Reflection\ReflectionMethod;
 use BetterReflection\Reflection\ReflectionProperty;
@@ -538,5 +539,42 @@ class ReflectionClassTest extends \PHPUnit_Framework_TestCase
         $this->setExpectedException(NotAnObject::class);
 
         $class->isInstance('foo');
+    }
+
+    public function testIsSubclassOf()
+    {
+        $sourceLocator   = new SingleFileSourceLocator(__DIR__ . '/../Fixture/ClassWithInterfaces.php');
+        $subExampleClass = (new ClassReflector($sourceLocator))
+            ->reflect(ClassWithInterfaces\SubExampleClass::class);
+
+        $this->assertFalse($subExampleClass->isSubclassOf(
+            ClassWithInterfaces\SubExampleClass::class,
+            $sourceLocator,
+            'Not a subclass of itself'
+        ));
+        $this->assertFalse($subExampleClass->isSubclassOf(
+            ClassWithInterfaces\SubSubExampleClass::class,
+            $sourceLocator,
+            'Not a subclass of a child class'
+        ));
+        $this->assertFalse($subExampleClass->isSubclassOf(
+            \stdClass::class,
+            $sourceLocator,
+            'Not a subclass of a unrelated'
+        ));
+        $this->assertTrue($subExampleClass->isSubclassOf(
+            ClassWithInterfaces\ExampleClass::class,
+            $sourceLocator,
+            'A subclass of a parent class'
+        ));
+        $this->assertTrue($subExampleClass->isSubclassOf(
+            '\\' . ClassWithInterfaces\ExampleClass::class,
+            $sourceLocator,
+            'A subclass of a parent class (considering eventual backslashes upfront)'
+        ));
+
+        $this->setExpectedException(NotAString::class);
+
+        $subExampleClass->isSubclassOf($this, $sourceLocator);
     }
 }

--- a/test/unit/Reflection/ReflectionClassTest.php
+++ b/test/unit/Reflection/ReflectionClassTest.php
@@ -547,34 +547,48 @@ class ReflectionClassTest extends \PHPUnit_Framework_TestCase
         $subExampleClass = (new ClassReflector($sourceLocator))
             ->reflect(ClassWithInterfaces\SubExampleClass::class);
 
-        $this->assertFalse($subExampleClass->isSubclassOf(
-            ClassWithInterfaces\SubExampleClass::class,
-            $sourceLocator,
+        $this->assertFalse(
+            $subExampleClass->isSubclassOf(ClassWithInterfaces\SubExampleClass::class, $sourceLocator),
             'Not a subclass of itself'
-        ));
-        $this->assertFalse($subExampleClass->isSubclassOf(
-            ClassWithInterfaces\SubSubExampleClass::class,
-            $sourceLocator,
+        );
+        $this->assertFalse(
+            $subExampleClass->isSubclassOf(ClassWithInterfaces\SubSubExampleClass::class, $sourceLocator),
             'Not a subclass of a child class'
-        ));
-        $this->assertFalse($subExampleClass->isSubclassOf(
-            \stdClass::class,
-            $sourceLocator,
+        );
+        $this->assertFalse(
+            $subExampleClass->isSubclassOf(\stdClass::class, $sourceLocator),
             'Not a subclass of a unrelated'
-        ));
-        $this->assertTrue($subExampleClass->isSubclassOf(
-            ClassWithInterfaces\ExampleClass::class,
-            $sourceLocator,
+        );
+        $this->assertTrue(
+            $subExampleClass->isSubclassOf(ClassWithInterfaces\ExampleClass::class, $sourceLocator),
             'A subclass of a parent class'
-        ));
-        $this->assertTrue($subExampleClass->isSubclassOf(
-            '\\' . ClassWithInterfaces\ExampleClass::class,
-            $sourceLocator,
+        );
+        $this->assertTrue(
+            $subExampleClass->isSubclassOf('\\' . ClassWithInterfaces\ExampleClass::class, $sourceLocator),
             'A subclass of a parent class (considering eventual backslashes upfront)'
-        ));
+        );
 
         $this->setExpectedException(NotAString::class);
 
         $subExampleClass->isSubclassOf($this, $sourceLocator);
+    }
+
+    public function testImplementsInterface()
+    {
+        $sourceLocator   = new SingleFileSourceLocator(__DIR__ . '/../Fixture/ClassWithInterfaces.php');
+        $subExampleClass = (new ClassReflector($sourceLocator))
+            ->reflect(ClassWithInterfaces\SubExampleClass::class);
+
+        $this->assertTrue($subExampleClass->implementsInterface(ClassWithInterfaces\A::class, $sourceLocator));
+        $this->assertFalse($subExampleClass->implementsInterface(ClassWithInterfaces\B::class, $sourceLocator));
+        $this->assertTrue($subExampleClass->implementsInterface(ClassWithInterfacesOther\B::class, $sourceLocator));
+        $this->assertTrue($subExampleClass->implementsInterface(ClassWithInterfaces\C::class, $sourceLocator));
+        $this->assertTrue($subExampleClass->implementsInterface(ClassWithInterfacesOther\D::class, $sourceLocator));
+        $this->assertTrue($subExampleClass->implementsInterface(\E::class, $sourceLocator));
+        $this->assertFalse($subExampleClass->implementsInterface(\Iterator::class, $sourceLocator));
+
+        $this->setExpectedException(NotAString::class);
+
+        $subExampleClass->implementsInterface($this, $sourceLocator);
     }
 }

--- a/test/unit/Reflection/ReflectionClassTest.php
+++ b/test/unit/Reflection/ReflectionClassTest.php
@@ -2,6 +2,7 @@
 
 namespace BetterReflectionTest\Reflection;
 
+use BetterReflection\Reflection\Exception\NotAnObject;
 use BetterReflection\Reflection\ReflectionClass;
 use BetterReflection\Reflection\ReflectionMethod;
 use BetterReflection\Reflection\ReflectionProperty;
@@ -12,6 +13,7 @@ use BetterReflection\SourceLocator\SourceLocator;
 use BetterReflection\SourceLocator\StringSourceLocator;
 use BetterReflectionTest\ClassWithInterfaces;
 use BetterReflectionTest\ClassWithInterfacesOther;
+use BetterReflectionTest\Fixture\ClassForHinting;
 
 /**
  * @covers \BetterReflection\Reflection\ReflectionClass
@@ -521,5 +523,20 @@ class ReflectionClassTest extends \PHPUnit_Framework_TestCase
             $this->assertInstanceOf(ReflectionClass::class, $interfaces[$expectedInterface]);
             $this->assertSame($expectedInterface, $interfaces[$expectedInterface]->getName());
         }
+    }
+
+    public function testIsInstance()
+    {
+        // note: ClassForHinting is safe to type-check against, as it will actually be loaded at runtime
+        $class = (new ClassReflector(new SingleFileSourceLocator(__DIR__ . '/../Fixture/ClassForHinting.php')))
+            ->reflect(ClassForHinting::class);
+
+        $this->assertFalse($class->isInstance(new \stdClass()));
+        $this->assertFalse($class->isInstance($this));
+        $this->assertTrue($class->isInstance(new ClassForHinting()));
+
+        $this->setExpectedException(NotAnObject::class);
+
+        $class->isInstance('foo');
     }
 }

--- a/test/unit/Reflection/ReflectionClassTest.php
+++ b/test/unit/Reflection/ReflectionClassTest.php
@@ -319,4 +319,15 @@ class ReflectionClassTest extends \PHPUnit_Framework_TestCase
             \Reflection::getModifierNames($classInfo->getModifiers())
         );
     }
+
+    public function testIsTrait()
+    {
+        $reflector = new ClassReflector(new SingleFileSourceLocator(__DIR__ . '/../Fixture/ExampleClass.php'));
+
+        $classInfo = $reflector->reflect('\BetterReflectionTest\Fixture\ExampleTrait');
+        $this->assertTrue($classInfo->isTrait());
+
+        $classInfo = $reflector->reflect('\BetterReflectionTest\Fixture\ExampleClass');
+        $this->assertFalse($classInfo->isTrait());
+    }
 }

--- a/test/unit/Reflection/ReflectionClassTest.php
+++ b/test/unit/Reflection/ReflectionClassTest.php
@@ -10,6 +10,7 @@ use BetterReflection\Reflector\ClassReflector;
 use BetterReflection\SourceLocator\ComposerSourceLocator;
 use BetterReflection\SourceLocator\SingleFileSourceLocator;
 use BetterReflection\SourceLocator\SourceLocator;
+use BetterReflection\SourceLocator\StringSourceLocator;
 
 /**
  * @covers \BetterReflection\Reflection\ReflectionClass
@@ -179,5 +180,29 @@ class ReflectionClassTest extends \PHPUnit_Framework_TestCase
 
         $parentReflection = $childReflection->getParentClass($mockLocator);
         $this->assertSame('ExampleClass', $parentReflection->getShortName());
+    }
+
+    public function startEndLineProvider()
+    {
+        return [
+            ["<?php\n\nclass Foo {\n}\n", 3, 4],
+            ["<?php\n\nclass Foo {\n\n}\n", 3, 5],
+            ["<?php\n\n\nclass Foo {\n}\n", 4, 5],
+        ];
+    }
+
+    /**
+     * @param string $php
+     * @param int $expectedStart
+     * @param int $expectedEnd
+     * @dataProvider startEndLineProvider
+     */
+    public function testStartEndLine($php, $expectedStart, $expectedEnd)
+    {
+        $reflector = new ClassReflector(new StringSourceLocator($php));
+        $classInfo = $reflector->reflect('Foo');
+
+        $this->assertSame($expectedStart, $classInfo->getStartLine());
+        $this->assertSame($expectedEnd, $classInfo->getEndLine());
     }
 }

--- a/test/unit/Reflection/ReflectionClassTest.php
+++ b/test/unit/Reflection/ReflectionClassTest.php
@@ -261,4 +261,13 @@ class ReflectionClassTest extends \PHPUnit_Framework_TestCase
 
         $this->assertCount(3, $defaultProperties);
     }
+
+    public function testIsInternal()
+    {
+        $reflector = new ClassReflector($this->getComposerLocator());
+        $classInfo = $reflector->reflect('\BetterReflectionTest\Fixture\ExampleClass');
+
+        $this->assertFalse($classInfo->isInternal());
+        $this->assertTrue($classInfo->isUserDefined());
+    }
 }

--- a/test/unit/Reflection/ReflectionClassTest.php
+++ b/test/unit/Reflection/ReflectionClassTest.php
@@ -377,4 +377,18 @@ class ReflectionClassTest extends \PHPUnit_Framework_TestCase
             (new ClassReflector($sourceLocator))->reflect('TraitFixtureA')->getTraitNames($sourceLocator)
         );
     }
+
+    public function testGetTraitAliases()
+    {
+        $sourceLocator = new SingleFileSourceLocator(__DIR__ . '/../Fixture/TraitFixture.php');
+        $reflector = new ClassReflector($sourceLocator);
+
+        $classInfo = $reflector->reflect('TraitFixtureC');
+        $traitAliases = $classInfo->getTraitAliases();
+
+        $this->assertSame([
+            'a_protected' => 'TraitFixtureTraitC::a',
+            'b_renamed' => 'TraitFixtureTraitC::b',
+        ], $classInfo->getTraitAliases());
+    }
 }

--- a/test/unit/Reflection/ReflectionClassTest.php
+++ b/test/unit/Reflection/ReflectionClassTest.php
@@ -372,7 +372,7 @@ class ReflectionClassTest extends \PHPUnit_Framework_TestCase
 
         $this->assertSame(
             [
-                'TraitFixtureTraitA'
+                'TraitFixtureTraitA',
             ],
             (new ClassReflector($sourceLocator))->reflect('TraitFixtureA')->getTraitNames($sourceLocator)
         );

--- a/test/unit/Reflection/ReflectionClassTest.php
+++ b/test/unit/Reflection/ReflectionClassTest.php
@@ -365,4 +365,16 @@ class ReflectionClassTest extends \PHPUnit_Framework_TestCase
 
         $this->assertCount(0, $traits);
     }
+
+    public function testGetTraitNames()
+    {
+        $sourceLocator = new SingleFileSourceLocator(__DIR__ . '/../Fixture/TraitFixture.php');
+
+        $this->assertSame(
+            [
+                'TraitFixtureTraitA'
+            ],
+            (new ClassReflector($sourceLocator))->reflect('TraitFixtureA')->getTraitNames($sourceLocator)
+        );
+    }
 }

--- a/test/unit/Reflection/ReflectionClassTest.php
+++ b/test/unit/Reflection/ReflectionClassTest.php
@@ -292,4 +292,31 @@ class ReflectionClassTest extends \PHPUnit_Framework_TestCase
         $classInfo = $reflector->reflect('\BetterReflectionTest\Fixture\ExampleClass');
         $this->assertFalse($classInfo->isFinal());
     }
+
+    public function modifierProvider()
+    {
+        return [
+            ['ExampleClass', 0, []],
+            ['AbstractClass', \ReflectionClass::IS_EXPLICIT_ABSTRACT, ['abstract']],
+            ['FinalClass', \ReflectionClass::IS_FINAL, ['final']],
+        ];
+    }
+
+    /**
+     * @param string $className
+     * @param int $expectedModifier
+     * @param string[] $expectedModifierNames
+     * @dataProvider modifierProvider
+     */
+    public function testGetModifiers($className, $expectedModifier, array $expectedModifierNames)
+    {
+        $reflector = new ClassReflector(new SingleFileSourceLocator(__DIR__ . '/../Fixture/ExampleClass.php'));
+        $classInfo = $reflector->reflect('\BetterReflectionTest\Fixture\\' . $className);
+
+        $this->assertSame($expectedModifier, $classInfo->getModifiers());
+        $this->assertSame(
+            $expectedModifierNames,
+            \Reflection::getModifierNames($classInfo->getModifiers())
+        );
+    }
 }

--- a/test/unit/Reflection/ReflectionClassTest.php
+++ b/test/unit/Reflection/ReflectionClassTest.php
@@ -205,4 +205,20 @@ class ReflectionClassTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($expectedStart, $classInfo->getStartLine());
         $this->assertSame($expectedEnd, $classInfo->getEndLine());
     }
+
+    public function testGetDocComment()
+    {
+        $reflector = new ClassReflector($this->getComposerLocator());
+        $classInfo = $reflector->reflect('\BetterReflectionTest\Fixture\ExampleClass');
+
+        $this->assertContains('Some comments here', $classInfo->getDocComment());
+    }
+
+    public function testGetDocCommentReturnsEmptyStringWithNoComment()
+    {
+        $reflector = new ClassReflector(new SingleFileSourceLocator(__DIR__ . '/../Fixture/ExampleClass.php'));
+        $classInfo = $reflector->reflect('\BetterReflectionTest\FixtureOther\AnotherClass');
+
+        $this->assertSame('', $classInfo->getDocComment());
+    }
 }

--- a/test/unit/Reflection/ReflectionClassTest.php
+++ b/test/unit/Reflection/ReflectionClassTest.php
@@ -270,4 +270,26 @@ class ReflectionClassTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($classInfo->isInternal());
         $this->assertTrue($classInfo->isUserDefined());
     }
+
+    public function testIsAbstract()
+    {
+        $reflector = new ClassReflector(new SingleFileSourceLocator(__DIR__ . '/../Fixture/ExampleClass.php'));
+
+        $classInfo = $reflector->reflect('\BetterReflectionTest\Fixture\AbstractClass');
+        $this->assertTrue($classInfo->isAbstract());
+
+        $classInfo = $reflector->reflect('\BetterReflectionTest\Fixture\ExampleClass');
+        $this->assertFalse($classInfo->isAbstract());
+    }
+
+    public function testIsFinal()
+    {
+        $reflector = new ClassReflector(new SingleFileSourceLocator(__DIR__ . '/../Fixture/ExampleClass.php'));
+
+        $classInfo = $reflector->reflect('\BetterReflectionTest\Fixture\FinalClass');
+        $this->assertTrue($classInfo->isFinal());
+
+        $classInfo = $reflector->reflect('\BetterReflectionTest\Fixture\ExampleClass');
+        $this->assertFalse($classInfo->isFinal());
+    }
 }

--- a/test/unit/Reflection/ReflectionClassTest.php
+++ b/test/unit/Reflection/ReflectionClassTest.php
@@ -330,4 +330,15 @@ class ReflectionClassTest extends \PHPUnit_Framework_TestCase
         $classInfo = $reflector->reflect('\BetterReflectionTest\Fixture\ExampleClass');
         $this->assertFalse($classInfo->isTrait());
     }
+
+    public function testIsInterface()
+    {
+        $reflector = new ClassReflector(new SingleFileSourceLocator(__DIR__ . '/../Fixture/ExampleClass.php'));
+
+        $classInfo = $reflector->reflect('\BetterReflectionTest\Fixture\ExampleInterface');
+        $this->assertTrue($classInfo->isInterface());
+
+        $classInfo = $reflector->reflect('\BetterReflectionTest\Fixture\ExampleClass');
+        $this->assertFalse($classInfo->isInterface());
+    }
 }

--- a/test/unit/Reflection/ReflectionClassTest.php
+++ b/test/unit/Reflection/ReflectionClassTest.php
@@ -94,6 +94,7 @@ class ReflectionClassTest extends \PHPUnit_Framework_TestCase
         $classInfo = $reflector->reflect('\BetterReflectionTest\Fixture\ExampleClass');
         $this->assertSame(123, $classInfo->getConstant('MY_CONST_1'));
         $this->assertSame(234, $classInfo->getConstant('MY_CONST_2'));
+        $this->assertNull($classInfo->getConstant('NON_EXISTENT_CONSTANT'));
     }
 
     public function testIsConstructor()
@@ -121,6 +122,8 @@ class ReflectionClassTest extends \PHPUnit_Framework_TestCase
     {
         $reflector = new ClassReflector($this->getComposerLocator());
         $classInfo = $reflector->reflect('\BetterReflectionTest\Fixture\ExampleClass');
+
+        $this->assertNull($classInfo->getProperty('aNonExistentProperty'));
 
         $property = $classInfo->getProperty('publicProperty');
 
@@ -220,5 +223,32 @@ class ReflectionClassTest extends \PHPUnit_Framework_TestCase
         $classInfo = $reflector->reflect('\BetterReflectionTest\FixtureOther\AnotherClass');
 
         $this->assertSame('', $classInfo->getDocComment());
+    }
+
+    public function testHasProperty()
+    {
+        $reflector = new ClassReflector($this->getComposerLocator());
+        $classInfo = $reflector->reflect('\BetterReflectionTest\Fixture\ExampleClass');
+
+        $this->assertFalse($classInfo->hasProperty('aNonExistentProperty'));
+        $this->assertTrue($classInfo->hasProperty('publicProperty'));
+    }
+
+    public function testHasConstant()
+    {
+        $reflector = new ClassReflector($this->getComposerLocator());
+        $classInfo = $reflector->reflect('\BetterReflectionTest\Fixture\ExampleClass');
+
+        $this->assertFalse($classInfo->hasConstant('NON_EXISTENT_CONSTANT'));
+        $this->assertTrue($classInfo->hasConstant('MY_CONST_1'));
+    }
+
+    public function testHasMethod()
+    {
+        $reflector = new ClassReflector($this->getComposerLocator());
+        $classInfo = $reflector->reflect('\BetterReflectionTest\Fixture\ExampleClass');
+
+        $this->assertFalse($classInfo->hasMethod('aNonExistentMethod'));
+        $this->assertTrue($classInfo->hasMethod('someMethod'));
     }
 }

--- a/test/unit/Reflection/ReflectionClassTest.php
+++ b/test/unit/Reflection/ReflectionClassTest.php
@@ -251,4 +251,14 @@ class ReflectionClassTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($classInfo->hasMethod('aNonExistentMethod'));
         $this->assertTrue($classInfo->hasMethod('someMethod'));
     }
+
+    public function testGetDefaultProperties()
+    {
+        $reflector = new ClassReflector($this->getComposerLocator());
+        $classInfo = $reflector->reflect('\BetterReflectionTest\Fixture\ExampleClass');
+
+        $defaultProperties = $classInfo->getDefaultProperties();
+
+        $this->assertCount(3, $defaultProperties);
+    }
 }

--- a/test/unit/Reflection/ReflectionFunctionAbstractTest.php
+++ b/test/unit/Reflection/ReflectionFunctionAbstractTest.php
@@ -2,8 +2,6 @@
 
 namespace BetterReflectionTest\Reflection;
 
-use BetterReflection\Reflection\ReflectionFunction;
-use BetterReflection\Reflection\ReflectionFunctionAbstract;
 use BetterReflection\Reflection\ReflectionParameter;
 use BetterReflection\Reflector\FunctionReflector;
 use BetterReflection\SourceLocator\SingleFileSourceLocator;
@@ -194,12 +192,12 @@ class ReflectionFunctionAbstractTest extends \PHPUnit_Framework_TestCase
 
     public function testGetDocCommentWithComment()
     {
-        $php = "<?php
+        $php = '<?php
         /**
          * Some function comment
          */
         function foo() {}
-        ";
+        ';
 
         $reflector = new FunctionReflector(new StringSourceLocator($php));
         $functionInfo = $reflector->reflect('foo');
@@ -209,7 +207,7 @@ class ReflectionFunctionAbstractTest extends \PHPUnit_Framework_TestCase
 
     public function testGetDocReturnsEmptyStringWithNoComment()
     {
-        $php = "<?php function foo() {}";
+        $php = '<?php function foo() {}';
 
         $reflector = new FunctionReflector(new StringSourceLocator($php));
         $functionInfo = $reflector->reflect('foo');

--- a/test/unit/Reflector/ClassReflectorTest.php
+++ b/test/unit/Reflector/ClassReflectorTest.php
@@ -20,7 +20,7 @@ class ClassReflectorTest extends \PHPUnit_Framework_TestCase
         ))->getAllClasses();
 
         $this->assertContainsOnlyInstancesOf(ReflectionClass::class, $classes);
-        $this->assertCount(6, $classes);
+        $this->assertCount(7, $classes);
     }
 
     public function testReflectProxiesToGenericReflectMethod()

--- a/test/unit/Reflector/ClassReflectorTest.php
+++ b/test/unit/Reflector/ClassReflectorTest.php
@@ -20,7 +20,7 @@ class ClassReflectorTest extends \PHPUnit_Framework_TestCase
         ))->getAllClasses();
 
         $this->assertContainsOnlyInstancesOf(ReflectionClass::class, $classes);
-        $this->assertCount(3, $classes);
+        $this->assertCount(4, $classes);
     }
 
     public function testReflectProxiesToGenericReflectMethod()

--- a/test/unit/Reflector/ClassReflectorTest.php
+++ b/test/unit/Reflector/ClassReflectorTest.php
@@ -20,7 +20,7 @@ class ClassReflectorTest extends \PHPUnit_Framework_TestCase
         ))->getAllClasses();
 
         $this->assertContainsOnlyInstancesOf(ReflectionClass::class, $classes);
-        $this->assertCount(4, $classes);
+        $this->assertCount(6, $classes);
     }
 
     public function testReflectProxiesToGenericReflectMethod()

--- a/test/unit/Reflector/ClassReflectorTest.php
+++ b/test/unit/Reflector/ClassReflectorTest.php
@@ -20,7 +20,7 @@ class ClassReflectorTest extends \PHPUnit_Framework_TestCase
         ))->getAllClasses();
 
         $this->assertContainsOnlyInstancesOf(ReflectionClass::class, $classes);
-        $this->assertCount(7, $classes);
+        $this->assertCount(8, $classes);
     }
 
     public function testReflectProxiesToGenericReflectMethod()

--- a/test/unit/Reflector/GenericTest.php
+++ b/test/unit/Reflector/GenericTest.php
@@ -22,10 +22,10 @@ class GenericTest extends \PHPUnit_Framework_TestCase
 
     public function testReflectingWithinNamespace()
     {
-        $php = "<?php
+        $php = '<?php
         namespace Foo;
         class Bar {}
-        ";
+        ';
 
         $reflector = new Generic(new StringSourceLocator($php));
         $classInfo = $reflector->reflect($this->getIdentifier('Foo\Bar', IdentifierType::IDENTIFIER_CLASS));
@@ -35,9 +35,9 @@ class GenericTest extends \PHPUnit_Framework_TestCase
 
     public function testReflectingTopLevelClass()
     {
-        $php = "<?php
+        $php = '<?php
         class Foo {}
-        ";
+        ';
 
         $reflector = new Generic(new StringSourceLocator($php));
         $classInfo = $reflector->reflect($this->getIdentifier('Foo', IdentifierType::IDENTIFIER_CLASS));
@@ -47,9 +47,9 @@ class GenericTest extends \PHPUnit_Framework_TestCase
 
     public function testReflectingTopLevelFunction()
     {
-        $php = "<?php
+        $php = '<?php
         function foo() {}
-        ";
+        ';
 
         $reflector = new Generic(new StringSourceLocator($php));
         $functionInfo = $reflector->reflect($this->getIdentifier('foo', IdentifierType::IDENTIFIER_FUNCTION));
@@ -59,7 +59,7 @@ class GenericTest extends \PHPUnit_Framework_TestCase
 
     public function testReflectThrowsExeptionWhenClassNotFoundAndNoNodesExist()
     {
-        $php = "<?php";
+        $php = '<?php';
 
         $reflector = new Generic(new StringSourceLocator($php));
 
@@ -82,11 +82,11 @@ class GenericTest extends \PHPUnit_Framework_TestCase
 
     public function testGetAllFunctions()
     {
-        $php = "<?php
+        $php = '<?php
         namespace Foo;
         function a() {}
         function b() {}
-        ";
+        ';
 
         $reflector = new Generic(new StringSourceLocator($php));
 
@@ -99,11 +99,11 @@ class GenericTest extends \PHPUnit_Framework_TestCase
 
     public function testGetAllFunctionsWhenNoneExist()
     {
-        $php = "<?php
+        $php = '<?php
         namespace Foo;
         class a {}
         class b {}
-        ";
+        ';
 
         $reflector = new Generic(new StringSourceLocator($php));
 
@@ -115,11 +115,11 @@ class GenericTest extends \PHPUnit_Framework_TestCase
 
     public function testGetAllClasses()
     {
-        $php = "<?php
+        $php = '<?php
         namespace Foo;
         class a {}
         class b {}
-        ";
+        ';
 
         $reflector = new Generic(new StringSourceLocator($php));
 
@@ -132,11 +132,11 @@ class GenericTest extends \PHPUnit_Framework_TestCase
 
     public function testGetAllClassesWhenNoneExist()
     {
-        $php = "<?php
+        $php = '<?php
         namespace Foo;
         function a() {}
         function b() {}
-        ";
+        ';
 
         $reflector = new Generic(new StringSourceLocator($php));
 


### PR DESCRIPTION
This PR brings about "most" compatibility for `ReflectionClass`, thus merging this will finally resolve #7.

### General
* [x] Rebase onto master before merge (#60 may cause conflict)
* [x] getParentClass
* [x] getDefaultProperties
* [x] getDocComment
* [x] getStartLine
* [x] getEndLine
* [x] hasConstant
* [x] hasMethod
* [x] hasProperty
* [x] isInternal
* [x] isUserDefined
* [x] isAbstract
* [x] isFinal
* [x] getModifiers

### Trait-related
* [x] getTraits
* [x] getTraitNames
* [x] getTraitAliases - waiting for PR merge: phpDocumentor/TypeResolver#9
* [x] isTrait

### Interface-related
* [x] getInterfaceNames
* [x] getInterfaces
* [x] isInterface

### Needs parent/interface/trait hierarchy
* [x] isCloneable
* [x] isInstance
* [x] isInstantiable
* [x] isIterateable
* [x] isSubClassOf
* [x] implementsInterface

### Other stuff
* [x] Inject `BetterReflection\Reflector\Reflector` instead of a `SourceLocator` to things like `getTraits`, `getInterfaces`, `getParentClass` (and other related methods)