### PR TITLE
Moar test coverage

### DIFF
--- a/src/Reflection/ReflectionFunctionAbstract.php
+++ b/src/Reflection/ReflectionFunctionAbstract.php
@@ -28,7 +28,7 @@ abstract class ReflectionFunctionAbstract
     /**
      * @var string
      */
-    private $docBlock;
+    private $docBlock = '';
 
     /**
      * @var LocatedSource

--- a/src/Reflection/ReflectionParameter.php
+++ b/src/Reflection/ReflectionParameter.php
@@ -126,14 +126,14 @@ class ReflectionParameter implements \Reflector
         $param->isVariadic = (bool)$node->variadic;
         $param->isByReference = (bool)$node->byRef;
         $param->parameterIndex = (int)$parameterIndex;
+
+        $namespaceForType = $function instanceof ReflectionMethod
+            ? $function->getDeclaringClass()->getNamespaceName()
+            : $function->getNamespaceName();
         $param->typeHint = (new FindTypeFromAst())->__invoke(
             $node->type,
             $function->getLocatedSource(),
-            (
-                $function instanceof ReflectionMethod
-                ? $function->getDeclaringClass()->getNamespaceName()
-                : $function->getNamespaceName()
-            )
+            $namespaceForType
         );
 
         if ($param->hasDefaultValue) {
@@ -254,28 +254,7 @@ class ReflectionParameter implements \Reflector
      */
     public function getDefaultValueAsString()
     {
-        $defaultValue = $this->getDefaultValue();
-        $type = gettype($defaultValue);
-        switch ($type) {
-            case 'boolean':
-                return $defaultValue ? 'true' : 'false';
-            case 'integer':
-            case 'float':
-            case 'double':
-                return (string)$defaultValue;
-            case 'array':
-                return '[]'; // @todo do this less terribly
-            case 'NULL':
-                return 'null';
-            case 'object':
-            case 'resource':
-            case 'unknown type':
-            default:
-                throw new Exception\InvalidDefaultValueType(sprintf(
-                    'Default value as an instance of an %s does not make any sense',
-                    $type
-                ));
-        }
+        return var_export($this->getDefaultValue(), true);
     }
 
     /**

--- a/src/Reflector/Exception/IdentifierNotFound.php
+++ b/src/Reflector/Exception/IdentifierNotFound.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace BetterReflection\Reflector\Exception;
+
+class IdentifierNotFound extends \RuntimeException
+{
+}

--- a/src/Reflector/Generic.php
+++ b/src/Reflector/Generic.php
@@ -55,8 +55,8 @@ class Generic
             }
         }
 
-        throw new \UnexpectedValueException(sprintf(
-            '%s "%s" could not be found to load',
+        throw new Exception\IdentifierNotFound(sprintf(
+            '%s "%s" could not be found in the located source',
             $identifier->getType()->getName(),
             $identifier->getName()
         ));

--- a/test/unit/Identifier/IdentifierTest.php
+++ b/test/unit/Identifier/IdentifierTest.php
@@ -26,4 +26,20 @@ class IdentifierTest extends \PHPUnit_Framework_TestCase
         $identifier = new Identifier('Foo', $identifierType);
         $this->assertSame($identifierType, $identifier->getType());
     }
+
+    public function testIsTypesForClass()
+    {
+        $identifier = new Identifier('Foo', new IdentifierType(IdentifierType::IDENTIFIER_CLASS));
+
+        $this->assertTrue($identifier->isClass());
+        $this->assertFalse($identifier->isFunction());
+    }
+
+    public function testIsTypesForFunction()
+    {
+        $identifier = new Identifier('Foo', new IdentifierType(IdentifierType::IDENTIFIER_FUNCTION));
+
+        $this->assertFalse($identifier->isClass());
+        $this->assertTrue($identifier->isFunction());
+    }
 }

--- a/test/unit/Identifier/IdentifierTypeTest.php
+++ b/test/unit/Identifier/IdentifierTypeTest.php
@@ -4,6 +4,7 @@ namespace BetterReflectionTest\Identifier;
 
 use BetterReflection\Identifier\IdentifierType;
 use BetterReflection\Reflection\ReflectionClass;
+use BetterReflection\Reflection\ReflectionFunction;
 use InvalidArgumentException;
 
 /**
@@ -40,15 +41,26 @@ class IdentifierTypeTest extends \PHPUnit_Framework_TestCase
         new IdentifierType('foo');
     }
 
-    public function testIsMatchingReflector()
+    public function testIsMatchingReflectorClass()
     {
         $reflectionClass = $this->getMockBuilder(ReflectionClass::class)
             ->disableOriginalConstructor()
             ->getMock();
 
-        $classType = new IdentifierType(IdentifierType::IDENTIFIER_CLASS);
+        $type = new IdentifierType(IdentifierType::IDENTIFIER_CLASS);
 
-        $this->assertTrue($classType->isMatchingReflector($reflectionClass));
+        $this->assertTrue($type->isMatchingReflector($reflectionClass));
+    }
+
+    public function testIsMatchingReflectorFunction()
+    {
+        $reflectionFunction = $this->getMockBuilder(ReflectionFunction::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $type = new IdentifierType(IdentifierType::IDENTIFIER_FUNCTION);
+
+        $this->assertTrue($type->isMatchingReflector($reflectionFunction));
     }
 
     public function testIsMatchingReflectorReturnsFalseWhenTypeIsInvalid()
@@ -67,5 +79,21 @@ class IdentifierTypeTest extends \PHPUnit_Framework_TestCase
             ->getMock();
 
         $this->assertFalse($classType->isMatchingReflector($reflectionClass));
+    }
+
+    public function testIsTypesForClass()
+    {
+        $classType = new IdentifierType(IdentifierType::IDENTIFIER_CLASS);
+
+        $this->assertTrue($classType->isClass());
+        $this->assertFalse($classType->isFunction());
+    }
+
+    public function testIsTypesForFunction()
+    {
+        $functionType = new IdentifierType(IdentifierType::IDENTIFIER_FUNCTION);
+
+        $this->assertFalse($functionType->isClass());
+        $this->assertTrue($functionType->isFunction());
     }
 }

--- a/test/unit/Reflection/ReflectionParameterTest.php
+++ b/test/unit/Reflection/ReflectionParameterTest.php
@@ -320,7 +320,7 @@ class ReflectionParameterTest extends \PHPUnit_Framework_TestCase
             ['false', 'false'],
             ['null', 'NULL'],
             ['[]', "array (\n)"],
-            ['[1, 2, 3]', "array (\n)"],
+            ['[1, 2, 3]', "array (\n  0 => 1,\n  1 => 2,\n  2 => 3,\n)"],
             ['"foo"', "'foo'"],
         ];
     }

--- a/test/unit/Reflection/ReflectionParameterTest.php
+++ b/test/unit/Reflection/ReflectionParameterTest.php
@@ -2,7 +2,9 @@
 
 namespace BetterReflectionTest\Reflection;
 
+use BetterReflection\Reflection\ReflectionParameter;
 use BetterReflection\Reflector\ClassReflector;
+use BetterReflection\Reflector\FunctionReflector;
 use phpDocumentor\Reflection\Types;
 use BetterReflection\SourceLocator\ComposerSourceLocator;
 use BetterReflection\SourceLocator\StringSourceLocator;
@@ -21,6 +23,12 @@ class ReflectionParameterTest extends \PHPUnit_Framework_TestCase
     {
         global $loader;
         $this->reflector = new ClassReflector(new ComposerSourceLocator($loader));
+    }
+
+    public function testExportThrowsException()
+    {
+        $this->setExpectedException(\Exception::class);
+        ReflectionParameter::export();
     }
 
     /**
@@ -57,6 +65,19 @@ class ReflectionParameterTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($expectedValue, $actualValue);
     }
 
+    public function testGetDefaultValueWhenDefaultValueNotAvailableThrowsException()
+    {
+        $content = "<?php class Foo { public function myMethod(\$var) {} }";
+
+        $reflector = new ClassReflector(new StringSourceLocator($content));
+        $classInfo = $reflector->reflect('Foo');
+        $methodInfo = $classInfo->getMethod('myMethod');
+        $paramInfo = $methodInfo->getParameter('var');
+
+        $this->setExpectedException(\LogicException::class, 'This parameter does not have a default value available');
+        $paramInfo->getDefaultValue();
+    }
+
     public function testGetDocBlockTypeStrings()
     {
         $classInfo = $this->reflector->reflect('\BetterReflectionTest\Fixture\Methods');
@@ -70,6 +91,24 @@ class ReflectionParameterTest extends \PHPUnit_Framework_TestCase
         $this->assertSame(['int', 'float'], $param2->getDocBlockTypeStrings());
     }
 
+    public function testGetDocBlockTypes()
+    {
+        $classInfo = $this->reflector->reflect('\BetterReflectionTest\Fixture\Methods');
+
+        $method = $classInfo->getMethod('methodWithParameters');
+
+        $param1 = $method->getParameter('parameter1');
+        $param1Types = $param1->getDocBlockTypes();
+        $this->assertCount(1, $param1Types);
+        $this->assertInstanceOf(Types\String_::class, $param1Types[0]);
+
+        $param2 = $method->getParameter('parameter2');
+        $param2Types = $param2->getDocBlockTypes();
+        $this->assertCount(2, $param2Types);
+        $this->assertInstanceOf(Types\Integer::class, $param2Types[0]);
+        $this->assertInstanceOf(Types\Float_::class, $param2Types[1]);
+    }
+
     public function testStringCast()
     {
         $classInfo = $this->reflector->reflect('\BetterReflectionTest\Fixture\Methods');
@@ -79,7 +118,7 @@ class ReflectionParameterTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('Parameter #0 [ <required> $parameter ]', (string)$requiredParam);
 
         $optionalParam = $method->getParameter('optionalParameter');
-        $this->assertSame('Parameter #1 [ <optional> $optionalParameter = null ]', (string)$optionalParam);
+        $this->assertSame('Parameter #1 [ <optional> $optionalParameter = NULL ]', (string)$optionalParam);
     }
 
     public function testGetPosition()
@@ -222,9 +261,6 @@ class ReflectionParameterTest extends \PHPUnit_Framework_TestCase
         $classInfo = $this->reflector->reflect('\BetterReflectionTest\Fixture\Methods');
         $method = $classInfo->getMethod('methodWithConstAsDefault');
 
-        $intDefault = $method->getParameter('intDefault');
-        $this->assertFalse($intDefault->isDefaultValueConstant());
-
         $constDefault = $method->getParameter('constDefault');
         $this->assertTrue($constDefault->isDefaultValueConstant());
         $this->assertSame('SOME_CONST', $constDefault->getDefaultValueConstantName());
@@ -232,5 +268,75 @@ class ReflectionParameterTest extends \PHPUnit_Framework_TestCase
         $definedDefault = $method->getParameter('definedDefault');
         $this->assertTrue($definedDefault->isDefaultValueConstant());
         $this->assertSame('SOME_DEFINED_VALUE', $definedDefault->getDefaultValueConstantName());
+
+        $intDefault = $method->getParameter('intDefault');
+        $this->assertFalse($intDefault->isDefaultValueConstant());
+
+        $this->setExpectedException(\LogicException::class, 'This parameter is not a constant default value, so cannot have a constant name');
+        $intDefault->getDefaultValueConstantName();
+    }
+
+    public function testGetDeclaringFunction()
+    {
+        $content = "<?php class Foo { public function myMethod(\$var = 123) {} }";
+
+        $reflector = new ClassReflector(new StringSourceLocator($content));
+        $classInfo = $reflector->reflect('Foo');
+        $methodInfo = $classInfo->getMethod('myMethod');
+        $paramInfo = $methodInfo->getParameter('var');
+
+        $this->assertSame($methodInfo, $paramInfo->getDeclaringFunction());
+    }
+
+    public function testGetDeclaringClassForMethod()
+    {
+        $content = "<?php class Foo { public function myMethod(\$var = 123) {} }";
+
+        $reflector = new ClassReflector(new StringSourceLocator($content));
+        $classInfo = $reflector->reflect('Foo');
+        $methodInfo = $classInfo->getMethod('myMethod');
+        $paramInfo = $methodInfo->getParameter('var');
+
+        $this->assertSame($classInfo, $paramInfo->getDeclaringClass());
+    }
+
+    public function testGetDeclaringClassForFunctionReturnsNull()
+    {
+        $content = "<?php function myMethod(\$var = 123) {}";
+
+        $reflector = new FunctionReflector(new StringSourceLocator($content));
+        $functionInfo = $reflector->reflect('myMethod');
+        $paramInfo = $functionInfo->getParameter('var');
+
+        $this->assertNull($paramInfo->getDeclaringClass());
+    }
+
+    public function defaultValueStringProvider()
+    {
+        return [
+            ['123', '123'],
+            ['12.3', '12.300000000000001'], // Oh, yes, because PHP.
+            ['true', 'true'],
+            ['false', 'false'],
+            ['null', 'NULL'],
+            ['[]', "array (\n)"],
+            ['[1, 2, 3]', "array (\n)"],
+            ['"foo"', "'foo'"],
+        ];
+    }
+
+    /**
+     * @param string $defaultValue
+     * @dataProvider defaultValueStringProvider
+     */
+    public function testGetDefaultValueAsString($defaultValue, $expectedValue)
+    {
+        $content = "<?php function myMethod(\$var = $defaultValue) {}";
+
+        $reflector = new FunctionReflector(new StringSourceLocator($content));
+        $functionInfo = $reflector->reflect('myMethod');
+        $paramInfo = $functionInfo->getParameter('var');
+
+        $this->assertSame($expectedValue, $paramInfo->getDefaultValueAsString());
     }
 }

--- a/test/unit/Reflector/GenericTest.php
+++ b/test/unit/Reflector/GenericTest.php
@@ -1,0 +1,148 @@
+<?php
+
+namespace BetterReflectionTest\Reflector;
+
+use BetterReflection\Reflector\Exception\IdentifierNotFound;
+use BetterReflection\Reflector\Generic;
+use BetterReflection\SourceLocator\StringSourceLocator;
+use BetterReflection\Identifier\Identifier;
+use BetterReflection\Identifier\IdentifierType;
+use BetterReflection\Reflection\ReflectionClass;
+use BetterReflection\Reflection\ReflectionFunction;
+
+/**
+ * @covers \BetterReflection\Reflector\Generic
+ */
+class GenericTest extends \PHPUnit_Framework_TestCase
+{
+    private function getIdentifier($name, $type)
+    {
+        return new Identifier($name, new IdentifierType($type));
+    }
+
+    public function testReflectingWithinNamespace()
+    {
+        $php = "<?php
+        namespace Foo;
+        class Bar {}
+        ";
+
+        $reflector = new Generic(new StringSourceLocator($php));
+        $classInfo = $reflector->reflect($this->getIdentifier('Foo\Bar', IdentifierType::IDENTIFIER_CLASS));
+
+        $this->assertInstanceOf(ReflectionClass::class, $classInfo);
+    }
+
+    public function testReflectingTopLevelClass()
+    {
+        $php = "<?php
+        class Foo {}
+        ";
+
+        $reflector = new Generic(new StringSourceLocator($php));
+        $classInfo = $reflector->reflect($this->getIdentifier('Foo', IdentifierType::IDENTIFIER_CLASS));
+
+        $this->assertInstanceOf(ReflectionClass::class, $classInfo);
+    }
+
+    public function testReflectingTopLevelFunction()
+    {
+        $php = "<?php
+        function foo() {}
+        ";
+
+        $reflector = new Generic(new StringSourceLocator($php));
+        $functionInfo = $reflector->reflect($this->getIdentifier('foo', IdentifierType::IDENTIFIER_FUNCTION));
+
+        $this->assertInstanceOf(ReflectionFunction::class, $functionInfo);
+    }
+
+    public function testReflectThrowsExeptionWhenClassNotFoundAndNoNodesExist()
+    {
+        $php = "<?php";
+
+        $reflector = new Generic(new StringSourceLocator($php));
+
+        $this->setExpectedException(IdentifierNotFound::class);
+        $reflector->reflect($this->getIdentifier('Foo', IdentifierType::IDENTIFIER_CLASS));
+    }
+
+    public function testReflectThrowsExeptionWhenClassNotFoundButNodesExist()
+    {
+        $php = "<?php
+        namespace Foo;
+        echo 'Hello world';
+        ";
+
+        $reflector = new Generic(new StringSourceLocator($php));
+
+        $this->setExpectedException(IdentifierNotFound::class);
+        $reflector->reflect($this->getIdentifier('Foo', IdentifierType::IDENTIFIER_CLASS));
+    }
+
+    public function testGetAllFunctions()
+    {
+        $php = "<?php
+        namespace Foo;
+        function a() {}
+        function b() {}
+        ";
+
+        $reflector = new Generic(new StringSourceLocator($php));
+
+        $found = $reflector->getAllByIdentifierType(new IdentifierType(IdentifierType::IDENTIFIER_FUNCTION));
+
+        $this->assertInternalType('array', $found);
+        $this->assertCount(2, $found);
+        $this->assertContainsOnlyInstancesOf(ReflectionFunction::class, $found);
+    }
+
+    public function testGetAllFunctionsWhenNoneExist()
+    {
+        $php = "<?php
+        namespace Foo;
+        class a {}
+        class b {}
+        ";
+
+        $reflector = new Generic(new StringSourceLocator($php));
+
+        $found = $reflector->getAllByIdentifierType(new IdentifierType(IdentifierType::IDENTIFIER_FUNCTION));
+
+        $this->assertInternalType('array', $found);
+        $this->assertCount(0, $found);
+    }
+
+    public function testGetAllClasses()
+    {
+        $php = "<?php
+        namespace Foo;
+        class a {}
+        class b {}
+        ";
+
+        $reflector = new Generic(new StringSourceLocator($php));
+
+        $found = $reflector->getAllByIdentifierType(new IdentifierType(IdentifierType::IDENTIFIER_CLASS));
+
+        $this->assertInternalType('array', $found);
+        $this->assertCount(2, $found);
+        $this->assertContainsOnlyInstancesOf(ReflectionClass::class, $found);
+    }
+
+    public function testGetAllClassesWhenNoneExist()
+    {
+        $php = "<?php
+        namespace Foo;
+        function a() {}
+        function b() {}
+        ";
+
+        $reflector = new Generic(new StringSourceLocator($php));
+
+        $found = $reflector->getAllByIdentifierType(new IdentifierType(IdentifierType::IDENTIFIER_CLASS));
+
+        $this->assertInternalType('array', $found);
+        $this->assertCount(0, $found);
+    }
+}

--- a/test/unit/SourceLocator/ComposerSourceLocatorTest.php
+++ b/test/unit/SourceLocator/ComposerSourceLocatorTest.php
@@ -7,6 +7,7 @@ use BetterReflection\Identifier\IdentifierType;
 use BetterReflection\SourceLocator\ComposerSourceLocator;
 use ClassWithNoNamespace;
 use Composer\Autoload\ClassLoader;
+use LogicException;
 use UnexpectedValueException;
 
 /**
@@ -63,6 +64,20 @@ class ComposerSourceLocatorTest extends \PHPUnit_Framework_TestCase
         $locator->__invoke(new Identifier(
             $className,
             new IdentifierType(IdentifierType::IDENTIFIER_CLASS)
+        ));
+    }
+
+    public function testInvokeThrowsExceptionWhenTryingToLocateFunction()
+    {
+        $loader = $this->getMock(ClassLoader::class);
+
+        /** @var ClassLoader $loader */
+        $locator = new ComposerSourceLocator($loader);
+
+        $this->setExpectedException(LogicException::class);
+        $locator->__invoke(new Identifier(
+            'foo',
+            new IdentifierType(IdentifierType::IDENTIFIER_FUNCTION)
         ));
     }
 }


### PR DESCRIPTION
Merging this will resolve #24

Note that the coverage for `ReflectionClass` is already improved in #59 

![co](https://cloud.githubusercontent.com/assets/496145/8696427/1db7dbd6-2ae4-11e5-98d0-bb930d5c67ac.png)

The stuff that means it's not 100% quite yet is:

* PR #59 improves `Reflection` folder so is already accounted for
* There is a specific path in `Reflector\Generic` that somehow is not covered and I'm not sure why (see http://s.asgrim.com/1034bf.png)
* `NodeCompiler` this will be fixed by issue #19 so is already accounted for