### PR TITLE
AggregateSourceLocator for combining multiple SourceLocators

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="test/bootstrap.php">
+<phpunit bootstrap="test/bootstrap.php" colors="true">
     <testsuites>
         <testsuite name="unit">
             <directory>./test/unit</directory>

--- a/src/Reflector/Exception/IdentifierNotFound.php
+++ b/src/Reflector/Exception/IdentifierNotFound.php
@@ -2,6 +2,16 @@
 
 namespace BetterReflection\Reflector\Exception;
 
+use BetterReflection\Identifier\Identifier;
+
 class IdentifierNotFound extends \RuntimeException
 {
+    public static function fromIdentifier(Identifier $identifier)
+    {
+        return new self(sprintf(
+            '%s "%s" could not be found in the located source',
+            $identifier->getType()->getName(),
+            $identifier->getName()
+        ));
+    }
 }

--- a/src/Reflector/Generic.php
+++ b/src/Reflector/Generic.php
@@ -40,7 +40,7 @@ class Generic
             $aggregate = new AggregateSourceLocator([$this->sourceLocator]);
         }
 
-        foreach ($aggregate->__invoke($identifier) as $locatedSource) {
+        foreach ($aggregate($identifier) as $locatedSource) {
             try {
                 return $this->reflectFromLocatedSource($identifier, $locatedSource);
             }

--- a/src/Reflector/Generic.php
+++ b/src/Reflector/Generic.php
@@ -5,6 +5,7 @@ namespace BetterReflection\Reflector;
 use BetterReflection\Identifier\Identifier;
 use BetterReflection\Identifier\IdentifierType;
 use BetterReflection\Reflection\ReflectionFunction;
+use BetterReflection\SourceLocator\AggregateSourceLocator;
 use BetterReflection\SourceLocator\LocatedSource;
 use BetterReflection\SourceLocator\SourceLocator;
 use BetterReflection\Reflection\ReflectionClass;
@@ -34,10 +35,20 @@ class Generic
      */
     public function reflect(Identifier $identifier)
     {
-        return $this->reflectFromLocatedSource(
-            $identifier,
-            $this->sourceLocator->__invoke($identifier)
-        );
+        $aggregate = $this->sourceLocator;
+        if (!($aggregate instanceof AggregateSourceLocator)) {
+            $aggregate = new AggregateSourceLocator([$this->sourceLocator]);
+        }
+
+        foreach ($aggregate->__invoke($identifier) as $locatedSource) {
+            try {
+                return $this->reflectFromLocatedSource($identifier, $locatedSource);
+            }
+            catch (Exception\IdentifierNotFound $identifierNotFound) {
+            }
+        }
+
+        throw Exception\IdentifierNotFound::fromIdentifier($identifier);
     }
 
     /**
@@ -55,11 +66,7 @@ class Generic
             }
         }
 
-        throw new Exception\IdentifierNotFound(sprintf(
-            '%s "%s" could not be found in the located source',
-            $identifier->getType()->getName(),
-            $identifier->getName()
-        ));
+        throw Exception\IdentifierNotFound::fromIdentifier($identifier);
     }
 
     /**

--- a/src/SourceLocator/AggregateSourceLocator.php
+++ b/src/SourceLocator/AggregateSourceLocator.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace BetterReflection\SourceLocator;
+
+use BetterReflection\Identifier\Identifier;
+
+class AggregateSourceLocator implements SourceLocator
+{
+    /**
+     * @var SourceLocator[]
+     */
+    private $sourceLocators;
+
+    public function __construct(array $sourceLocators = [])
+    {
+        // This slightly confusing code simply type-checks the $sourceLocators
+        // array by unpacking them and splatting them in the closure.
+        $validator = function (SourceLocator ...$sourceLocator) {
+            return $sourceLocator;
+        };
+        $this->sourceLocators = $validator(...$sourceLocators);
+    }
+
+    /**
+     * Generator to invoke multiple source locators
+     *
+     * @param Identifier $identifier
+     * @return LocatedSource
+     */
+    public function __invoke(Identifier $identifier)
+    {
+        foreach ($this->sourceLocators as $sourceLocator) {
+            yield $sourceLocator->__invoke($identifier);
+        }
+    }
+}

--- a/test/unit/Reflector/Exception/IdentifierNotFoundTest.php
+++ b/test/unit/Reflector/Exception/IdentifierNotFoundTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace BetterReflectionTest\Reflector\Exception;
+
+use BetterReflection\Identifier\Identifier;
+use BetterReflection\Identifier\IdentifierType;
+use BetterReflection\Reflector\Exception\IdentifierNotFound;
+
+/**
+ * @covers \BetterReflection\Reflector\Exception\IdentifierNotFound
+ */
+class IdentifierNotFoundTest extends \PHPUnit_Framework_TestCase
+{
+    public function testFromNonObject()
+    {
+        $exception = IdentifierNotFound::fromIdentifier(new Identifier(
+            "myIdentifier",
+            new IdentifierType(IdentifierType::IDENTIFIER_CLASS)
+        ));
+
+        $this->assertInstanceOf(IdentifierNotFound::class, $exception);
+        $this->assertSame(IdentifierType::IDENTIFIER_CLASS . ' "myIdentifier" could not be found in the located source', $exception->getMessage());
+    }
+}

--- a/test/unit/Reflector/GenericTest.php
+++ b/test/unit/Reflector/GenericTest.php
@@ -4,6 +4,7 @@ namespace BetterReflectionTest\Reflector;
 
 use BetterReflection\Reflector\Exception\IdentifierNotFound;
 use BetterReflection\Reflector\Generic;
+use BetterReflection\SourceLocator\AggregateSourceLocator;
 use BetterReflection\SourceLocator\StringSourceLocator;
 use BetterReflection\Identifier\Identifier;
 use BetterReflection\Identifier\IdentifierType;
@@ -144,5 +145,29 @@ class GenericTest extends \PHPUnit_Framework_TestCase
 
         $this->assertInternalType('array', $found);
         $this->assertCount(0, $found);
+    }
+
+    public function testReflectWithAggregateSourceLocatorWhenIdentifierDoesNotExist()
+    {
+        $reflector = new Generic(new AggregateSourceLocator([
+            new StringSourceLocator('<?php'),
+            new StringSourceLocator('<?php'),
+        ]));
+
+        $this->setExpectedException(IdentifierNotFound::class);
+        $reflector->reflect($this->getIdentifier('Foo', IdentifierType::IDENTIFIER_CLASS));
+    }
+
+    public function testReflectWithAggregateSourceLocatorFindsClass()
+    {
+        $reflector = new Generic(new AggregateSourceLocator([
+            new StringSourceLocator('<?php'),
+            new StringSourceLocator('<?php class Foo {}'),
+        ]));
+
+        $classInfo = $reflector->reflect($this->getIdentifier('Foo', IdentifierType::IDENTIFIER_CLASS));
+
+        $this->assertInstanceOf(ReflectionClass::class, $classInfo);
+        $this->assertSame('Foo', $classInfo->getName());
     }
 }

--- a/test/unit/SourceLocator/AggregateSourceLocatorTest.php
+++ b/test/unit/SourceLocator/AggregateSourceLocatorTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace BetterReflectionTest\SourceLocator;
+use BetterReflection\Identifier\Identifier;
+use BetterReflection\Identifier\IdentifierType;
+use BetterReflection\SourceLocator\AggregateSourceLocator;
+use BetterReflection\SourceLocator\LocatedSource;
+use BetterReflection\SourceLocator\StringSourceLocator;
+
+/**
+ * @covers \BetterReflection\SourceLocator\AggregateSourceLocator
+ */
+class AggregateSourceLocatorTest extends \PHPUnit_Framework_TestCase
+{
+    public function testInvokeGenerator()
+    {
+        $inputLocators = [
+            new StringSourceLocator('<?php source1'),
+            new StringSourceLocator('<?php source2'),
+        ];
+
+        $aggregate = new AggregateSourceLocator($inputLocators);
+
+        $identifier = new Identifier('Foo', new IdentifierType(IdentifierType::IDENTIFIER_CLASS));
+
+        /** @var \Generator $values */
+        $values = $aggregate->__invoke($identifier);
+
+        $values->rewind();
+        $this->assertInstanceOf(LocatedSource::class, $values->current());
+        $this->assertSame('<?php source1', $values->current()->getSource());
+
+        $values->next();
+        $this->assertInstanceOf(LocatedSource::class, $values->current());
+        $this->assertSame('<?php source2', $values->current()->getSource());
+
+        $values->next();
+        $this->assertNull($values->current());
+    }
+}


### PR DESCRIPTION
Add AggregateSourceLocator which is now used internally if the source locator specified is not already an aggregate.

This fixes #53 which means in the future we can add multiple sources to source locators.