### PR TITLE
Internal class reflections

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,9 +3,10 @@
     "description": "Better Reflection - an improved code reflection API",
     "require": {
         "php": ">= 5.6",
-        "nikic/php-parser": "^1.3",
+        "nikic/php-parser": "dev-master",
         "phpdocumentor/reflection-docblock": "^2.0",
-        "phpdocumentor/type-resolver": "dev-master"
+        "phpdocumentor/type-resolver": "dev-master",
+        "zendframework/zend-code": "^2.5@dev"
     },
     "require-dev": {
         "fabpot/php-cs-fixer": "^1.8",

--- a/composer.lock
+++ b/composer.lock
@@ -4,30 +4,30 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "adff438cea0b94105ee46e3611c7af34",
+    "hash": "0576a3289b58e50f2362e51bb1c6edb9",
     "packages": [
         {
             "name": "nikic/php-parser",
-            "version": "v1.4.0",
+            "version": "dev-master",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "196f177cfefa0f1f7166c0a05d8255889be12418"
+                "reference": "e0a75ededaecccee2f083f951f4611ef95f6a562"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/196f177cfefa0f1f7166c0a05d8255889be12418",
-                "reference": "196f177cfefa0f1f7166c0a05d8255889be12418",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/e0a75ededaecccee2f083f951f4611ef95f6a562",
+                "reference": "e0a75ededaecccee2f083f951f4611ef95f6a562",
                 "shasum": ""
             },
             "require": {
                 "ext-tokenizer": "*",
-                "php": ">=5.3"
+                "php": ">=5.4"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.4-dev"
+                    "dev-master": "2.0-dev"
                 }
             },
             "autoload": {
@@ -49,7 +49,7 @@
                 "parser",
                 "php"
             ],
-            "time": "2015-07-14 17:31:05"
+            "time": "2015-07-14 19:13:42"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -200,6 +200,160 @@
                 }
             ],
             "time": "2015-07-18 13:58:32"
+        },
+        {
+            "name": "zendframework/zend-code",
+            "version": "2.5.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zendframework/zend-code.git",
+                "reference": "a97ef49f82496fabc3b7379b37f6bbff925b58b8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zendframework/zend-code/zipball/a97ef49f82496fabc3b7379b37f6bbff925b58b8",
+                "reference": "a97ef49f82496fabc3b7379b37f6bbff925b58b8",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5",
+                "zendframework/zend-eventmanager": "~2.5"
+            },
+            "require-dev": {
+                "doctrine/common": ">=2.1",
+                "fabpot/php-cs-fixer": "1.7.*",
+                "phpunit/phpunit": "~4.0",
+                "zendframework/zend-stdlib": "~2.5",
+                "zendframework/zend-version": "~2.5"
+            },
+            "suggest": {
+                "doctrine/common": "Doctrine\\Common >=2.1 for annotation features",
+                "zendframework/zend-stdlib": "Zend\\Stdlib component"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.5-dev",
+                    "dev-develop": "2.6-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Zend\\Code\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "provides facilities to generate arbitrary code using an object oriented interface",
+            "homepage": "https://github.com/zendframework/zend-code",
+            "keywords": [
+                "code",
+                "zf2"
+            ],
+            "time": "2015-07-21 22:40:59"
+        },
+        {
+            "name": "zendframework/zend-eventmanager",
+            "version": "2.5.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zendframework/zend-eventmanager.git",
+                "reference": "135af03d07fd048c322259aab6611d2be290475c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zendframework/zend-eventmanager/zipball/135af03d07fd048c322259aab6611d2be290475c",
+                "reference": "135af03d07fd048c322259aab6611d2be290475c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5",
+                "zendframework/zend-stdlib": "~2.5"
+            },
+            "require-dev": {
+                "fabpot/php-cs-fixer": "1.7.*",
+                "phpunit/phpunit": "~4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.5-dev",
+                    "dev-develop": "2.6-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Zend\\EventManager\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "homepage": "https://github.com/zendframework/zend-eventmanager",
+            "keywords": [
+                "eventmanager",
+                "zf2"
+            ],
+            "time": "2015-07-16 19:00:49"
+        },
+        {
+            "name": "zendframework/zend-stdlib",
+            "version": "2.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zendframework/zend-stdlib.git",
+                "reference": "a35758803fc9051ec1aff43989e679b6b451b1b4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zendframework/zend-stdlib/zipball/a35758803fc9051ec1aff43989e679b6b451b1b4",
+                "reference": "a35758803fc9051ec1aff43989e679b6b451b1b4",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5"
+            },
+            "require-dev": {
+                "fabpot/php-cs-fixer": "1.7.*",
+                "phpunit/phpunit": "~4.0",
+                "zendframework/zend-config": "~2.5",
+                "zendframework/zend-eventmanager": "~2.5",
+                "zendframework/zend-filter": "~2.5",
+                "zendframework/zend-inputfilter": "~2.5",
+                "zendframework/zend-serializer": "~2.5",
+                "zendframework/zend-servicemanager": "~2.5"
+            },
+            "suggest": {
+                "zendframework/zend-eventmanager": "To support aggregate hydrator usage",
+                "zendframework/zend-filter": "To support naming strategy hydrator usage",
+                "zendframework/zend-serializer": "Zend\\Serializer component",
+                "zendframework/zend-servicemanager": "To support hydrator plugin manager usage"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.6-dev",
+                    "dev-develop": "2.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Zend\\Stdlib\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "homepage": "https://github.com/zendframework/zend-stdlib",
+            "keywords": [
+                "stdlib",
+                "zf2"
+            ],
+            "time": "2015-07-21 17:08:05"
         }
     ],
     "packages-dev": [
@@ -1473,7 +1627,9 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
-        "phpdocumentor/type-resolver": 20
+        "nikic/php-parser": 20,
+        "phpdocumentor/type-resolver": 20,
+        "zendframework/zend-code": 20
     },
     "prefer-stable": true,
     "prefer-lowest": false,

--- a/src/NodeCompiler/CompileNodeToValue.php
+++ b/src/NodeCompiler/CompileNodeToValue.php
@@ -21,6 +21,11 @@ class CompileNodeToValue
             return $node->value;
         }
 
+        // common edge case - negative numbers
+        if ($node instanceof Node\Expr\UnaryMinus) {
+            return $this->__invoke($node->expr) * -1;
+        }
+
         if ($node instanceof Node\Expr\Array_) {
             $compiledArray = [];
             foreach ($node->items as $arrayItem) {

--- a/src/Reflection/ReflectionClass.php
+++ b/src/Reflection/ReflectionClass.php
@@ -416,16 +416,11 @@ class ReflectionClass implements Reflection
     /**
      * Is this an internal class?
      *
-     * Note - we cannot reflect on internal classes (as there is no PHP source
-     * code we can access. This means, at present, we can only EVER return false
-     * from this function.
-     *
-     * @see https://github.com/Roave/BetterReflection/issues/38
      * @return bool
      */
     public function isInternal()
     {
-        return false;
+        return $this->locatedSource->isInternal();
     }
 
     /**

--- a/src/Reflection/ReflectionClass.php
+++ b/src/Reflection/ReflectionClass.php
@@ -9,8 +9,11 @@ use BetterReflection\Reflection\Exception\NotAnObject;
 use BetterReflection\Reflection\Exception\NotAString;
 use BetterReflection\Reflector\ClassReflector;
 use BetterReflection\Reflector\Reflector;
+use BetterReflection\SourceLocator\AggregateSourceLocator;
 use BetterReflection\SourceLocator\AutoloadSourceLocator;
+use BetterReflection\SourceLocator\EvaledCodeSourceLocator;
 use BetterReflection\SourceLocator\LocatedSource;
+use BetterReflection\SourceLocator\PhpInternalSourceLocator;
 use BetterReflection\TypesFinder\FindTypeFromAst;
 use phpDocumentor\Reflection\Fqsen;
 use phpDocumentor\Reflection\Types\Object_;
@@ -77,8 +80,11 @@ class ReflectionClass implements Reflection
 
     public static function createFromName($className)
     {
-        // @TODO consider having one main "DefaultReflector"
-        return (new ClassReflector(new AutoloadSourceLocator()))->reflect($className);
+        return (new ClassReflector(new AggregateSourceLocator([
+            new PhpInternalSourceLocator(),
+            new EvaledCodeSourceLocator(),
+            new AutoloadSourceLocator(),
+        ])))->reflect($className);
     }
 
     /**
@@ -338,7 +344,7 @@ class ReflectionClass implements Reflection
     }
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getFileName()
     {

--- a/src/Reflector/Generic.php
+++ b/src/Reflector/Generic.php
@@ -7,6 +7,7 @@ use BetterReflection\Identifier\IdentifierType;
 use BetterReflection\Reflection\ReflectionFunction;
 use BetterReflection\SourceLocator\AggregateSourceLocator;
 use BetterReflection\SourceLocator\LocatedSource;
+use BetterReflection\SourceLocator\PhpInternalSourceLocator;
 use BetterReflection\SourceLocator\SourceLocator;
 use BetterReflection\Reflection\ReflectionClass;
 use BetterReflection\Reflection\Reflection;
@@ -31,13 +32,18 @@ class Generic
      * specified and returns the \Reflector.
      *
      * @param Identifier $identifier
+     * @param bool $autoReflectInternals
      * @return Reflection
      */
-    public function reflect(Identifier $identifier)
+    public function reflect(Identifier $identifier, $autoReflectInternals = true)
     {
         $aggregate = $this->sourceLocator;
         if (!($aggregate instanceof AggregateSourceLocator)) {
             $aggregate = new AggregateSourceLocator([$this->sourceLocator]);
+        }
+
+        if ($autoReflectInternals) {
+            $aggregate = new AggregateSourceLocator([$aggregate, new PhpInternalSourceLocator()]);
         }
 
         foreach ($aggregate($identifier) as $locatedSource) {

--- a/src/Reflector/Generic.php
+++ b/src/Reflector/Generic.php
@@ -41,6 +41,10 @@ class Generic
         }
 
         foreach ($aggregate($identifier) as $locatedSource) {
+            if (null === $locatedSource) {
+                continue;
+            }
+
             try {
                 return $this->reflectFromLocatedSource($identifier, $locatedSource);
             }

--- a/src/Reflector/Generic.php
+++ b/src/Reflector/Generic.php
@@ -22,9 +22,18 @@ class Generic
      */
     private $sourceLocator;
 
+    /**
+     * @var Parser
+     */
+    private $parser;
+
     public function __construct(SourceLocator $sourceLocator)
     {
         $this->sourceLocator = $sourceLocator;
+        $this->parser        = new Parser\Multiple([
+            new Parser\Php7(new Lexer()),
+            new Parser\Php5(new Lexer())
+        ]);
     }
 
     /**
@@ -185,7 +194,7 @@ class Generic
     private function getReflections(LocatedSource $locatedSource, Identifier $identifier)
     {
         return $this->reflectFromTree(
-            (new Parser(new Lexer()))->parse($locatedSource->getSource()),
+            $this->parser->parse($locatedSource->getSource()),
             $identifier,
             $locatedSource
         );

--- a/src/SourceLocator/AggregateSourceLocator.php
+++ b/src/SourceLocator/AggregateSourceLocator.php
@@ -30,7 +30,13 @@ class AggregateSourceLocator implements SourceLocator
     public function __invoke(Identifier $identifier)
     {
         foreach ($this->sourceLocators as $sourceLocator) {
-            yield $sourceLocator->__invoke($identifier);
+            if ($sourceLocator instanceof self) {
+                foreach ($sourceLocator->__invoke($identifier) as $value) {
+                    yield $value;
+                }
+                continue;
+            }
+            yield $sourceLocator($identifier);
         }
     }
 }

--- a/src/SourceLocator/AutoloadSourceLocator.php
+++ b/src/SourceLocator/AutoloadSourceLocator.php
@@ -22,7 +22,7 @@ class AutoloadSourceLocator implements SourceLocator
 
     /**
      * @param Identifier $identifier
-     * @return LocatedSource
+     * @return LocatedSource|null
      * @throws Exception\AutoloadFailure
      */
     public function __invoke(Identifier $identifier)
@@ -30,11 +30,7 @@ class AutoloadSourceLocator implements SourceLocator
         $potentiallyLocatedFile = $this->locateIdentifier($identifier);
 
         if (!$potentiallyLocatedFile) {
-            throw new Exception\AutoloadFailure(sprintf(
-                'Unable to autoload the %s called %s',
-                $identifier->getType()->getName(),
-                $identifier->getName()
-            ));
+            return null;
         }
 
         return new LocatedSource(
@@ -58,8 +54,6 @@ class AutoloadSourceLocator implements SourceLocator
         if ($identifier->isFunction()) {
             return $this->locateFunctionByName($identifier->getName());
         }
-
-        throw new Exception\UnloadableIdentifierType('AutoloadSourceLocator cannot locate ' . $identifier->getType()->getName());
     }
 
     /**

--- a/src/SourceLocator/ComposerSourceLocator.php
+++ b/src/SourceLocator/ComposerSourceLocator.php
@@ -27,20 +27,18 @@ class ComposerSourceLocator implements SourceLocator
 
     /**
      * @param Identifier $identifier
-     * @return LocatedSource
+     * @return LocatedSource|null
      */
     public function __invoke(Identifier $identifier)
     {
         if ($identifier->getType()->getName() !== IdentifierType::IDENTIFIER_CLASS) {
-            throw new \LogicException(__CLASS__ . ' can only be used to locate classes');
+            return null;
         }
 
         $filename = $this->classLoader->findFile($identifier->getName());
 
         if (!$filename) {
-            throw new \UnexpectedValueException(sprintf(
-                'Could not locate file to load "%s"', $identifier->getName()
-            ));
+            return null;
         }
 
         return new LocatedSource(

--- a/src/SourceLocator/EvaledCodeSourceLocator.php
+++ b/src/SourceLocator/EvaledCodeSourceLocator.php
@@ -6,7 +6,7 @@ use BetterReflection\Identifier\Identifier;
 use Zend\Code\Generator\ClassGenerator;
 use Zend\Code\Reflection\ClassReflection;
 
-class PhpInternalSourceLocator implements SourceLocator
+class EvaledCodeSourceLocator implements SourceLocator
 {
     /**
      * {@inheritDoc}
@@ -17,7 +17,7 @@ class PhpInternalSourceLocator implements SourceLocator
             return null;
         }
 
-        return new InternalLocatedSource(
+        return new EvaledLocatedSource(
             "<?php\n\n" . ClassGenerator::fromReflection(new ClassReflection($name))->generate()
         );
     }
@@ -41,6 +41,6 @@ class PhpInternalSourceLocator implements SourceLocator
 
         $reflection = new \ReflectionClass($name);
 
-        return $reflection->isInternal() ? $reflection->getName() : null;
+        return $reflection->getFileName() ? $reflection->getName() : null;
     }
 }

--- a/src/SourceLocator/EvaledLocatedSource.php
+++ b/src/SourceLocator/EvaledLocatedSource.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace BetterReflection\SourceLocator;
+
+/**
+ * {@inheritDoc}
+ */
+class EvaledLocatedSource extends LocatedSource
+{
+    /**
+     * @param string $fileName
+     */
+    public function __construct($fileName)
+    {
+        parent::__construct($fileName, null);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function isEvaled()
+    {
+        return true;
+    }
+}

--- a/src/SourceLocator/Exception/AutoloadFailure.php
+++ b/src/SourceLocator/Exception/AutoloadFailure.php
@@ -1,7 +1,0 @@
-<?php
-
-namespace BetterReflection\SourceLocator\Exception;
-
-class AutoloadFailure extends \RuntimeException
-{
-}

--- a/src/SourceLocator/Exception/NotInternalClass.php
+++ b/src/SourceLocator/Exception/NotInternalClass.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace BetterReflection\SourceLocator\Exception;
+
+class NotInternalClass extends \LogicException
+{
+}

--- a/src/SourceLocator/Exception/UnloadableIdentifierType.php
+++ b/src/SourceLocator/Exception/UnloadableIdentifierType.php
@@ -1,7 +1,0 @@
-<?php
-
-namespace BetterReflection\SourceLocator\Exception;
-
-class UnloadableIdentifierType extends \InvalidArgumentException
-{
-}

--- a/src/SourceLocator/InternalLocatedSource.php
+++ b/src/SourceLocator/InternalLocatedSource.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace BetterReflection\SourceLocator;
+
+/**
+ * {@inheritDoc}
+ */
+class InternalLocatedSource extends LocatedSource
+{
+    /**
+     * @param string $source
+     */
+    public function __construct($source)
+    {
+        parent::__construct($source, null);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function isInternal()
+    {
+        return true;
+    }
+}

--- a/src/SourceLocator/LocatedSource.php
+++ b/src/SourceLocator/LocatedSource.php
@@ -7,8 +7,6 @@ namespace BetterReflection\SourceLocator;
  */
 class LocatedSource
 {
-    const INTERNAL_SOURCE_MAGIC_CONST = 'BetterReflectionPhpInternalSourceStub';
-
     /**
      * @var string
      */
@@ -19,6 +17,10 @@ class LocatedSource
      */
     private $filename;
 
+    /**
+     * @param string      $source
+     * @param string|null $filename
+     */
     public function __construct($source, $filename)
     {
         if (!is_string($source) || empty($source)) {
@@ -33,7 +35,7 @@ class LocatedSource
             );
         }
 
-        if (null !== $filename && self::INTERNAL_SOURCE_MAGIC_CONST !== $filename) {
+        if (null !== $filename) {
             if (empty($filename)) {
                 throw new Exception\InvalidFileLocation('Filename was empty');
             }
@@ -78,6 +80,16 @@ class LocatedSource
      */
     public function isInternal()
     {
-        return $this->filename === self::INTERNAL_SOURCE_MAGIC_CONST;
+        return false;
+    }
+
+    /**
+     * Is the located source produced by eval() or function_create()?
+     *
+     * @return bool
+     */
+    public function isEvaled()
+    {
+        return false;
     }
 }

--- a/src/SourceLocator/LocatedSource.php
+++ b/src/SourceLocator/LocatedSource.php
@@ -7,6 +7,8 @@ namespace BetterReflection\SourceLocator;
  */
 class LocatedSource
 {
+    const INTERNAL_SOURCE_MAGIC_CONST = 'BetterReflectionPhpInternalSourceStub';
+
     /**
      * @var string
      */
@@ -31,7 +33,7 @@ class LocatedSource
             );
         }
 
-        if (null !== $filename) {
+        if (null !== $filename && self::INTERNAL_SOURCE_MAGIC_CONST !== $filename) {
             if (empty($filename)) {
                 throw new Exception\InvalidFileLocation('Filename was empty');
             }
@@ -67,5 +69,15 @@ class LocatedSource
     public function getFileName()
     {
         return $this->filename;
+    }
+
+    /**
+     * Is the located source in PHP internals?
+     *
+     * @return bool
+     */
+    public function isInternal()
+    {
+        return $this->filename === self::INTERNAL_SOURCE_MAGIC_CONST;
     }
 }

--- a/src/SourceLocator/PhpInternalSourceLocator.php
+++ b/src/SourceLocator/PhpInternalSourceLocator.php
@@ -8,23 +8,19 @@ class PhpInternalSourceLocator implements SourceLocator
 {
     public function __invoke(Identifier $identifier)
     {
-        if (!$identifier->isClass()) {
-            throw new \LogicException(__CLASS__ . ' can only be used to locate classes');
-        }
-
         $methodName = str_replace('\\', '__', $identifier->getName());
         if (!method_exists($this, $methodName)) {
-            throw new Exception\NotInternalClass(sprintf(
-                '%s was not a defined internal class, or stub was not found',
-                $identifier->getName()
-            ));
+            return new LocatedSource('<?php', LocatedSource::INTERNAL_SOURCE_MAGIC_CONST);
         }
 
-        return new LocatedSource($this->$methodName(), null);
+        return new LocatedSource(
+            '<?php ' . $this->$methodName(),
+            LocatedSource::INTERNAL_SOURCE_MAGIC_CONST
+        );
     }
 
     public function stdClass()
     {
-        return '<?php class stdClass {}';
+        return 'class stdClass {}';
     }
 }

--- a/src/SourceLocator/PhpInternalSourceLocator.php
+++ b/src/SourceLocator/PhpInternalSourceLocator.php
@@ -8,9 +8,13 @@ class PhpInternalSourceLocator implements SourceLocator
 {
     public function __invoke(Identifier $identifier)
     {
+        if (!$identifier->isClass()) {
+            return null;
+        }
+
         $methodName = str_replace('\\', '__', $identifier->getName());
         if (!method_exists($this, $methodName)) {
-            return new LocatedSource('<?php', LocatedSource::INTERNAL_SOURCE_MAGIC_CONST);
+            return null;
         }
 
         return new LocatedSource(

--- a/src/SourceLocator/PhpInternalSourceLocator.php
+++ b/src/SourceLocator/PhpInternalSourceLocator.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace BetterReflection\SourceLocator;
+
+use BetterReflection\Identifier\Identifier;
+
+class PhpInternalSourceLocator implements SourceLocator
+{
+    public function __invoke(Identifier $identifier)
+    {
+        if (!$identifier->isClass()) {
+            throw new \LogicException(__CLASS__ . ' can only be used to locate classes');
+        }
+
+        $methodName = str_replace('\\', '__', $identifier->getName());
+        if (!method_exists($this, $methodName)) {
+            throw new Exception\NotInternalClass(sprintf(
+                '%s was not a defined internal class, or stub was not found',
+                $identifier->getName()
+            ));
+        }
+
+        return new LocatedSource($this->$methodName(), null);
+    }
+
+    public function stdClass()
+    {
+        return '<?php class stdClass {}';
+    }
+}

--- a/src/SourceLocator/SourceLocator.php
+++ b/src/SourceLocator/SourceLocator.php
@@ -12,7 +12,7 @@ interface SourceLocator
      * This method should return a LocatedSource value object
      *
      * @param Identifier $identifier
-     * @return LocatedSource
+     * @return LocatedSource|null
      */
     public function __invoke(Identifier $identifier);
 }

--- a/test/unit/NodeCompiler/CompileNodeToValueTest.php
+++ b/test/unit/NodeCompiler/CompileNodeToValueTest.php
@@ -27,6 +27,8 @@ class CompileNodeToValueTest extends \PHPUnit_Framework_TestCase
             ['["foo","bar"]', ['foo', 'bar']],
             ['[1 => "foo", 2 => "bar"]', [1 => 'foo', 2 => 'bar']],
             ['["foo" => "bar"]', ['foo' => 'bar']],
+            ['-1', -1],
+            ['-123.456', -123.456],
         ];
     }
 
@@ -37,7 +39,7 @@ class CompileNodeToValueTest extends \PHPUnit_Framework_TestCase
      */
     public function testCompilations($phpCode, $expectedValue)
     {
-        $node = (new Parser(new Lexer()))->parse('<?php ' . $phpCode . ';');
+        $node = (new Parser\Php7(new Lexer()))->parse('<?php ' . $phpCode . ';');
 
         $actualValue = (new CompileNodeToValue())->__invoke($node[0]);
 

--- a/test/unit/Reflection/ReflectionClassTest.php
+++ b/test/unit/Reflection/ReflectionClassTest.php
@@ -259,6 +259,15 @@ class ReflectionClassTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($classInfo->isUserDefined());
     }
 
+    public function testIsInternalWithInternalClass()
+    {
+        $reflector = new ClassReflector($this->getComposerLocator());
+        $classInfo = $reflector->reflect('stdClass');
+
+        $this->assertTrue($classInfo->isInternal());
+        $this->assertFalse($classInfo->isUserDefined());
+    }
+
     public function testIsAbstract()
     {
         $reflector = new ClassReflector(new SingleFileSourceLocator(__DIR__ . '/../Fixture/ExampleClass.php'));

--- a/test/unit/Reflection/ReflectionClassTest.php
+++ b/test/unit/Reflection/ReflectionClassTest.php
@@ -33,6 +33,20 @@ class ReflectionClassTest extends \PHPUnit_Framework_TestCase
         return new ComposerSourceLocator($loader);
     }
 
+    public function testCanReflectInternalClassWithDefaultLocator()
+    {
+        $this->assertSame(\stdClass::class, ReflectionClass::createFromName(\stdClass::class)->getName());
+    }
+
+    public function testCanReflectEvaledClassWithDefaultLocator()
+    {
+        $className = uniqid('foo');
+
+        eval('class ' . $className . '{}');
+
+        $this->assertSame($className, ReflectionClass::createFromName($className)->getName());
+    }
+
     public function testClassNameMethodsWithNamespace()
     {
         $reflector = new ClassReflector($this->getComposerLocator());

--- a/test/unit/Reflection/ReflectionClassTest.php
+++ b/test/unit/Reflection/ReflectionClassTest.php
@@ -250,7 +250,7 @@ class ReflectionClassTest extends \PHPUnit_Framework_TestCase
         $this->assertCount(3, $defaultProperties);
     }
 
-    public function testIsInternal()
+    public function testIsInternalWithUserDefinedClass()
     {
         $reflector = new ClassReflector($this->getComposerLocator());
         $classInfo = $reflector->reflect('\BetterReflectionTest\Fixture\ExampleClass');

--- a/test/unit/SourceLocator/AutoloadSourceLocatorTest.php
+++ b/test/unit/SourceLocator/AutoloadSourceLocatorTest.php
@@ -5,6 +5,7 @@ namespace BetterReflectionTest\SourceLocator;
 use BetterReflection\Identifier\Identifier;
 use BetterReflection\Identifier\IdentifierType;
 use BetterReflection\Reflector\ClassReflector;
+use BetterReflection\Reflector\Exception\IdentifierNotFound;
 use BetterReflection\Reflector\FunctionReflector;
 use BetterReflection\SourceLocator\AutoloadSourceLocator;
 use BetterReflection\SourceLocator\Exception\AutoloadFailure;
@@ -61,7 +62,7 @@ class AutoloadSourceLocatorTest extends \PHPUnit_Framework_TestCase
         $reflector->reflect('this function does not exist, hopefully');
     }
 
-    public function testExceptionThrownWhenInvalidTypeGiven()
+    public function testNullReturnedWhenInvalidTypeGiven()
     {
         $locator = new AutoloadSourceLocator();
 
@@ -71,16 +72,15 @@ class AutoloadSourceLocatorTest extends \PHPUnit_Framework_TestCase
         $prop->setAccessible(true);
         $prop->setValue($type, 'nonsense');
 
-        $this->setExpectedException(UnloadableIdentifierType::class, 'AutoloadSourceLocator cannot locate nonsense');
         $identifier = new Identifier('foo', $type);
-        $locator->__invoke($identifier);
+        $this->assertNull($locator->__invoke($identifier));
     }
 
     public function testExceptionThrownWhenUnableToAutoload()
     {
         $reflector = new ClassReflector(new AutoloadSourceLocator());
 
-        $this->setExpectedException(AutoloadFailure::class);
+        $this->setExpectedException(IdentifierNotFound::class);
         $reflector->reflect('Some\Class\That\Cannot\Exist');
     }
 }

--- a/test/unit/SourceLocator/ComposerSourceLocatorTest.php
+++ b/test/unit/SourceLocator/ComposerSourceLocatorTest.php
@@ -60,11 +60,10 @@ class ComposerSourceLocatorTest extends \PHPUnit_Framework_TestCase
         /** @var ClassLoader $loader */
         $locator = new ComposerSourceLocator($loader);
 
-        $this->setExpectedException(UnexpectedValueException::class);
-        $locator->__invoke(new Identifier(
+        $this->assertNull($locator->__invoke(new Identifier(
             $className,
             new IdentifierType(IdentifierType::IDENTIFIER_CLASS)
-        ));
+        )));
     }
 
     public function testInvokeThrowsExceptionWhenTryingToLocateFunction()
@@ -74,10 +73,9 @@ class ComposerSourceLocatorTest extends \PHPUnit_Framework_TestCase
         /** @var ClassLoader $loader */
         $locator = new ComposerSourceLocator($loader);
 
-        $this->setExpectedException(LogicException::class);
-        $locator->__invoke(new Identifier(
+        $this->assertNull($locator->__invoke(new Identifier(
             'foo',
             new IdentifierType(IdentifierType::IDENTIFIER_FUNCTION)
-        ));
+        )));
     }
 }

--- a/test/unit/SourceLocator/EvaledCodeSourceLocatorTest.php
+++ b/test/unit/SourceLocator/EvaledCodeSourceLocatorTest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace BetterReflectionTest\SourceLocator;
+
+use BetterReflection\Identifier\Identifier;
+use BetterReflection\Identifier\IdentifierType;
+use BetterReflection\Reflection\ReflectionClass;
+use BetterReflection\Reflector\ClassReflector;
+use BetterReflection\SourceLocator\EvaledCodeSourceLocator;
+use BetterReflection\SourceLocator\EvaledLocatedSource;
+
+/**
+ * @covers \BetterReflection\SourceLocator\EvaledCodeSourceLocator
+ */
+class EvaledCodeSourceLocatorTest extends \PHPUnit_Framework_TestCase
+{
+    public function testCanReflectEvaledClass()
+    {
+        $className = uniqid('foo');
+
+        eval('class ' . $className . ' {function foo(){}}');
+
+        $locator = new EvaledCodeSourceLocator();
+
+        $source = $locator->__invoke(
+            new Identifier($className, new IdentifierType(IdentifierType::IDENTIFIER_CLASS))
+        );
+
+        $this->assertInstanceOf(EvaledLocatedSource::class, $source);
+        $this->assertStringMatchesFormat('%Aclass%A' . $className . '%A', $source->getSource());
+    }
+
+    public function testCanReflectEvaledInterface()
+    {
+        $interfaceName = uniqid('foo');
+
+        eval('interface ' . $interfaceName . ' {function foo();}');
+
+        $locator = new EvaledCodeSourceLocator();
+
+        $source = $locator->__invoke(
+            new Identifier($interfaceName, new IdentifierType(IdentifierType::IDENTIFIER_CLASS))
+        );
+
+        $this->assertInstanceOf(EvaledLocatedSource::class, $source);
+        $this->assertStringMatchesFormat('%Aclass%A' . $interfaceName . '%A', $source->getSource());
+    }
+
+    public function testCanReflectEvaledTrait()
+    {
+        $traitName = uniqid('foo');
+
+        eval('trait ' . $traitName . ' {function foo(){}}');
+
+        $locator = new EvaledCodeSourceLocator();
+
+        $source = $locator->__invoke(
+            new Identifier($traitName, new IdentifierType(IdentifierType::IDENTIFIER_CLASS))
+        );
+
+        $this->assertInstanceOf(EvaledLocatedSource::class, $source);
+        $this->assertStringMatchesFormat('%Aclass%A' . $traitName . '%A', $source->getSource());
+    }
+
+    public function testCanReflectEvaledLocatedSourceClass()
+    {
+        /* @var $class */
+        $reflector = (new ClassReflector(new EvaledCodeSourceLocator()));
+        $className = uniqid('foo');
+
+        eval('class ' . $className . ' {function foo($bar = "baz") {}}');
+
+        $class = $reflector->reflect($className);
+
+        $this->assertInstanceOf(ReflectionClass::class, $class);
+        $this->assertSame($className, $class->getName());
+        $this->assertFalse($class->isInternal());
+        $this->assertTrue($class->isUserDefined());
+        $this->assertNull($class->getFileName());
+        $this->assertCount(1, $class->getMethods());
+    }
+}

--- a/test/unit/SourceLocator/EvaledLocatedSourceTest.php
+++ b/test/unit/SourceLocator/EvaledLocatedSourceTest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace BetterReflectionTest\SourceLocator;
+
+use BetterReflection\SourceLocator\EvaledLocatedSource;
+
+/**
+ * @covers \BetterReflection\SourceLocator\EvaledLocatedSource
+ */
+class EvaledLocatedSourceTest extends \PHPUnit_Framework_TestCase
+{
+    public function testInternalsLocatedSource()
+    {
+        $locatedSource = new EvaledLocatedSource('foo');
+
+        $this->assertSame('foo', $locatedSource->getSource());
+        $this->assertNull($locatedSource->getFileName());
+        $this->assertFalse($locatedSource->isInternal());
+        $this->assertTrue($locatedSource->isEvaled());
+    }
+}

--- a/test/unit/SourceLocator/InternalLocatedSourceTest.php
+++ b/test/unit/SourceLocator/InternalLocatedSourceTest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace BetterReflectionTest\SourceLocator;
+
+use BetterReflection\SourceLocator\InternalLocatedSource;
+
+/**
+ * @covers \BetterReflection\SourceLocator\InternalLocatedSource
+ */
+class InternalLocatedSourceTest extends \PHPUnit_Framework_TestCase
+{
+    public function testInternalsLocatedSource()
+    {
+        $locatedSource = new InternalLocatedSource('foo');
+
+        $this->assertSame('foo', $locatedSource->getSource());
+        $this->assertNull($locatedSource->getFileName());
+    }
+}

--- a/test/unit/SourceLocator/LocatedSourceTest.php
+++ b/test/unit/SourceLocator/LocatedSourceTest.php
@@ -19,6 +19,7 @@ class LocatedSourceTest extends \PHPUnit_Framework_TestCase
 
         $this->assertSame($source, $locatedSource->getSource());
         $this->assertSame($file, $locatedSource->getFileName());
+        $this->assertFalse($locatedSource->isEvaled());
     }
 
     public function testValuesWithNullFilename()
@@ -29,6 +30,7 @@ class LocatedSourceTest extends \PHPUnit_Framework_TestCase
 
         $this->assertSame($source, $locatedSource->getSource());
         $this->assertNull($locatedSource->getFileName());
+        $this->assertFalse($locatedSource->isEvaled());
     }
 
     /**

--- a/test/unit/SourceLocator/PhpInternalSourceLocatorTest.php
+++ b/test/unit/SourceLocator/PhpInternalSourceLocatorTest.php
@@ -7,7 +7,7 @@ use BetterReflection\Reflector\ClassReflector;
 use BetterReflection\SourceLocator\PhpInternalSourceLocator;
 
 /**
- * @covers \BetterReflection\SourceLocator\AggregateSourceLocator
+ * @covers \BetterReflection\SourceLocator\PhpInternalSourceLocator
  */
 class PhpInternalSourceLocatorTest extends \PHPUnit_Framework_TestCase
 {

--- a/test/unit/SourceLocator/PhpInternalSourceLocatorTest.php
+++ b/test/unit/SourceLocator/PhpInternalSourceLocatorTest.php
@@ -18,5 +18,7 @@ class PhpInternalSourceLocatorTest extends \PHPUnit_Framework_TestCase
 
         $this->assertInstanceOf(ReflectionClass::class, $classInfo);
         $this->assertSame('stdClass', $classInfo->getName());
+        $this->assertTrue($classInfo->isInternal());
+        $this->assertFalse($classInfo->isUserDefined());
     }
 }

--- a/test/unit/SourceLocator/PhpInternalSourceLocatorTest.php
+++ b/test/unit/SourceLocator/PhpInternalSourceLocatorTest.php
@@ -2,23 +2,96 @@
 
 namespace BetterReflectionTest\SourceLocator;
 
+use BetterReflection\Identifier\Identifier;
+use BetterReflection\Identifier\IdentifierType;
 use BetterReflection\Reflection\ReflectionClass;
 use BetterReflection\Reflector\ClassReflector;
+use BetterReflection\SourceLocator\InternalLocatedSource;
 use BetterReflection\SourceLocator\PhpInternalSourceLocator;
+use ReflectionClass as PhpReflectionClass;
 
 /**
  * @covers \BetterReflection\SourceLocator\PhpInternalSourceLocator
  */
 class PhpInternalSourceLocatorTest extends \PHPUnit_Framework_TestCase
 {
-    public function testStdClass()
+    /**
+     * @dataProvider internalSymbolsProvider
+     *
+     * @param string $className
+     */
+    public function testCanFetchInternalLocatedSource($className)
     {
-        $reflector = new ClassReflector(new PhpInternalSourceLocator());
-        $classInfo = $reflector->reflect('\stdClass');
+        $locator = new PhpInternalSourceLocator();
 
-        $this->assertInstanceOf(ReflectionClass::class, $classInfo);
-        $this->assertSame('stdClass', $classInfo->getName());
-        $this->assertTrue($classInfo->isInternal());
-        $this->assertFalse($classInfo->isUserDefined());
+        try {
+            $source = $locator->__invoke(
+                new Identifier($className, new IdentifierType(IdentifierType::IDENTIFIER_CLASS))
+            );
+
+            $this->assertInstanceOf(InternalLocatedSource::class, $source);
+            $this->assertNotEmpty($source->getSource());
+        } catch (\ReflectionException $e) {
+            $this->markTestIncomplete(sprintf(
+                'Can\'t reflect class "%s" due to an internal reflection exception: "%s". Consider adding a stub class',
+                $className,
+                $e->getMessage()
+            ));
+        }
+
+    }
+
+    /**
+     * @dataProvider internalSymbolsProvider
+     *
+     * @param string $className
+     */
+    public function testCanReflectInternalClasses($className)
+    {
+        /* @var $class */
+        $reflector = (new ClassReflector(new PhpInternalSourceLocator()));
+
+        try {
+            $class = $reflector->reflect($className);
+        } catch (\ReflectionException $e) {
+            $this->markTestIncomplete(sprintf(
+                'Can\'t reflect class "%s" due to an internal reflection exception: "%s". Consider adding a stub class',
+                $className,
+                $e->getMessage()
+            ));
+        }
+
+        $this->assertInstanceOf(ReflectionClass::class, $class);
+        $this->assertSame($className, $class->getName());
+        $this->assertTrue($class->isInternal());
+        $this->assertFalse($class->isUserDefined());
+    }
+
+    /**
+     * @return string[] internal symbols
+     */
+    public function internalSymbolsProvider()
+    {
+        $allSymbols = array_merge(
+            get_declared_classes(),
+            get_declared_interfaces(),
+            get_declared_traits()
+        );
+
+        $indexedSymbols = array_combine($allSymbols, $allSymbols);
+
+        return array_map(
+            function ($symbol) {
+                return [$symbol];
+            },
+            array_filter(
+                $indexedSymbols,
+                function ($symbol) {
+                    $reflection = new PhpReflectionClass($symbol);
+
+                    return $reflection->isInternal();
+                }
+            )
+        );
     }
 }

--- a/test/unit/SourceLocator/PhpInternalSourceLocatorTest.php
+++ b/test/unit/SourceLocator/PhpInternalSourceLocatorTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace BetterReflectionTest\SourceLocator;
+
+use BetterReflection\Reflection\ReflectionClass;
+use BetterReflection\Reflector\ClassReflector;
+use BetterReflection\SourceLocator\PhpInternalSourceLocator;
+
+/**
+ * @covers \BetterReflection\SourceLocator\AggregateSourceLocator
+ */
+class PhpInternalSourceLocatorTest extends \PHPUnit_Framework_TestCase
+{
+    public function testStdClass()
+    {
+        $reflector = new ClassReflector(new PhpInternalSourceLocator());
+        $classInfo = $reflector->reflect('\stdClass');
+
+        $this->assertInstanceOf(ReflectionClass::class, $classInfo);
+        $this->assertSame('stdClass', $classInfo->getName());
+    }
+}


### PR DESCRIPTION
This PR fixes #38

* `AggregateSourceLocator`s can be nested now (`Reflector\Generic` will recurse through them in a flat ordered way)
* I had to modify the behaviour of the `SourceLocator`s slightly so that they don't throw exceptions, but merely return null. This is so that when we loop through the `AggregateSourceLocator`, we don't break the loop.
* By default `PhpInternalSourceLocator` gets added to all calls to `reflect()`. Can be disabled by a paramter
* A new magic const is defined as a flag to notify `ReflectionClass` that the `LocatedSource` originated from the `PhpInternalSourceLocator` (thus `isInternal() === true`)

### Todo
* [x] Needs the rest of the internal classes implemented...
* [x] ~~~Need to implement functions too...~~~
* [x] More path coverage for `PhpInternalSourceLocator`