### PR TITLE
Increase coverage again

### DIFF
--- a/test/unit/Reflection/ReflectionFunctionAbstractTest.php
+++ b/test/unit/Reflection/ReflectionFunctionAbstractTest.php
@@ -2,10 +2,13 @@
 
 namespace BetterReflectionTest\Reflection;
 
+use BetterReflection\Reflection\ReflectionFunction;
 use BetterReflection\Reflection\ReflectionParameter;
 use BetterReflection\Reflector\FunctionReflector;
+use BetterReflection\SourceLocator\LocatedSource;
 use BetterReflection\SourceLocator\SingleFileSourceLocator;
 use BetterReflection\SourceLocator\StringSourceLocator;
+use PhpParser\Node\Stmt\Function_;
 
 /**
  * @covers \BetterReflection\Reflection\ReflectionFunctionAbstract
@@ -255,5 +258,14 @@ class ReflectionFunctionAbstractTest extends \PHPUnit_Framework_TestCase
         $functionInfo = $reflector->reflect('BetterReflectionTest\Fixture\myFunction');
 
         $this->assertContains('Fixture/Functions.php', $functionInfo->getFileName());
+    }
+
+    public function testGetLocatedSource()
+    {
+        $node = new Function_('foo');
+        $locatedSource = new LocatedSource('<?php function foo() {}', null);
+        $functionInfo = ReflectionFunction::createFromNode($node, $locatedSource);
+
+        $this->assertSame($locatedSource, $functionInfo->getLocatedSource());
     }
 }

--- a/test/unit/Reflection/ReflectionPropertyTest.php
+++ b/test/unit/Reflection/ReflectionPropertyTest.php
@@ -114,6 +114,14 @@ class ReflectionPropertyTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($expectedDoc, $property->getDocComment());
     }
 
+    public function testGetDocCommentReturnsEmptyStringWithNoComment()
+    {
+        $classInfo = $this->reflector->reflect('\BetterReflectionTest\Fixture\ExampleClass');
+        $property = $classInfo->getProperty('publicStaticProperty');
+
+        $this->assertSame('', $property->getDocComment());
+    }
+
     public function testExportThrowsException()
     {
         $this->setExpectedException(\Exception::class);

--- a/test/unit/SourceLocator/EvaledCodeSourceLocatorTest.php
+++ b/test/unit/SourceLocator/EvaledCodeSourceLocatorTest.php
@@ -79,4 +79,30 @@ class EvaledCodeSourceLocatorTest extends \PHPUnit_Framework_TestCase
         $this->assertNull($class->getFileName());
         $this->assertCount(1, $class->getMethods());
     }
+
+    public function testReturnsNullForNonExistentCode()
+    {
+        $locator = new EvaledCodeSourceLocator();
+        $this->assertNull(
+            $locator->__invoke(
+                new Identifier(
+                    'Foo\Bar',
+                    new IdentifierType(IdentifierType::IDENTIFIER_CLASS)
+                )
+            )
+        );
+    }
+
+    public function testReturnsNullForFunctions()
+    {
+        $locator = new EvaledCodeSourceLocator();
+        $this->assertNull(
+            $locator->__invoke(
+                new Identifier(
+                    'foo',
+                    new IdentifierType(IdentifierType::IDENTIFIER_FUNCTION)
+                )
+            )
+        );
+    }
 }

--- a/test/unit/SourceLocator/InternalLocatedSourceTest.php
+++ b/test/unit/SourceLocator/InternalLocatedSourceTest.php
@@ -15,5 +15,7 @@ class InternalLocatedSourceTest extends \PHPUnit_Framework_TestCase
 
         $this->assertSame('foo', $locatedSource->getSource());
         $this->assertNull($locatedSource->getFileName());
+        $this->assertTrue($locatedSource->isInternal());
+        $this->assertFalse($locatedSource->isEvaled());
     }
 }

--- a/test/unit/SourceLocator/LocatedSourceTest.php
+++ b/test/unit/SourceLocator/LocatedSourceTest.php
@@ -20,6 +20,7 @@ class LocatedSourceTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($source, $locatedSource->getSource());
         $this->assertSame($file, $locatedSource->getFileName());
         $this->assertFalse($locatedSource->isEvaled());
+        $this->assertFalse($locatedSource->isInternal());
     }
 
     public function testValuesWithNullFilename()
@@ -31,6 +32,7 @@ class LocatedSourceTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($source, $locatedSource->getSource());
         $this->assertNull($locatedSource->getFileName());
         $this->assertFalse($locatedSource->isEvaled());
+        $this->assertFalse($locatedSource->isInternal());
     }
 
     /**

--- a/test/unit/SourceLocator/PhpInternalSourceLocatorTest.php
+++ b/test/unit/SourceLocator/PhpInternalSourceLocatorTest.php
@@ -94,4 +94,30 @@ class PhpInternalSourceLocatorTest extends \PHPUnit_Framework_TestCase
             )
         );
     }
+
+    public function testReturnsNullForNonExistentCode()
+    {
+        $locator = new PhpInternalSourceLocator();
+        $this->assertNull(
+            $locator->__invoke(
+                new Identifier(
+                    'Foo\Bar',
+                    new IdentifierType(IdentifierType::IDENTIFIER_CLASS)
+                )
+            )
+        );
+    }
+
+    public function testReturnsNullForFunctions()
+    {
+        $locator = new PhpInternalSourceLocator();
+        $this->assertNull(
+            $locator->__invoke(
+                new Identifier(
+                    'foo',
+                    new IdentifierType(IdentifierType::IDENTIFIER_FUNCTION)
+                )
+            )
+        );
+    }
 }


### PR DESCRIPTION
Improved coverage. There's a couple of uncovered things still:

* CompileNodeToValue - because implementation incomplete (bugs already open)
* `ClassReflector->reflect` - not sure why, the exit path seems uncovered for me, very odd o_O
* Similar thing with `Generic->reflectFromNamespace`, the parameter `LocatedSource $locatedSource` on L141 is uncovered for me

![cov](https://cloud.githubusercontent.com/assets/496145/8896087/9982c12e-33e8-11e5-97fc-c91a4357de28.png)
