### PR TITLE
Implementing reflector interface

### DIFF
--- a/src/Reflection/ReflectionClass.php
+++ b/src/Reflection/ReflectionClass.php
@@ -79,7 +79,7 @@ class ReflectionClass implements Reflection, \Reflector
 
     public function __toString()
     {
-        $format  = "Class [ <user> class %s%s ] {\n";
+        $format  = "Class [ <user> class %s%s%s ] {\n";
         $format .= "  @@ %s %d-%d\n\n";
         $format .= "  - Constants [%d] {%s\n  }\n\n";
         $format .= "  - Static properties [%d] {%s\n  }\n\n";
@@ -125,10 +125,13 @@ class ReflectionClass implements Reflection, \Reflector
             return $str;
         };
 
+        $interfaceNames = $this->getInterfaceNames();
+
         $str = sprintf(
             $format,
             $this->getName(),
-            '', // @todo extends+implements - in https://github.com/Roave/BetterReflection/issues/7
+            null !== $this->getParentClass() ? (' extends ' . $this->getParentClass()->getName()) : '',
+            count($interfaceNames) ? (' implements ' . implode(', ', $interfaceNames)) : '',
             $this->getFileName(),
             $this->getStartLine(),
             $this->getEndLine(),

--- a/src/Reflection/ReflectionClass.php
+++ b/src/Reflection/ReflectionClass.php
@@ -26,7 +26,7 @@ use PhpParser\Node\Stmt\ClassConst as ConstNode;
 use PhpParser\Node\Stmt\Property as PropertyNode;
 use PhpParser\Node\Stmt\TraitUse;
 
-class ReflectionClass implements Reflection
+class ReflectionClass implements Reflection, \Reflector
 {
     /**
      * @var Reflector
@@ -65,6 +65,86 @@ class ReflectionClass implements Reflection
 
     private function __construct()
     {
+    }
+
+    public static function export($className = null)
+    {
+        if (null === $className) {
+            throw new \InvalidArgumentException('Class name must be provided');
+        }
+
+        $reflection = self::createFromName($className);
+        return $reflection->__toString();
+    }
+
+    public function __toString()
+    {
+        $format  = "Class [ <user> class %s%s ] {\n";
+        $format .= "  @@ %s %d-%d\n\n";
+        $format .= "  - Constants [%d] {%s\n  }\n\n";
+        $format .= "  - Static properties [%d] {%s\n  }\n\n";
+        $format .= "  - Static methods [%d] {%s\n  }\n\n";
+        $format .= "  - Properties [%d] {%s\n  }\n\n";
+        $format .= "  - Methods [%d] {%s\n  }\n";
+        $format .= "}\n";
+
+        $staticProperties = array_filter($this->getProperties(), function (ReflectionProperty $property) {
+            return $property->isStatic();
+        });
+        $staticMethods = array_filter($this->getMethods(), function (ReflectionMethod $method) {
+            return $method->isStatic();
+        });
+        $properties = array_filter($this->getProperties(), function (ReflectionProperty $property) {
+            return !$property->isStatic();
+        });
+        $methods = array_filter($this->getMethods(), function (ReflectionMethod $method) {
+            return !$method->isStatic();
+        });
+
+        $buildString = function (array $items, $indentLevel = 4) {
+            if (!count($items)) {
+                return '';
+            }
+            $indent = "\n" . str_repeat(' ', $indentLevel);
+            return $indent . implode($indent, explode("\n", implode("\n", $items)));
+        };
+
+        $buildConstants = function (array $items, $indentLevel = 4) {
+            $str = '';
+
+            foreach ($items as $name => $value) {
+                $str .= "\n" . str_repeat(' ', $indentLevel);
+                $str .= sprintf(
+                    'Constant [ %s %s ] { %s }',
+                    gettype($value),
+                    $name,
+                    $value
+                );
+            }
+
+            return $str;
+        };
+
+        $str = sprintf(
+            $format,
+            $this->getName(),
+            '', // @todo extends+implements - in https://github.com/Roave/BetterReflection/issues/7
+            $this->getFileName(),
+            $this->getStartLine(),
+            $this->getEndLine(),
+            count($this->getConstants()),
+            $buildConstants($this->getConstants()),
+            count($staticProperties),
+            $buildString($staticProperties),
+            count($staticMethods),
+            $buildString($staticMethods),
+            count($properties),
+            $buildString($properties),
+            count($methods),
+            $buildString($methods)
+        );
+
+        return $str;
     }
 
     public static function createFromName($className)

--- a/src/Reflection/ReflectionFunction.php
+++ b/src/Reflection/ReflectionFunction.php
@@ -20,6 +20,29 @@ class ReflectionFunction extends ReflectionFunctionAbstract implements Reflectio
     }
 
     /**
+     * Check to see if a flag is set on this method.
+     * Return string representation of this parameter
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        $paramFormat = ($this->getNumberOfParameters() > 0) ? "\n\n  - Parameters [%d] {%s\n  }" : '';
+
+        return sprintf(
+            "Function [ <user> function %s ] {\n  @@ %s %d - %d{$paramFormat}\n}",
+            $this->getName(),
+            $this->getFileName(),
+            $this->getStartLine(),
+            $this->getEndLine(),
+            count($this->getParameters()),
+            array_reduce($this->getParameters(), function ($str, ReflectionParameter $param) {
+                return $str . "\n    " . $param;
+            }, '')
+        );
+    }
+
+    /**
      * @param FunctionNode $node
      * @param NamespaceNode|null $namespaceNode
      * @param LocatedSource $locatedSource

--- a/src/Reflection/ReflectionFunctionAbstract.php
+++ b/src/Reflection/ReflectionFunctionAbstract.php
@@ -29,6 +29,11 @@ abstract class ReflectionFunctionAbstract
     {
     }
 
+    public static function export()
+    {
+        throw new \Exception('Unable to export statically');
+    }
+
     /**
      * Populate the common elements of the function abstract.
      *

--- a/src/Reflection/ReflectionFunctionAbstract.php
+++ b/src/Reflection/ReflectionFunctionAbstract.php
@@ -8,7 +8,7 @@ use PhpParser\Node\Stmt as MethodOrFunctionNode;
 use PhpParser\Node\Stmt\Namespace_ as NamespaceNode;
 use PhpParser\Node\Expr\Yield_ as YieldNode;
 
-abstract class ReflectionFunctionAbstract
+abstract class ReflectionFunctionAbstract implements \Reflector
 {
     /**
      * @var NamespaceNode

--- a/src/Reflection/ReflectionMethod.php
+++ b/src/Reflection/ReflectionMethod.php
@@ -84,7 +84,36 @@ class ReflectionMethod extends ReflectionFunctionAbstract
     }
 
     /**
-     * Check to see if a flag is set on this method.
+     * Return string representation of this parameter
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        $paramFormat = ($this->getNumberOfParameters() > 0) ? "\n\n  - Parameters [%d] {%s\n  }" : '';
+
+        return sprintf(
+            "Method [ <user%s%s>%s%s%s %s method %s ] {\n  @@ %s %d - %d{$paramFormat}\n}",
+            $this->isConstructor() ? ', ctor' : '',
+            $this->isDestructor() ? ', dtor' : '',
+            $this->isFinal() ? ' final' : '',
+            $this->isStatic() ? ' static' : '',
+            $this->isAbstract() ? ' abstract' : '',
+            $this->getVisibilityAsString(),
+            $this->getName(),
+            $this->getFileName(),
+            $this->getStartLine(),
+            $this->getEndLine(),
+            count($this->getParameters()),
+            array_reduce($this->getParameters(), function ($str, ReflectionParameter $param) {
+                return $str . "\n    " . $param;
+            }, '')
+        );
+    }
+
+    /**
+     * Get the visibility of this method as a string (private/protected/public)
+     *
      * @return string
      */
     private function getVisibilityAsString()

--- a/src/Reflection/ReflectionMethod.php
+++ b/src/Reflection/ReflectionMethod.php
@@ -84,6 +84,23 @@ class ReflectionMethod extends ReflectionFunctionAbstract
     }
 
     /**
+     * Check to see if a flag is set on this method.
+     * @return string
+     */
+    private function getVisibilityAsString()
+    {
+        if ($this->isPrivate()) {
+            return 'private';
+        }
+
+        if ($this->isProtected()) {
+            return 'protected';
+        }
+
+        return 'public';
+    }
+
+    /**
      * Get the method node (ensuring it is a ClassMethod node)
      *
      * @throws \RuntimeException

--- a/src/Reflection/ReflectionParameter.php
+++ b/src/Reflection/ReflectionParameter.php
@@ -68,12 +68,18 @@ class ReflectionParameter implements \Reflector
      */
     public function __toString()
     {
+        $isNullableObjectParam = $this->getTypeHint() && $this->getTypeHint() instanceof Types\Object_ && $this->isOptional();
+
         return sprintf(
-            'Parameter #%d [ %s $%s%s ]',
+            'Parameter #%d [ %s %s%s%s%s$%s%s ]',
             $this->parameterIndex,
-            $this->isOptional() ? '<optional>' : '<required>',
+            ($this->isVariadic() || $this->isOptional()) ? '<optional>' : '<required>',
+            $this->getTypeHint() ? ltrim($this->getTypeHint()->__toString(), '\\') . ' ' : '',
+            $isNullableObjectParam ? 'or NULL ' : '',
+            $this->isVariadic() ? '...' : '',
+            $this->isPassedByReference() ? '&' : '',
             $this->getName(),
-            $this->isDefaultValueAvailable()
+            $this->isOptional()
                 ? (' = ' . $this->getDefaultValueAsString())
                 : ''
         );

--- a/test/unit/Fixture/ExampleClassExport.txt
+++ b/test/unit/Fixture/ExampleClassExport.txt
@@ -1,0 +1,30 @@
+Class [ <user> class BetterReflectionTest\Fixture\ExampleClass ] {
+  @@ %s/test/unit/Fixture/ExampleClass.php 7-36
+
+  - Constants [2] {
+    Constant [ integer MY_CONST_1 ] { 123 }
+    Constant [ integer MY_CONST_2 ] { 234 }
+  }
+
+  - Static properties [1] {
+    Property [ public static $publicStaticProperty ]
+  }
+
+  - Static methods [0] {
+  }
+
+  - Properties [3] {
+    Property [ <default> private $privateProperty ]
+    Property [ <default> protected $protectedProperty ]
+    Property [ <default> public $publicProperty ]
+  }
+
+  - Methods [2] {
+    Method [ <user, ctor> public method __construct ] {
+      @@ %s/test/unit/Fixture/ExampleClass.php 29 - 31
+    }
+    Method [ <user> public method someMethod ] {
+      @@ %s/test/unit/Fixture/ExampleClass.php 33 - 35
+    }
+  }
+}

--- a/test/unit/Fixture/Functions.php
+++ b/test/unit/Fixture/Functions.php
@@ -4,3 +4,6 @@ namespace BetterReflectionTest\Fixture;
 
 function myFunction() {
 }
+
+function myFunctionWithParams($a, $b) {
+}

--- a/test/unit/Reflection/ReflectionClassTest.php
+++ b/test/unit/Reflection/ReflectionClassTest.php
@@ -804,4 +804,45 @@ class ReflectionClassTest extends \PHPUnit_Framework_TestCase
         $this->setExpectedException(\InvalidArgumentException::class);
         ReflectionClass::export();
     }
+
+    public function testToStringWhenImplementingInterface()
+    {
+        $php = '<?php
+            namespace Qux;
+            interface Foo {}
+            class Bar implements Foo {}
+        ';
+
+        $reflection = (new ClassReflector(new StringSourceLocator($php)))->reflect('Qux\Bar');
+
+        $this->assertStringStartsWith('Class [ <user> class Qux\Bar implements Qux\Foo ] {', $reflection->__toString());
+    }
+
+    public function testToStringWhenExtending()
+    {
+        $php = '<?php
+            namespace Qux;
+            class Foo {}
+            class Bar extends Foo {}
+        ';
+
+        $reflection = (new ClassReflector(new StringSourceLocator($php)))->reflect('Qux\Bar');
+
+        $this->assertStringStartsWith('Class [ <user> class Qux\Bar extends Qux\Foo ] {', $reflection->__toString());
+    }
+
+    public function testToStringWhenExtendingAndImplementing()
+    {
+        $php = '<?php
+            namespace Qux;
+            interface Foo {}
+            interface Bar {}
+            class Bat {}
+            class Baz extends Bat implements Foo, Bar {}
+        ';
+
+        $reflection = (new ClassReflector(new StringSourceLocator($php)))->reflect('Qux\Baz');
+
+        $this->assertStringStartsWith('Class [ <user> class Qux\Baz extends Qux\Bat implements Qux\Foo, Qux\Bar ] {', $reflection->__toString());
+    }
 }

--- a/test/unit/Reflection/ReflectionClassTest.php
+++ b/test/unit/Reflection/ReflectionClassTest.php
@@ -780,7 +780,7 @@ class ReflectionClassTest extends \PHPUnit_Framework_TestCase
             $reflection->__toString()
         );
     }
-    
+
     public function testImplementsReflector()
     {
         $php = '<?php class Foo {}';
@@ -789,5 +789,19 @@ class ReflectionClassTest extends \PHPUnit_Framework_TestCase
         $classInfo = $reflector->reflect('Foo');
 
         $this->assertInstanceOf(\Reflector::class, $classInfo);
+    }
+
+    public function testExportMatchesFormat()
+    {
+        $this->assertStringMatchesFormat(
+            file_get_contents(__DIR__ . '/../Fixture/ExampleClassExport.txt'),
+            ReflectionClass::export('BetterReflectionTest\Fixture\ExampleClass')
+        );
+    }
+
+    public function testExportWithNoClassName()
+    {
+        $this->setExpectedException(\InvalidArgumentException::class);
+        ReflectionClass::export();
     }
 }

--- a/test/unit/Reflection/ReflectionClassTest.php
+++ b/test/unit/Reflection/ReflectionClassTest.php
@@ -780,4 +780,14 @@ class ReflectionClassTest extends \PHPUnit_Framework_TestCase
             $reflection->__toString()
         );
     }
+    
+    public function testImplementsReflector()
+    {
+        $php = '<?php class Foo {}';
+
+        $reflector = new ClassReflector(new StringSourceLocator($php));
+        $classInfo = $reflector->reflect('Foo');
+
+        $this->assertInstanceOf(\Reflector::class, $classInfo);
+    }
 }

--- a/test/unit/Reflection/ReflectionClassTest.php
+++ b/test/unit/Reflection/ReflectionClassTest.php
@@ -771,4 +771,13 @@ class ReflectionClassTest extends \PHPUnit_Framework_TestCase
         $this->setExpectedException(\Exception::class, 'Unable to determine FQSEN for named node');
         $reflectionClassMethodReflection->invoke($reflection, $nameNode);
     }
+
+    public function testClassToString()
+    {
+        $reflection = ReflectionClass::createFromName('BetterReflectionTest\Fixture\ExampleClass');
+        $this->assertStringMatchesFormat(
+            file_get_contents(__DIR__ . '/../Fixture/ExampleClassExport.txt'),
+            $reflection->__toString()
+        );
+    }
 }

--- a/test/unit/Reflection/ReflectionFunctionAbstractTest.php
+++ b/test/unit/Reflection/ReflectionFunctionAbstractTest.php
@@ -3,6 +3,7 @@
 namespace BetterReflectionTest\Reflection;
 
 use BetterReflection\Reflection\ReflectionFunction;
+use BetterReflection\Reflection\ReflectionFunctionAbstract;
 use BetterReflection\Reflection\ReflectionParameter;
 use BetterReflection\Reflector\FunctionReflector;
 use BetterReflection\SourceLocator\LocatedSource;

--- a/test/unit/Reflection/ReflectionFunctionAbstractTest.php
+++ b/test/unit/Reflection/ReflectionFunctionAbstractTest.php
@@ -15,6 +15,12 @@ use PhpParser\Node\Stmt\Function_;
  */
 class ReflectionFunctionAbstractTest extends \PHPUnit_Framework_TestCase
 {
+    public function testExportThrowsException()
+    {
+        $this->setExpectedException(\Exception::class);
+        ReflectionFunctionAbstract::export();
+    }
+
     public function testNameMethodsWithNamespace()
     {
         $php = '<?php namespace Foo { function bar() {}}';

--- a/test/unit/Reflection/ReflectionFunctionTest.php
+++ b/test/unit/Reflection/ReflectionFunctionTest.php
@@ -90,8 +90,8 @@ class ReflectionFunctionTest extends \PHPUnit_Framework_TestCase
     public function functionStringRepresentations()
     {
         return [
-            ['BetterReflectionTest\Fixture\myFunction', "Function [ <user> function BetterReflectionTest\Fixture\myFunction ] {\n  @@ /home/james/workspace/better-reflection/test/unit/Fixture/Functions.php 5 - 6\n}"],
-            ['BetterReflectionTest\Fixture\myFunctionWithParams', "Function [ <user> function BetterReflectionTest\Fixture\myFunctionWithParams ] {\n  @@ /home/james/workspace/better-reflection/test/unit/Fixture/Functions.php 8 - 9\n\n  - Parameters [2] {\n    Parameter #0 [ <required> \$a ]\n    Parameter #1 [ <required> \$b ]\n  }\n}"],
+            ['BetterReflectionTest\Fixture\myFunction', "Function [ <user> function BetterReflectionTest\Fixture\myFunction ] {\n  @@ %s/test/unit/Fixture/Functions.php 5 - 6\n}"],
+            ['BetterReflectionTest\Fixture\myFunctionWithParams', "Function [ <user> function BetterReflectionTest\Fixture\myFunctionWithParams ] {\n  @@ %s/test/unit/Fixture/Functions.php 8 - 9\n\n  - Parameters [2] {\n    Parameter #0 [ <required> \$a ]\n    Parameter #1 [ <required> \$b ]\n  }\n}"],
         ];
     }
 
@@ -105,6 +105,6 @@ class ReflectionFunctionTest extends \PHPUnit_Framework_TestCase
         require_once(__DIR__ . '/../Fixture/Functions.php');
         $functionInfo = ReflectionFunction::createFromName($functionName);
 
-        $this->assertSame($expectedStringValue, (string)$functionInfo);
+        $this->assertStringMatchesFormat($expectedStringValue, (string)$functionInfo);
     }
 }

--- a/test/unit/Reflection/ReflectionFunctionTest.php
+++ b/test/unit/Reflection/ReflectionFunctionTest.php
@@ -76,4 +76,25 @@ class ReflectionFunctionTest extends \PHPUnit_Framework_TestCase
         $reflection = ReflectionFunction::createFromName('BetterReflectionTest\Fixture\myFunction');
         $this->assertSame('myFunction', $reflection->getShortName());
     }
+
+    public function functionStringRepresentations()
+    {
+        return [
+            ['BetterReflectionTest\Fixture\myFunction', "Function [ <user> function BetterReflectionTest\Fixture\myFunction ] {\n  @@ /home/james/workspace/better-reflection/test/unit/Fixture/Functions.php 5 - 6\n}"],
+            ['BetterReflectionTest\Fixture\myFunctionWithParams', "Function [ <user> function BetterReflectionTest\Fixture\myFunctionWithParams ] {\n  @@ /home/james/workspace/better-reflection/test/unit/Fixture/Functions.php 8 - 9\n\n  - Parameters [2] {\n    Parameter #0 [ <required> \$a ]\n    Parameter #1 [ <required> \$b ]\n  }\n}"],
+        ];
+    }
+
+    /**
+     * @param string $functionName
+     * @param string $expectedStringValue
+     * @dataProvider functionStringRepresentations
+     */
+    public function testStringCast($functionName, $expectedStringValue)
+    {
+        require_once(__DIR__ . '/../Fixture/Functions.php');
+        $functionInfo = ReflectionFunction::createFromName($functionName);
+
+        $this->assertSame($expectedStringValue, (string)$functionInfo);
+    }
 }

--- a/test/unit/Reflection/ReflectionFunctionTest.php
+++ b/test/unit/Reflection/ReflectionFunctionTest.php
@@ -11,6 +11,16 @@ use BetterReflection\SourceLocator\StringSourceLocator;
  */
 class ReflectionFunctionTest extends \PHPUnit_Framework_TestCase
 {
+    public function testImplementsReflector()
+    {
+        $php = '<?php function foo() {}';
+
+        $reflector = new FunctionReflector(new StringSourceLocator($php));
+        $functionInfo = $reflector->reflect('foo');
+
+        $this->assertInstanceOf(\Reflector::class, $functionInfo);
+    }
+
     public function testNameMethodsWithNoNamespace()
     {
         $php = '<?php function foo() {}';

--- a/test/unit/Reflection/ReflectionMethodTest.php
+++ b/test/unit/Reflection/ReflectionMethodTest.php
@@ -27,6 +27,14 @@ class ReflectionMethodTest extends \PHPUnit_Framework_TestCase
         $this->reflector = new ClassReflector(new ComposerSourceLocator($loader));
     }
 
+    public function testImplementsReflector()
+    {
+        $classInfo = $this->reflector->reflect('BetterReflectionTest\Fixture\Methods');
+        $methodInfo = $classInfo->getMethod('publicMethod');
+
+        $this->assertInstanceOf(\Reflector::class, $methodInfo);
+    }
+
     /**
      * @return array
      */

--- a/test/unit/Reflection/ReflectionMethodTest.php
+++ b/test/unit/Reflection/ReflectionMethodTest.php
@@ -224,22 +224,22 @@ class ReflectionMethodTest extends \PHPUnit_Framework_TestCase
     public function methodStringRepresentations()
     {
         return [
-            ['__construct', "Method [ <user, ctor> public method __construct ] {\n  @@ /home/james/workspace/better-reflection/test/unit/Fixture/Methods.php 11 - 13\n}"],
-            ['publicMethod', "Method [ <user> public method publicMethod ] {\n  @@ /home/james/workspace/better-reflection/test/unit/Fixture/Methods.php 15 - 17\n}"],
-            ['privateMethod', "Method [ <user> private method privateMethod ] {\n  @@ /home/james/workspace/better-reflection/test/unit/Fixture/Methods.php 19 - 21\n}"],
-            ['protectedMethod', "Method [ <user> protected method protectedMethod ] {\n  @@ /home/james/workspace/better-reflection/test/unit/Fixture/Methods.php 23 - 25\n}"],
-            ['finalPublicMethod', "Method [ <user> final public method finalPublicMethod ] {\n  @@ /home/james/workspace/better-reflection/test/unit/Fixture/Methods.php 27 - 29\n}"],
-            ['abstractPublicMethod', "Method [ <user> abstract public method abstractPublicMethod ] {\n  @@ /home/james/workspace/better-reflection/test/unit/Fixture/Methods.php 31 - 31\n}"],
-            ['staticPublicMethod', "Method [ <user> static public method staticPublicMethod ] {\n  @@ /home/james/workspace/better-reflection/test/unit/Fixture/Methods.php 33 - 35\n}"],
-            ['noVisibility', "Method [ <user> public method noVisibility ] {\n  @@ /home/james/workspace/better-reflection/test/unit/Fixture/Methods.php 37 - 39\n}"],
-            ['__destruct', "Method [ <user, dtor> public method __destruct ] {\n  @@ /home/james/workspace/better-reflection/test/unit/Fixture/Methods.php 41 - 43\n}"],
-            ['methodWithParameters', "Method [ <user> public method methodWithParameters ] {\n  @@ /home/james/workspace/better-reflection/test/unit/Fixture/Methods.php 49 - 51\n\n  - Parameters [2] {\n    Parameter #0 [ <required> \$parameter1 ]\n    Parameter #1 [ <required> \$parameter2 ]\n  }\n}"],
-            ['methodWithOptionalParameters', "Method [ <user> public method methodWithOptionalParameters ] {\n  @@ /home/james/workspace/better-reflection/test/unit/Fixture/Methods.php 53 - 55\n\n  - Parameters [2] {\n    Parameter #0 [ <required> \$parameter ]\n    Parameter #1 [ <optional> \$optionalParameter = NULL ]\n  }\n}"],
-            ['methodWithExplicitTypedParameters', "Method [ <user> public method methodWithExplicitTypedParameters ] {\n  @@ /home/james/workspace/better-reflection/test/unit/Fixture/Methods.php 57 - 64\n\n  - Parameters [5] {\n    Parameter #0 [ <required> stdClass \$stdClassParameter ]\n    Parameter #1 [ <required> BetterReflectionTest\Fixture\ClassForHinting \$namespaceClassParameter ]\n    Parameter #2 [ <required> BetterReflectionTest\Fixture\ClassForHinting \$fullyQualifiedClassParameter ]\n    Parameter #3 [ <required> array \$arrayParameter ]\n    Parameter #4 [ <required> callable \$callableParameter ]\n  }\n}"],
-            ['methodWithVariadic', "Method [ <user> public method methodWithVariadic ] {\n  @@ /home/james/workspace/better-reflection/test/unit/Fixture/Methods.php 66 - 68\n\n  - Parameters [2] {\n    Parameter #0 [ <required> \$nonVariadicParameter ]\n    Parameter #1 [ <optional> ...\$variadicParameter ]\n  }\n}"],
-            ['methodWithReference', "Method [ <user> public method methodWithReference ] {\n  @@ /home/james/workspace/better-reflection/test/unit/Fixture/Methods.php 70 - 72\n\n  - Parameters [2] {\n    Parameter #0 [ <required> \$nonRefParameter ]\n    Parameter #1 [ <required> &\$refParameter ]\n  }\n}"],
-            ['methodWithNonOptionalDefaultValue', "Method [ <user> public method methodWithNonOptionalDefaultValue ] {\n  @@ /home/james/workspace/better-reflection/test/unit/Fixture/Methods.php 74 - 76\n\n  - Parameters [2] {\n    Parameter #0 [ <required> \$firstParameter ]\n    Parameter #1 [ <required> \$secondParameter ]\n  }\n}"],
-            ['methodToCheckAllowsNull', "Method [ <user> public method methodToCheckAllowsNull ] {\n  @@ /home/james/workspace/better-reflection/test/unit/Fixture/Methods.php 78 - 80\n\n  - Parameters [3] {\n    Parameter #0 [ <required> \$allowsNull ]\n    Parameter #1 [ <required> stdClass \$hintDisallowNull ]\n    Parameter #2 [ <optional> stdClass or NULL \$hintAllowNull = NULL ]\n  }\n}"],
+            ['__construct', "Method [ <user, ctor> public method __construct ] {\n  @@ %s/test/unit/Fixture/Methods.php 11 - 13\n}"],
+            ['publicMethod', "Method [ <user> public method publicMethod ] {\n  @@ %s/test/unit/Fixture/Methods.php 15 - 17\n}"],
+            ['privateMethod', "Method [ <user> private method privateMethod ] {\n  @@ %s/test/unit/Fixture/Methods.php 19 - 21\n}"],
+            ['protectedMethod', "Method [ <user> protected method protectedMethod ] {\n  @@ %s/test/unit/Fixture/Methods.php 23 - 25\n}"],
+            ['finalPublicMethod', "Method [ <user> final public method finalPublicMethod ] {\n  @@ %s/test/unit/Fixture/Methods.php 27 - 29\n}"],
+            ['abstractPublicMethod', "Method [ <user> abstract public method abstractPublicMethod ] {\n  @@ %s/test/unit/Fixture/Methods.php 31 - 31\n}"],
+            ['staticPublicMethod', "Method [ <user> static public method staticPublicMethod ] {\n  @@ %s/test/unit/Fixture/Methods.php 33 - 35\n}"],
+            ['noVisibility', "Method [ <user> public method noVisibility ] {\n  @@ %s/test/unit/Fixture/Methods.php 37 - 39\n}"],
+            ['__destruct', "Method [ <user, dtor> public method __destruct ] {\n  @@ %s/test/unit/Fixture/Methods.php 41 - 43\n}"],
+            ['methodWithParameters', "Method [ <user> public method methodWithParameters ] {\n  @@ %s/test/unit/Fixture/Methods.php 49 - 51\n\n  - Parameters [2] {\n    Parameter #0 [ <required> \$parameter1 ]\n    Parameter #1 [ <required> \$parameter2 ]\n  }\n}"],
+            ['methodWithOptionalParameters', "Method [ <user> public method methodWithOptionalParameters ] {\n  @@ %s/test/unit/Fixture/Methods.php 53 - 55\n\n  - Parameters [2] {\n    Parameter #0 [ <required> \$parameter ]\n    Parameter #1 [ <optional> \$optionalParameter = NULL ]\n  }\n}"],
+            ['methodWithExplicitTypedParameters', "Method [ <user> public method methodWithExplicitTypedParameters ] {\n  @@ %s/test/unit/Fixture/Methods.php 57 - 64\n\n  - Parameters [5] {\n    Parameter #0 [ <required> stdClass \$stdClassParameter ]\n    Parameter #1 [ <required> BetterReflectionTest\Fixture\ClassForHinting \$namespaceClassParameter ]\n    Parameter #2 [ <required> BetterReflectionTest\Fixture\ClassForHinting \$fullyQualifiedClassParameter ]\n    Parameter #3 [ <required> array \$arrayParameter ]\n    Parameter #4 [ <required> callable \$callableParameter ]\n  }\n}"],
+            ['methodWithVariadic', "Method [ <user> public method methodWithVariadic ] {\n  @@ %s/test/unit/Fixture/Methods.php 66 - 68\n\n  - Parameters [2] {\n    Parameter #0 [ <required> \$nonVariadicParameter ]\n    Parameter #1 [ <optional> ...\$variadicParameter ]\n  }\n}"],
+            ['methodWithReference', "Method [ <user> public method methodWithReference ] {\n  @@ %s/test/unit/Fixture/Methods.php 70 - 72\n\n  - Parameters [2] {\n    Parameter #0 [ <required> \$nonRefParameter ]\n    Parameter #1 [ <required> &\$refParameter ]\n  }\n}"],
+            ['methodWithNonOptionalDefaultValue', "Method [ <user> public method methodWithNonOptionalDefaultValue ] {\n  @@ %s/test/unit/Fixture/Methods.php 74 - 76\n\n  - Parameters [2] {\n    Parameter #0 [ <required> \$firstParameter ]\n    Parameter #1 [ <required> \$secondParameter ]\n  }\n}"],
+            ['methodToCheckAllowsNull', "Method [ <user> public method methodToCheckAllowsNull ] {\n  @@ %s/test/unit/Fixture/Methods.php 78 - 80\n\n  - Parameters [3] {\n    Parameter #0 [ <required> \$allowsNull ]\n    Parameter #1 [ <required> stdClass \$hintDisallowNull ]\n    Parameter #2 [ <optional> stdClass or NULL \$hintAllowNull = NULL ]\n  }\n}"],
         ];
     }
 
@@ -253,6 +253,6 @@ class ReflectionMethodTest extends \PHPUnit_Framework_TestCase
         $classInfo = $this->reflector->reflect('\BetterReflectionTest\Fixture\Methods');
         $method = $classInfo->getMethod($methodName);
 
-        $this->assertSame($expectedStringValue, (string)$method);
+        $this->assertStringMatchesFormat($expectedStringValue, (string)$method);
     }
 }

--- a/test/unit/Reflection/ReflectionMethodTest.php
+++ b/test/unit/Reflection/ReflectionMethodTest.php
@@ -212,4 +212,39 @@ class ReflectionMethodTest extends \PHPUnit_Framework_TestCase
         $this->setExpectedException(\RuntimeException::class, 'Expected a ClassMethod node');
         $method->isPublic();
     }
+
+    public function methodStringRepresentations()
+    {
+        return [
+            ['__construct', "Method [ <user, ctor> public method __construct ] {\n  @@ /home/james/workspace/better-reflection/test/unit/Fixture/Methods.php 11 - 13\n}"],
+            ['publicMethod', "Method [ <user> public method publicMethod ] {\n  @@ /home/james/workspace/better-reflection/test/unit/Fixture/Methods.php 15 - 17\n}"],
+            ['privateMethod', "Method [ <user> private method privateMethod ] {\n  @@ /home/james/workspace/better-reflection/test/unit/Fixture/Methods.php 19 - 21\n}"],
+            ['protectedMethod', "Method [ <user> protected method protectedMethod ] {\n  @@ /home/james/workspace/better-reflection/test/unit/Fixture/Methods.php 23 - 25\n}"],
+            ['finalPublicMethod', "Method [ <user> final public method finalPublicMethod ] {\n  @@ /home/james/workspace/better-reflection/test/unit/Fixture/Methods.php 27 - 29\n}"],
+            ['abstractPublicMethod', "Method [ <user> abstract public method abstractPublicMethod ] {\n  @@ /home/james/workspace/better-reflection/test/unit/Fixture/Methods.php 31 - 31\n}"],
+            ['staticPublicMethod', "Method [ <user> static public method staticPublicMethod ] {\n  @@ /home/james/workspace/better-reflection/test/unit/Fixture/Methods.php 33 - 35\n}"],
+            ['noVisibility', "Method [ <user> public method noVisibility ] {\n  @@ /home/james/workspace/better-reflection/test/unit/Fixture/Methods.php 37 - 39\n}"],
+            ['__destruct', "Method [ <user, dtor> public method __destruct ] {\n  @@ /home/james/workspace/better-reflection/test/unit/Fixture/Methods.php 41 - 43\n}"],
+            ['methodWithParameters', "Method [ <user> public method methodWithParameters ] {\n  @@ /home/james/workspace/better-reflection/test/unit/Fixture/Methods.php 49 - 51\n\n  - Parameters [2] {\n    Parameter #0 [ <required> \$parameter1 ]\n    Parameter #1 [ <required> \$parameter2 ]\n  }\n}"],
+            ['methodWithOptionalParameters', "Method [ <user> public method methodWithOptionalParameters ] {\n  @@ /home/james/workspace/better-reflection/test/unit/Fixture/Methods.php 53 - 55\n\n  - Parameters [2] {\n    Parameter #0 [ <required> \$parameter ]\n    Parameter #1 [ <optional> \$optionalParameter = NULL ]\n  }\n}"],
+            ['methodWithExplicitTypedParameters', "Method [ <user> public method methodWithExplicitTypedParameters ] {\n  @@ /home/james/workspace/better-reflection/test/unit/Fixture/Methods.php 57 - 64\n\n  - Parameters [5] {\n    Parameter #0 [ <required> stdClass \$stdClassParameter ]\n    Parameter #1 [ <required> BetterReflectionTest\Fixture\ClassForHinting \$namespaceClassParameter ]\n    Parameter #2 [ <required> BetterReflectionTest\Fixture\ClassForHinting \$fullyQualifiedClassParameter ]\n    Parameter #3 [ <required> array \$arrayParameter ]\n    Parameter #4 [ <required> callable \$callableParameter ]\n  }\n}"],
+            ['methodWithVariadic', "Method [ <user> public method methodWithVariadic ] {\n  @@ /home/james/workspace/better-reflection/test/unit/Fixture/Methods.php 66 - 68\n\n  - Parameters [2] {\n    Parameter #0 [ <required> \$nonVariadicParameter ]\n    Parameter #1 [ <optional> ...\$variadicParameter ]\n  }\n}"],
+            ['methodWithReference', "Method [ <user> public method methodWithReference ] {\n  @@ /home/james/workspace/better-reflection/test/unit/Fixture/Methods.php 70 - 72\n\n  - Parameters [2] {\n    Parameter #0 [ <required> \$nonRefParameter ]\n    Parameter #1 [ <required> &\$refParameter ]\n  }\n}"],
+            ['methodWithNonOptionalDefaultValue', "Method [ <user> public method methodWithNonOptionalDefaultValue ] {\n  @@ /home/james/workspace/better-reflection/test/unit/Fixture/Methods.php 74 - 76\n\n  - Parameters [2] {\n    Parameter #0 [ <required> \$firstParameter ]\n    Parameter #1 [ <required> \$secondParameter ]\n  }\n}"],
+            ['methodToCheckAllowsNull', "Method [ <user> public method methodToCheckAllowsNull ] {\n  @@ /home/james/workspace/better-reflection/test/unit/Fixture/Methods.php 78 - 80\n\n  - Parameters [3] {\n    Parameter #0 [ <required> \$allowsNull ]\n    Parameter #1 [ <required> stdClass \$hintDisallowNull ]\n    Parameter #2 [ <optional> stdClass or NULL \$hintAllowNull = NULL ]\n  }\n}"],
+        ];
+    }
+
+    /**
+     * @param string $methodName
+     * @param string $expectedStringValue
+     * @dataProvider methodStringRepresentations
+     */
+    public function testStringCast($methodName, $expectedStringValue)
+    {
+        $classInfo = $this->reflector->reflect('\BetterReflectionTest\Fixture\Methods');
+        $method = $classInfo->getMethod($methodName);
+
+        $this->assertSame($expectedStringValue, (string)$method);
+    }
 }

--- a/test/unit/Reflection/ReflectionParameterTest.php
+++ b/test/unit/Reflection/ReflectionParameterTest.php
@@ -25,6 +25,15 @@ class ReflectionParameterTest extends \PHPUnit_Framework_TestCase
         $this->reflector = new ClassReflector(new ComposerSourceLocator($loader));
     }
 
+    public function testImplementsReflector()
+    {
+        $classInfo = $this->reflector->reflect('\BetterReflectionTest\Fixture\Methods');
+        $methodInfo = $classInfo->getMethod('methodWithParameters');
+        $paramInfo = $methodInfo->getParameter('parameter1');
+
+        $this->assertInstanceOf(\Reflector::class, $paramInfo);
+    }
+
     public function testExportThrowsException()
     {
         $this->setExpectedException(\Exception::class);

--- a/test/unit/Reflection/ReflectionPropertyTest.php
+++ b/test/unit/Reflection/ReflectionPropertyTest.php
@@ -23,6 +23,14 @@ class ReflectionPropertyTest extends \PHPUnit_Framework_TestCase
         $this->reflector = new ClassReflector(new ComposerSourceLocator($loader));
     }
 
+    public function testImplementsReflector()
+    {
+        $classInfo = $this->reflector->reflect('\BetterReflectionTest\Fixture\ExampleClass');
+        $publicProp = $classInfo->getProperty('publicProperty');
+
+        $this->assertInstanceOf(\Reflector::class, $publicProp);
+    }
+
     public function testVisibilityMethods()
     {
         $classInfo = $this->reflector->reflect('\BetterReflectionTest\Fixture\ExampleClass');


### PR DESCRIPTION
Now all `Reflection*` classes implement `\Reflector`, thus resolving #17 