### PR TITLE
#87 Loads of stubs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "nikic/php-parser": "^2.0-beta",
         "phpdocumentor/reflection-docblock": "^2.0",
         "phpdocumentor/type-resolver": "^0.1.5",
-        "zendframework/zend-code": "^2.5",
+        "zendframework/zend-code": "^2.5|^3.0",
         "jeremeamia/superclosure": "^2.2"
     },
     "require-dev": {

--- a/src/SourceLocator/Type/PhpInternalSourceLocator.php
+++ b/src/SourceLocator/Type/PhpInternalSourceLocator.php
@@ -90,7 +90,7 @@ final class PhpInternalSourceLocator extends AbstractSourceLocator
      */
     private function buildStubName($className)
     {
-        if (!preg_match('/^[a-zA-Z]+$/', $className)) {
+        if (!preg_match('/^[a-zA-Z_][a-zA-Z_\d]*$/', $className)) {
             return null;
         }
 

--- a/stub/APCIterator.stub
+++ b/stub/APCIterator.stub
@@ -1,5 +1,3 @@
-<?php
-
 class APCIterator implements Iterator, Traversable
 {
 

--- a/stub/APCIterator.stub
+++ b/stub/APCIterator.stub
@@ -1,0 +1,43 @@
+<?php
+
+class APCIterator implements Iterator, Traversable
+{
+
+    public function __construct($cache, $search = null, $format = APC_ITER_ALL, $chunk_size = 100, $list = APC_LIST_ACTIVE)
+    {
+    }
+
+    public function rewind()
+    {
+    }
+
+    public function current()
+    {
+    }
+
+    public function key()
+    {
+    }
+
+    public function next()
+    {
+    }
+
+    public function valid()
+    {
+    }
+
+    public function getTotalHits()
+    {
+    }
+
+    public function getTotalSize()
+    {
+    }
+
+    public function getTotalCount()
+    {
+    }
+
+
+}

--- a/stub/CURLFile.stub
+++ b/stub/CURLFile.stub
@@ -1,5 +1,3 @@
-<?php
-
 class CURLFile
 {
 

--- a/stub/CURLFile.stub
+++ b/stub/CURLFile.stub
@@ -1,0 +1,41 @@
+<?php
+
+class CURLFile
+{
+
+    public $name = '';
+
+    public $mime = '';
+
+    public $postname = '';
+
+    public function __construct($filename, $mimetype = null, $postname = null)
+    {
+    }
+
+    public function getFilename()
+    {
+    }
+
+    public function getMimeType()
+    {
+    }
+
+    public function setMimeType($name)
+    {
+    }
+
+    public function getPostFilename()
+    {
+    }
+
+    public function setPostFilename($name)
+    {
+    }
+
+    public function __wakeup()
+    {
+    }
+
+
+}

--- a/stub/CachingIterator.stub
+++ b/stub/CachingIterator.stub
@@ -1,0 +1,87 @@
+<?php
+
+class CachingIterator extends IteratorIterator implements ArrayAccess, Countable
+{
+
+    const CALL_TOSTRING = 1;
+
+    const CATCH_GET_CHILD = 16;
+
+    const TOSTRING_USE_KEY = 2;
+
+    const TOSTRING_USE_CURRENT = 4;
+
+    const TOSTRING_USE_INNER = 8;
+
+    const FULL_CACHE = 256;
+
+    public function __construct(\Iterator $iterator, $flags = self::CALL_TOSTRING)
+    {
+    }
+
+    public function rewind()
+    {
+    }
+
+    public function valid()
+    {
+    }
+
+    public function key()
+    {
+    }
+
+    public function current()
+    {
+    }
+
+    public function next()
+    {
+    }
+
+    public function hasNext()
+    {
+    }
+
+    public function __toString()
+    {
+    }
+
+    public function getInnerIterator()
+    {
+    }
+
+    public function getFlags()
+    {
+    }
+
+    public function setFlags($flags)
+    {
+    }
+
+    public function offsetGet($index)
+    {
+    }
+
+    public function offsetSet($index, $newval)
+    {
+    }
+
+    public function offsetUnset($index)
+    {
+    }
+
+    public function offsetExists($index)
+    {
+    }
+
+    public function getCache()
+    {
+    }
+
+    public function count()
+    {
+    }
+
+
+}

--- a/stub/CachingIterator.stub
+++ b/stub/CachingIterator.stub
@@ -1,5 +1,3 @@
-<?php
-
 class CachingIterator extends IteratorIterator implements ArrayAccess, Countable
 {
 

--- a/stub/Closure.stub
+++ b/stub/Closure.stub
@@ -13,5 +13,7 @@ class Closure
     {
     }
 
-
+    public function call($newthis, ...$parameters)
+    {
+    }
 }

--- a/stub/Closure.stub
+++ b/stub/Closure.stub
@@ -1,0 +1,19 @@
+<?php
+
+class Closure
+{
+
+    private function __construct()
+    {
+    }
+
+    public static function bind($closure, $newthis, $newscope = 'static')
+    {
+    }
+
+    public function bindTo($newthis, $newscope = 'static')
+    {
+    }
+
+
+}

--- a/stub/Closure.stub
+++ b/stub/Closure.stub
@@ -1,5 +1,3 @@
-<?php
-
 class Closure
 {
 

--- a/stub/Collator.stub
+++ b/stub/Collator.stub
@@ -1,0 +1,109 @@
+class Collator
+{
+
+    const DEFAULT_VALUE = -1;
+
+    const PRIMARY = 0;
+
+    const SECONDARY = 1;
+
+    const TERTIARY = 2;
+
+    const DEFAULT_STRENGTH = 2;
+
+    const QUATERNARY = 3;
+
+    const IDENTICAL = 15;
+
+    const OFF = 16;
+
+    const ON = 17;
+
+    const SHIFTED = 20;
+
+    const NON_IGNORABLE = 21;
+
+    const LOWER_FIRST = 24;
+
+    const UPPER_FIRST = 25;
+
+    const FRENCH_COLLATION = 0;
+
+    const ALTERNATE_HANDLING = 1;
+
+    const CASE_FIRST = 2;
+
+    const CASE_LEVEL = 3;
+
+    const NORMALIZATION_MODE = 4;
+
+    const STRENGTH = 5;
+
+    const HIRAGANA_QUATERNARY_MODE = 6;
+
+    const NUMERIC_COLLATION = 7;
+
+    const SORT_REGULAR = 0;
+
+    const SORT_STRING = 1;
+
+    const SORT_NUMERIC = 2;
+
+    public function __construct($arg1)
+    {
+    }
+
+    public static function create($arg1)
+    {
+    }
+
+    public function compare($arg1, $arg2)
+    {
+    }
+
+    public function sort(array &$arr, $flags = null)
+    {
+    }
+
+    public function sortWithSortKeys(array &$arr, $flags = null)
+    {
+    }
+
+    public function asort(array &$arr, $flags = null)
+    {
+    }
+
+    public function getAttribute($arg1)
+    {
+    }
+
+    public function setAttribute($arg1, $arg2)
+    {
+    }
+
+    public function getStrength()
+    {
+    }
+
+    public function setStrength($arg1)
+    {
+    }
+
+    public function getLocale($arg1)
+    {
+    }
+
+    public function getErrorCode()
+    {
+    }
+
+    public function getErrorMessage()
+    {
+    }
+
+    public function getSortKey($arg1, $arg2)
+    {
+    }
+
+
+}

--- a/stub/DOMAttr.stub
+++ b/stub/DOMAttr.stub
@@ -1,0 +1,15 @@
+<?php
+
+class DOMAttr extends DOMNode
+{
+
+    public function isId()
+    {
+    }
+
+    public function __construct($name, $value = null)
+    {
+    }
+
+
+}

--- a/stub/DOMAttr.stub
+++ b/stub/DOMAttr.stub
@@ -1,5 +1,3 @@
-<?php
-
 class DOMAttr extends DOMNode
 {
 

--- a/stub/DOMComment.stub
+++ b/stub/DOMComment.stub
@@ -1,0 +1,11 @@
+<?php
+
+class DOMComment extends DOMCharacterData
+{
+
+    public function __construct($value = null)
+    {
+    }
+
+
+}

--- a/stub/DOMComment.stub
+++ b/stub/DOMComment.stub
@@ -1,5 +1,3 @@
-<?php
-
 class DOMComment extends DOMCharacterData
 {
 

--- a/stub/DOMConfiguration.stub
+++ b/stub/DOMConfiguration.stub
@@ -1,5 +1,3 @@
-<?php
-
 class DOMConfiguration
 {
 

--- a/stub/DOMConfiguration.stub
+++ b/stub/DOMConfiguration.stub
@@ -1,0 +1,19 @@
+<?php
+
+class DOMConfiguration
+{
+
+    public function setParameter($name, $value)
+    {
+    }
+
+    public function getParameter($name = null)
+    {
+    }
+
+    public function canSetParameter($name = null, $value = null)
+    {
+    }
+
+
+}

--- a/stub/DOMDocument.stub
+++ b/stub/DOMDocument.stub
@@ -81,7 +81,7 @@ class DOMDocument extends DOMNode
     {
     }
 
-    public function saveXML(\DOMNode $node = null)
+    public function saveXML(\DOMNode $node = null, $options = null)
     {
     }
 

--- a/stub/DOMDocument.stub
+++ b/stub/DOMDocument.stub
@@ -1,5 +1,3 @@
-<?php
-
 class DOMDocument extends DOMNode
 {
 

--- a/stub/DOMDocument.stub
+++ b/stub/DOMDocument.stub
@@ -1,0 +1,139 @@
+<?php
+
+class DOMDocument extends DOMNode
+{
+
+    public function createElement($tagName, $value = null)
+    {
+    }
+
+    public function createDocumentFragment()
+    {
+    }
+
+    public function createTextNode($data)
+    {
+    }
+
+    public function createComment($data)
+    {
+    }
+
+    public function createCDATASection($data)
+    {
+    }
+
+    public function createProcessingInstruction($target, $data)
+    {
+    }
+
+    public function createAttribute($name)
+    {
+    }
+
+    public function createEntityReference($name)
+    {
+    }
+
+    public function getElementsByTagName($tagName)
+    {
+    }
+
+    public function importNode(\DOMNode $importedNode, $deep)
+    {
+    }
+
+    public function createElementNS($namespaceURI, $qualifiedName, $value = null)
+    {
+    }
+
+    public function createAttributeNS($namespaceURI, $qualifiedName)
+    {
+    }
+
+    public function getElementsByTagNameNS($namespaceURI, $localName)
+    {
+    }
+
+    public function getElementById($elementId)
+    {
+    }
+
+    public function adoptNode(\DOMNode $source)
+    {
+    }
+
+    public function normalizeDocument()
+    {
+    }
+
+    public function renameNode(\DOMNode $node, $namespaceURI, $qualifiedName)
+    {
+    }
+
+    public function load($source, $options = 0)
+    {
+    }
+
+    public function save($file)
+    {
+    }
+
+    public function loadXML($source, $options = 0)
+    {
+    }
+
+    public function saveXML(\DOMNode $node = null)
+    {
+    }
+
+    public function __construct($version = null, $encoding = null)
+    {
+    }
+
+    public function validate()
+    {
+    }
+
+    public function xinclude($options = null)
+    {
+    }
+
+    public function loadHTML($source, $options = 0)
+    {
+    }
+
+    public function loadHTMLFile($source, $options = 0)
+    {
+    }
+
+    public function saveHTML()
+    {
+    }
+
+    public function saveHTMLFile($file)
+    {
+    }
+
+    public function schemaValidate($filename)
+    {
+    }
+
+    public function schemaValidateSource($source)
+    {
+    }
+
+    public function relaxNGValidate($filename)
+    {
+    }
+
+    public function relaxNGValidateSource($source)
+    {
+    }
+
+    public function registerNodeClass($baseClass, $extendedClass)
+    {
+    }
+
+
+}

--- a/stub/DOMElement.stub
+++ b/stub/DOMElement.stub
@@ -1,0 +1,81 @@
+class DOMElement extends DOMNode
+{
+
+    public function getAttribute($name)
+    {
+    }
+
+    public function setAttribute($name, $value)
+    {
+    }
+
+    public function removeAttribute($name)
+    {
+    }
+
+    public function getAttributeNode($name)
+    {
+    }
+
+    public function setAttributeNode(\DOMAttr $newAttr)
+    {
+    }
+
+    public function removeAttributeNode(\DOMAttr $oldAttr)
+    {
+    }
+
+    public function getElementsByTagName($name)
+    {
+    }
+
+    public function getAttributeNS($namespaceURI, $localName)
+    {
+    }
+
+    public function setAttributeNS($namespaceURI, $qualifiedName, $value)
+    {
+    }
+
+    public function removeAttributeNS($namespaceURI, $localName)
+    {
+    }
+
+    public function getAttributeNodeNS($namespaceURI, $localName)
+    {
+    }
+
+    public function setAttributeNodeNS(\DOMAttr $newAttr)
+    {
+    }
+
+    public function getElementsByTagNameNS($namespaceURI, $localName)
+    {
+    }
+
+    public function hasAttribute($name)
+    {
+    }
+
+    public function hasAttributeNS($namespaceURI, $localName)
+    {
+    }
+
+    public function setIdAttribute($name, $isId)
+    {
+    }
+
+    public function setIdAttributeNS($namespaceURI, $localName, $isId)
+    {
+    }
+
+    public function setIdAttributeNode(\DOMAttr $attr, $isId)
+    {
+    }
+
+    public function __construct($name, $value = null, $uri = null)
+    {
+    }
+
+
+}

--- a/stub/DOMNamedNodeMap.stub
+++ b/stub/DOMNamedNodeMap.stub
@@ -1,0 +1,33 @@
+class DOMNamedNodeMap implements Traversable
+{
+
+    public function getNamedItem($name)
+    {
+    }
+
+    public function setNamedItem(\DOMNode $arg)
+    {
+    }
+
+    public function removeNamedItem($name = null)
+    {
+    }
+
+    public function item($index = null)
+    {
+    }
+
+    public function getNamedItemNS($namespaceURI = null, $localName = null)
+    {
+    }
+
+    public function setNamedItemNS(\DOMNode $arg = null)
+    {
+    }
+
+    public function removeNamedItemNS($namespaceURI = null, $localName = null)
+    {
+    }
+
+
+}

--- a/stub/DOMNode.stub
+++ b/stub/DOMNode.stub
@@ -1,0 +1,93 @@
+class DOMNode
+{
+
+    public function insertBefore(\DOMNode $newChild, \DOMNode $refChild = null)
+    {
+    }
+
+    public function replaceChild(\DOMNode $newChild, \DOMNode $oldChild)
+    {
+    }
+
+    public function removeChild(\DOMNode $oldChild)
+    {
+    }
+
+    public function appendChild(\DOMNode $newChild)
+    {
+    }
+
+    public function hasChildNodes()
+    {
+    }
+
+    public function cloneNode($deep)
+    {
+    }
+
+    public function normalize()
+    {
+    }
+
+    public function isSupported($feature, $version)
+    {
+    }
+
+    public function hasAttributes()
+    {
+    }
+
+    public function compareDocumentPosition(\DOMNode $other)
+    {
+    }
+
+    public function isSameNode(\DOMNode $other)
+    {
+    }
+
+    public function lookupPrefix($namespaceURI)
+    {
+    }
+
+    public function isDefaultNamespace($namespaceURI)
+    {
+    }
+
+    public function lookupNamespaceUri($prefix)
+    {
+    }
+
+    public function isEqualNode(\DOMNode $arg)
+    {
+    }
+
+    public function getFeature($feature, $version)
+    {
+    }
+
+    public function setUserData($key, $data, $handler)
+    {
+    }
+
+    public function getUserData($key)
+    {
+    }
+
+    public function getNodePath()
+    {
+    }
+
+    public function getLineNo()
+    {
+    }
+
+    public function C14N($exclusive = null, $with_comments = null, array $xpath = null, array $ns_prefixes = null)
+    {
+    }
+
+    public function C14NFile($uri, $exclusive = null, $with_comments = null, array $xpath = null, array $ns_prefixes = null)
+    {
+    }
+
+
+}

--- a/stub/DOMProcessingInstruction.stub
+++ b/stub/DOMProcessingInstruction.stub
@@ -1,0 +1,11 @@
+<?php
+
+class DOMProcessingInstruction extends DOMNode
+{
+
+    public function __construct($name, $value = null)
+    {
+    }
+
+
+}

--- a/stub/DOMProcessingInstruction.stub
+++ b/stub/DOMProcessingInstruction.stub
@@ -1,5 +1,3 @@
-<?php
-
 class DOMProcessingInstruction extends DOMNode
 {
 

--- a/stub/DOMText.stub
+++ b/stub/DOMText.stub
@@ -1,5 +1,3 @@
-<?php
-
 class DOMText extends DOMCharacterData
 {
 

--- a/stub/DOMText.stub
+++ b/stub/DOMText.stub
@@ -1,0 +1,27 @@
+<?php
+
+class DOMText extends DOMCharacterData
+{
+
+    public function splitText($offset)
+    {
+    }
+
+    public function isWhitespaceInElementContent()
+    {
+    }
+
+    public function isElementContentWhitespace()
+    {
+    }
+
+    public function replaceWholeText($content)
+    {
+    }
+
+    public function __construct($value = null)
+    {
+    }
+
+
+}

--- a/stub/DOMXPath.stub
+++ b/stub/DOMXPath.stub
@@ -1,0 +1,25 @@
+class DOMXPath
+{
+
+    public function __construct(\DOMDocument $doc)
+    {
+    }
+
+    public function registerNamespace($prefix, $uri)
+    {
+    }
+
+    public function query($expr, \DOMNode $context = null, $registerNodeNS = true)
+    {
+    }
+
+    public function evaluate($expr, \DOMNode $context = null, $registerNodeNS = true)
+    {
+    }
+
+    public function registerPhpFunctions()
+    {
+    }
+
+
+}

--- a/stub/DateTime.stub
+++ b/stub/DateTime.stub
@@ -1,5 +1,3 @@
-<?php
-
 class DateTime implements DateTimeInterface
 {
 

--- a/stub/DateTime.stub
+++ b/stub/DateTime.stub
@@ -25,7 +25,7 @@ class DateTime implements DateTimeInterface
 
     const W3C = 'Y-m-d\\TH:i:sP';
 
-    public function __construct($time = 'now', $timezone = null)
+    public function __construct($time = 'now', $object = null)
     {
     }
 

--- a/stub/DateTime.stub
+++ b/stub/DateTime.stub
@@ -1,0 +1,103 @@
+<?php
+
+class DateTime implements DateTimeInterface
+{
+
+    const ATOM = 'Y-m-d\\TH:i:sP';
+
+    const COOKIE = 'l, d-M-Y H:i:s T';
+
+    const ISO8601 = 'Y-m-d\\TH:i:sO';
+
+    const RFC822 = 'D, d M y H:i:s O';
+
+    const RFC850 = 'l, d-M-y H:i:s T';
+
+    const RFC1036 = 'D, d M y H:i:s O';
+
+    const RFC1123 = 'D, d M Y H:i:s O';
+
+    const RFC2822 = 'D, d M Y H:i:s O';
+
+    const RFC3339 = 'Y-m-d\\TH:i:sP';
+
+    const RFC3339_EXTENDED = 'Y-m-d\\TH:i:s.vP';
+
+    const RSS = 'D, d M Y H:i:s O';
+
+    const W3C = 'Y-m-d\\TH:i:sP';
+
+    public function __construct($time = 'now', $timezone = null)
+    {
+    }
+
+    public function __wakeup()
+    {
+    }
+
+    public static function __set_state()
+    {
+    }
+
+    public static function createFromFormat($format, $time, $object = null)
+    {
+    }
+
+    public static function getLastErrors()
+    {
+    }
+
+    public function format($format)
+    {
+    }
+
+    public function modify($modify)
+    {
+    }
+
+    public function add($interval)
+    {
+    }
+
+    public function sub($interval)
+    {
+    }
+
+    public function getTimezone()
+    {
+    }
+
+    public function setTimezone($timezone)
+    {
+    }
+
+    public function getOffset()
+    {
+    }
+
+    public function setTime($hour, $minute, $second = 0)
+    {
+    }
+
+    public function setDate($year, $month, $day)
+    {
+    }
+
+    public function setISODate($year, $week, $day = 1)
+    {
+    }
+
+    public function setTimestamp($unixtimestamp)
+    {
+    }
+
+    public function getTimestamp()
+    {
+    }
+
+    public function diff($object, $absolute = false)
+    {
+    }
+
+
+}

--- a/stub/DateTimeImmutable.stub
+++ b/stub/DateTimeImmutable.stub
@@ -1,0 +1,83 @@
+<?php
+
+class DateTimeImmutable implements DateTimeInterface
+{
+
+    public function __construct($time = 'now', $timezone = null)
+    {
+    }
+
+    public function __wakeup()
+    {
+    }
+
+    public static function __set_state()
+    {
+    }
+
+    public static function createFromFormat($format, $time, $object = null)
+    {
+    }
+
+    public static function getLastErrors()
+    {
+    }
+
+    public function format($format)
+    {
+    }
+
+    public function getTimezone()
+    {
+    }
+
+    public function getOffset()
+    {
+    }
+
+    public function getTimestamp()
+    {
+    }
+
+    public function diff($object, $absolute = false)
+    {
+    }
+
+    public function modify($modify)
+    {
+    }
+
+    public function add($interval)
+    {
+    }
+
+    public function sub($interval)
+    {
+    }
+
+    public function setTimezone($timezone)
+    {
+    }
+
+    public function setTime($hour, $minute, $second = 0)
+    {
+    }
+
+    public function setDate($year, $month, $day)
+    {
+    }
+
+    public function setISODate($year, $week, $day = 1)
+    {
+    }
+
+    public function setTimestamp($unixtimestamp)
+    {
+    }
+
+    public static function createFromMutable($DateTime)
+    {
+    }
+
+
+}

--- a/stub/DateTimeImmutable.stub
+++ b/stub/DateTimeImmutable.stub
@@ -1,7 +1,7 @@
 class DateTimeImmutable implements DateTimeInterface
 {
 
-    public function __construct($time = 'now', $timezone = null)
+    public function __construct($time = 'now', $object = null)
     {
     }
 

--- a/stub/DateTimeImmutable.stub
+++ b/stub/DateTimeImmutable.stub
@@ -1,5 +1,3 @@
-<?php
-
 class DateTimeImmutable implements DateTimeInterface
 {
 

--- a/stub/DateTimeInterface.stub
+++ b/stub/DateTimeInterface.stub
@@ -1,5 +1,5 @@
 interface DateTimeInterface {
-    public function diff ( DateTimeInterface $datetime2, $absolute = false);
+    public function diff ( $object, $absolute = false);
     public function format ($format);
     public function getOffset ();
     public function getTimestamp ();

--- a/stub/DateTimeZone.stub
+++ b/stub/DateTimeZone.stub
@@ -1,0 +1,71 @@
+<?php
+
+class DateTimeZone
+{
+
+    const AFRICA = 1;
+
+    const AMERICA = 2;
+
+    const ANTARCTICA = 4;
+
+    const ARCTIC = 8;
+
+    const ASIA = 16;
+
+    const ATLANTIC = 32;
+
+    const AUSTRALIA = 64;
+
+    const EUROPE = 128;
+
+    const INDIAN = 256;
+
+    const PACIFIC = 512;
+
+    const UTC = 1024;
+
+    const ALL = 2047;
+
+    const ALL_WITH_BC = 4095;
+
+    const PER_COUNTRY = 4096;
+
+    public function __construct($timezone)
+    {
+    }
+
+    public function __wakeup()
+    {
+    }
+
+    public static function __set_state()
+    {
+    }
+
+    public function getName()
+    {
+    }
+
+    public function getOffset($object)
+    {
+    }
+
+    public function getTransitions($timestamp_begin, $timestamp_end)
+    {
+    }
+
+    public function getLocation()
+    {
+    }
+
+    public static function listAbbreviations()
+    {
+    }
+
+    public static function listIdentifiers($what = DateTimeZone::ALL, $country = null)
+    {
+    }
+
+
+}

--- a/stub/DateTimeZone.stub
+++ b/stub/DateTimeZone.stub
@@ -1,5 +1,3 @@
-<?php
-
 class DateTimeZone
 {
 

--- a/stub/Directory.stub
+++ b/stub/Directory.stub
@@ -1,0 +1,19 @@
+<?php
+
+class Directory
+{
+
+    public function close($dir_handle = null)
+    {
+    }
+
+    public function rewind($dir_handle = null)
+    {
+    }
+
+    public function read($dir_handle = null)
+    {
+    }
+
+
+}

--- a/stub/Directory.stub
+++ b/stub/Directory.stub
@@ -1,5 +1,3 @@
-<?php
-
 class Directory
 {
 

--- a/stub/DirectoryIterator.stub
+++ b/stub/DirectoryIterator.stub
@@ -1,0 +1,55 @@
+<?php
+
+class DirectoryIterator extends SplFileInfo implements Iterator, Traversable, SeekableIterator
+{
+
+    public function __construct($path)
+    {
+    }
+
+    public function getFilename()
+    {
+    }
+
+    public function getExtension()
+    {
+    }
+
+    public function getBasename($suffix = null)
+    {
+    }
+
+    public function isDot()
+    {
+    }
+
+    public function rewind()
+    {
+    }
+
+    public function valid()
+    {
+    }
+
+    public function key()
+    {
+    }
+
+    public function current()
+    {
+    }
+
+    public function next()
+    {
+    }
+
+    public function seek($position)
+    {
+    }
+
+    public function __toString()
+    {
+    }
+
+
+}

--- a/stub/DirectoryIterator.stub
+++ b/stub/DirectoryIterator.stub
@@ -1,5 +1,3 @@
-<?php
-
 class DirectoryIterator extends SplFileInfo implements Iterator, Traversable, SeekableIterator
 {
 

--- a/stub/Error.stub
+++ b/stub/Error.stub
@@ -1,0 +1,63 @@
+class Error implements Throwable
+{
+
+    protected $message = '';
+
+    private $string = '';
+
+    protected $code = 0;
+
+    protected $file = null;
+
+    protected $line = null;
+
+    private $trace = null;
+
+    private $previous = null;
+
+    final private function __clone()
+    {
+    }
+
+    public function __construct($message = '', $code = 0, $previous = null)
+    {
+    }
+
+    public function __wakeup()
+    {
+    }
+
+    final public function getMessage()
+    {
+    }
+
+    final public function getCode()
+    {
+    }
+
+    final public function getFile()
+    {
+    }
+
+    final public function getLine()
+    {
+    }
+
+    final public function getTrace()
+    {
+    }
+
+    final public function getPrevious()
+    {
+    }
+
+    final public function getTraceAsString()
+    {
+    }
+
+    public function __toString()
+    {
+    }
+
+
+}

--- a/stub/ErrorException.stub
+++ b/stub/ErrorException.stub
@@ -1,0 +1,17 @@
+<?php
+
+class ErrorException extends Exception
+{
+
+    protected $severity = 1;
+
+    public function __construct($message = '', $code = 0, $severity = 1, $filename = null, $lineno = null, $previous = null)
+    {
+    }
+
+    final public function getSeverity()
+    {
+    }
+
+
+}

--- a/stub/ErrorException.stub
+++ b/stub/ErrorException.stub
@@ -1,5 +1,3 @@
-<?php
-
 class ErrorException extends Exception
 {
 

--- a/stub/Exception.stub
+++ b/stub/Exception.stub
@@ -12,5 +12,6 @@ class Exception {
     final public function getTrace(){}
     final public function getTraceAsString(){}
     public function __toString(){}
+    public function __wakeup(){}
     final private function __clone(){}
 }

--- a/stub/Exception.stub
+++ b/stub/Exception.stub
@@ -3,7 +3,7 @@ class Exception {
     protected $code;
     protected $file;
     protected $line;
-    public function __construct($message = "", $code = 0, Exception $previous = null){}
+    public function __construct($message = "", $code = 0, $previous = null){}
     final public function getMessage(){}
     final public function getPrevious(){}
     final public function getCode(){}

--- a/stub/FilesystemIterator.stub
+++ b/stub/FilesystemIterator.stub
@@ -1,5 +1,3 @@
-<?php
-
 class FilesystemIterator extends DirectoryIterator
 {
 

--- a/stub/FilesystemIterator.stub
+++ b/stub/FilesystemIterator.stub
@@ -1,0 +1,59 @@
+<?php
+
+class FilesystemIterator extends DirectoryIterator
+{
+
+    const CURRENT_MODE_MASK = 240;
+
+    const CURRENT_AS_PATHNAME = 32;
+
+    const CURRENT_AS_FILEINFO = 0;
+
+    const CURRENT_AS_SELF = 16;
+
+    const KEY_MODE_MASK = 3840;
+
+    const KEY_AS_PATHNAME = 0;
+
+    const FOLLOW_SYMLINKS = 512;
+
+    const KEY_AS_FILENAME = 256;
+
+    const NEW_CURRENT_AND_KEY = 256;
+
+    const OTHER_MODE_MASK = 12288;
+
+    const SKIP_DOTS = 4096;
+
+    const UNIX_PATHS = 8192;
+
+    public function __construct($path, $flags = FilesystemIterator::KEY_AS_PATHNAME | FilesystemIterator::CURRENT_AS_FILEINFO | FilesystemIterator::SKIP_DOTS)
+    {
+    }
+
+    public function rewind()
+    {
+    }
+
+    public function next()
+    {
+    }
+
+    public function key()
+    {
+    }
+
+    public function current()
+    {
+    }
+
+    public function getFlags()
+    {
+    }
+
+    public function setFlags($flags = null)
+    {
+    }
+
+
+}

--- a/stub/GlobIterator.stub
+++ b/stub/GlobIterator.stub
@@ -1,0 +1,39 @@
+<?php
+
+class GlobIterator extends FilesystemIterator implements Countable
+{
+
+    const CURRENT_MODE_MASK = 240;
+
+    const CURRENT_AS_PATHNAME = 32;
+
+    const CURRENT_AS_FILEINFO = 0;
+
+    const CURRENT_AS_SELF = 16;
+
+    const KEY_MODE_MASK = 3840;
+
+    const KEY_AS_PATHNAME = 0;
+
+    const FOLLOW_SYMLINKS = 512;
+
+    const KEY_AS_FILENAME = 256;
+
+    const NEW_CURRENT_AND_KEY = 256;
+
+    const OTHER_MODE_MASK = 12288;
+
+    const SKIP_DOTS = 4096;
+
+    const UNIX_PATHS = 8192;
+
+    public function __construct($path, $flags = FilesystemIterator::KEY_AS_PATHNAME | FilesystemIterator::CURRENT_AS_FILEINFO)
+    {
+    }
+
+    public function count()
+    {
+    }
+
+
+}

--- a/stub/GlobIterator.stub
+++ b/stub/GlobIterator.stub
@@ -1,5 +1,3 @@
-<?php
-
 class GlobIterator extends FilesystemIterator implements Countable
 {
 

--- a/stub/IntlBreakIterator.stub
+++ b/stub/IntlBreakIterator.stub
@@ -1,5 +1,3 @@
-<?php
-
 class IntlBreakIterator implements Traversable
 {
 

--- a/stub/IntlBreakIterator.stub
+++ b/stub/IntlBreakIterator.stub
@@ -1,0 +1,129 @@
+<?php
+
+class IntlBreakIterator implements Traversable
+{
+
+    const DONE = -1;
+
+    const WORD_NONE = 0;
+
+    const WORD_NONE_LIMIT = 100;
+
+    const WORD_NUMBER = 100;
+
+    const WORD_NUMBER_LIMIT = 200;
+
+    const WORD_LETTER = 200;
+
+    const WORD_LETTER_LIMIT = 300;
+
+    const WORD_KANA = 300;
+
+    const WORD_KANA_LIMIT = 400;
+
+    const WORD_IDEO = 400;
+
+    const WORD_IDEO_LIMIT = 500;
+
+    const LINE_SOFT = 0;
+
+    const LINE_SOFT_LIMIT = 100;
+
+    const LINE_HARD = 100;
+
+    const LINE_HARD_LIMIT = 200;
+
+    const SENTENCE_TERM = 0;
+
+    const SENTENCE_TERM_LIMIT = 100;
+
+    const SENTENCE_SEP = 100;
+
+    const SENTENCE_SEP_LIMIT = 200;
+
+    private function __construct()
+    {
+    }
+
+    public static function createWordInstance($locale = null)
+    {
+    }
+
+    public static function createLineInstance($locale = null)
+    {
+    }
+
+    public static function createCharacterInstance($locale = null)
+    {
+    }
+
+    public static function createSentenceInstance($locale = null)
+    {
+    }
+
+    public static function createTitleInstance($locale = null)
+    {
+    }
+
+    public static function createCodePointInstance()
+    {
+    }
+
+    public function getText()
+    {
+    }
+
+    public function setText($text)
+    {
+    }
+
+    public function first()
+    {
+    }
+
+    public function last()
+    {
+    }
+
+    public function previous()
+    {
+    }
+
+    public function next($offset = null)
+    {
+    }
+
+    public function current()
+    {
+    }
+
+    public function following($offset)
+    {
+    }
+
+    public function preceding($offset)
+    {
+    }
+
+    public function isBoundary($offset)
+    {
+    }
+
+    public function getLocale($locale_type)
+    {
+    }
+
+    public function getPartsIterator($key_type = null)
+    {
+    }
+
+    public function getErrorCode()
+    {
+    }
+
+    public function getErrorMessage()
+    {
+    }
+
+
+}

--- a/stub/IntlCalendar.stub
+++ b/stub/IntlCalendar.stub
@@ -1,0 +1,269 @@
+<?php
+
+class IntlCalendar
+{
+
+    const FIELD_ERA = 0;
+
+    const FIELD_YEAR = 1;
+
+    const FIELD_MONTH = 2;
+
+    const FIELD_WEEK_OF_YEAR = 3;
+
+    const FIELD_WEEK_OF_MONTH = 4;
+
+    const FIELD_DATE = 5;
+
+    const FIELD_DAY_OF_YEAR = 6;
+
+    const FIELD_DAY_OF_WEEK = 7;
+
+    const FIELD_DAY_OF_WEEK_IN_MONTH = 8;
+
+    const FIELD_AM_PM = 9;
+
+    const FIELD_HOUR = 10;
+
+    const FIELD_HOUR_OF_DAY = 11;
+
+    const FIELD_MINUTE = 12;
+
+    const FIELD_SECOND = 13;
+
+    const FIELD_MILLISECOND = 14;
+
+    const FIELD_ZONE_OFFSET = 15;
+
+    const FIELD_DST_OFFSET = 16;
+
+    const FIELD_YEAR_WOY = 17;
+
+    const FIELD_DOW_LOCAL = 18;
+
+    const FIELD_EXTENDED_YEAR = 19;
+
+    const FIELD_JULIAN_DAY = 20;
+
+    const FIELD_MILLISECONDS_IN_DAY = 21;
+
+    const FIELD_IS_LEAP_MONTH = 22;
+
+    const FIELD_FIELD_COUNT = 23;
+
+    const FIELD_DAY_OF_MONTH = 5;
+
+    const DOW_SUNDAY = 1;
+
+    const DOW_MONDAY = 2;
+
+    const DOW_TUESDAY = 3;
+
+    const DOW_WEDNESDAY = 4;
+
+    const DOW_THURSDAY = 5;
+
+    const DOW_FRIDAY = 6;
+
+    const DOW_SATURDAY = 7;
+
+    const DOW_TYPE_WEEKDAY = 0;
+
+    const DOW_TYPE_WEEKEND = 1;
+
+    const DOW_TYPE_WEEKEND_OFFSET = 2;
+
+    const DOW_TYPE_WEEKEND_CEASE = 3;
+
+    const WALLTIME_FIRST = 1;
+
+    const WALLTIME_LAST = 0;
+
+    const WALLTIME_NEXT_VALID = 2;
+
+    private function __construct()
+    {
+    }
+
+    public static function createInstance($timeZone = NULL, $locale = '')
+    {
+    }
+
+    public static function getKeywordValuesForLocale($key, $locale, $commonlyUsed)
+    {
+    }
+
+    public static function getNow()
+    {
+    }
+
+    public static function getAvailableLocales()
+    {
+    }
+
+    public function get($field)
+    {
+    }
+
+    public function getTime()
+    {
+    }
+
+    public function setTime($date)
+    {
+    }
+
+    public function add($field, $amount)
+    {
+    }
+
+    public function setTimeZone($timeZone)
+    {
+    }
+
+    public function after(\IntlCalendar $calendar)
+    {
+    }
+
+    public function before(\IntlCalendar $calendar)
+    {
+    }
+
+    public function set($fieldOrYear, $valueOrMonth, $dayOfMonth = NULL, $hour = NULL, $minute = NULL, $second = NULL)
+    {
+    }
+
+    public function roll($field, $amountOrUpOrDown)
+    {
+    }
+
+    public function clear($field = NULL)
+    {
+    }
+
+    public function fieldDifference($when, $field)
+    {
+    }
+
+    public function getActualMaximum($field)
+    {
+    }
+
+    public function getActualMinimum($field)
+    {
+    }
+
+    public function getDayOfWeekType($dayOfWeek)
+    {
+    }
+
+    public function getFirstDayOfWeek()
+    {
+    }
+
+    public function getGreatestMinimum($field)
+    {
+    }
+
+    public function getLeastMaximum($field)
+    {
+    }
+
+    public function getLocale($localeType)
+    {
+    }
+
+    public function getMaximum($field)
+    {
+    }
+
+    public function getMinimalDaysInFirstWeek()
+    {
+    }
+
+    public function getMinimum($field)
+    {
+    }
+
+    public function getTimeZone()
+    {
+    }
+
+    public function getType()
+    {
+    }
+
+    public function getWeekendTransition($dayOfWeek)
+    {
+    }
+
+    public function inDaylightTime()
+    {
+    }
+
+    public function isEquivalentTo(\IntlCalendar $calendar)
+    {
+    }
+
+    public function isLenient()
+    {
+    }
+
+    public function isSet($field)
+    {
+    }
+
+    public function isWeekend($date = NULL)
+    {
+    }
+
+    public function setFirstDayOfWeek($dayOfWeek)
+    {
+    }
+
+    public function setLenient($isLenient)
+    {
+    }
+
+    public function setMinimalDaysInFirstWeek($numberOfDays)
+    {
+    }
+
+    public function equals(\IntlCalendar $calendar)
+    {
+    }
+
+    public function getRepeatedWallTimeOption()
+    {
+    }
+
+    public function getSkippedWallTimeOption()
+    {
+    }
+
+    public function setRepeatedWallTimeOption($wallTimeOption)
+    {
+    }
+
+    public function setSkippedWallTimeOption($wallTimeOption)
+    {
+    }
+
+    public static function fromDateTime($dateTime)
+    {
+    }
+
+    public function toDateTime()
+    {
+    }
+
+    public function getErrorCode()
+    {
+    }
+
+    public function getErrorMessage()
+    {
+    }
+
+
+}

--- a/stub/IntlCalendar.stub
+++ b/stub/IntlCalendar.stub
@@ -1,5 +1,3 @@
-<?php
-
 class IntlCalendar
 {
 

--- a/stub/IntlChar.stub
+++ b/stub/IntlChar.stub
@@ -1,5 +1,3 @@
-<?php
-
 class IntlChar
 {
 

--- a/stub/IntlChar.stub
+++ b/stub/IntlChar.stub
@@ -1,0 +1,1563 @@
+<?php
+
+class IntlChar
+{
+
+    const UNICODE_VERSION = '7.0';
+
+    const CODEPOINT_MIN = 0;
+
+    const CODEPOINT_MAX = 1114111;
+
+    const PROPERTY_ALPHABETIC = 0;
+
+    const PROPERTY_BINARY_START = 0;
+
+    const PROPERTY_ASCII_HEX_DIGIT = 1;
+
+    const PROPERTY_BIDI_CONTROL = 2;
+
+    const PROPERTY_BIDI_MIRRORED = 3;
+
+    const PROPERTY_DASH = 4;
+
+    const PROPERTY_DEFAULT_IGNORABLE_CODE_POINT = 5;
+
+    const PROPERTY_DEPRECATED = 6;
+
+    const PROPERTY_DIACRITIC = 7;
+
+    const PROPERTY_EXTENDER = 8;
+
+    const PROPERTY_FULL_COMPOSITION_EXCLUSION = 9;
+
+    const PROPERTY_GRAPHEME_BASE = 10;
+
+    const PROPERTY_GRAPHEME_EXTEND = 11;
+
+    const PROPERTY_GRAPHEME_LINK = 12;
+
+    const PROPERTY_HEX_DIGIT = 13;
+
+    const PROPERTY_HYPHEN = 14;
+
+    const PROPERTY_ID_CONTINUE = 15;
+
+    const PROPERTY_ID_START = 16;
+
+    const PROPERTY_IDEOGRAPHIC = 17;
+
+    const PROPERTY_IDS_BINARY_OPERATOR = 18;
+
+    const PROPERTY_IDS_TRINARY_OPERATOR = 19;
+
+    const PROPERTY_JOIN_CONTROL = 20;
+
+    const PROPERTY_LOGICAL_ORDER_EXCEPTION = 21;
+
+    const PROPERTY_LOWERCASE = 22;
+
+    const PROPERTY_MATH = 23;
+
+    const PROPERTY_NONCHARACTER_CODE_POINT = 24;
+
+    const PROPERTY_QUOTATION_MARK = 25;
+
+    const PROPERTY_RADICAL = 26;
+
+    const PROPERTY_SOFT_DOTTED = 27;
+
+    const PROPERTY_TERMINAL_PUNCTUATION = 28;
+
+    const PROPERTY_UNIFIED_IDEOGRAPH = 29;
+
+    const PROPERTY_UPPERCASE = 30;
+
+    const PROPERTY_WHITE_SPACE = 31;
+
+    const PROPERTY_XID_CONTINUE = 32;
+
+    const PROPERTY_XID_START = 33;
+
+    const PROPERTY_CASE_SENSITIVE = 34;
+
+    const PROPERTY_S_TERM = 35;
+
+    const PROPERTY_VARIATION_SELECTOR = 36;
+
+    const PROPERTY_NFD_INERT = 37;
+
+    const PROPERTY_NFKD_INERT = 38;
+
+    const PROPERTY_NFC_INERT = 39;
+
+    const PROPERTY_NFKC_INERT = 40;
+
+    const PROPERTY_SEGMENT_STARTER = 41;
+
+    const PROPERTY_PATTERN_SYNTAX = 42;
+
+    const PROPERTY_PATTERN_WHITE_SPACE = 43;
+
+    const PROPERTY_POSIX_ALNUM = 44;
+
+    const PROPERTY_POSIX_BLANK = 45;
+
+    const PROPERTY_POSIX_GRAPH = 46;
+
+    const PROPERTY_POSIX_PRINT = 47;
+
+    const PROPERTY_POSIX_XDIGIT = 48;
+
+    const PROPERTY_CASED = 49;
+
+    const PROPERTY_CASE_IGNORABLE = 50;
+
+    const PROPERTY_CHANGES_WHEN_LOWERCASED = 51;
+
+    const PROPERTY_CHANGES_WHEN_UPPERCASED = 52;
+
+    const PROPERTY_CHANGES_WHEN_TITLECASED = 53;
+
+    const PROPERTY_CHANGES_WHEN_CASEFOLDED = 54;
+
+    const PROPERTY_CHANGES_WHEN_CASEMAPPED = 55;
+
+    const PROPERTY_CHANGES_WHEN_NFKC_CASEFOLDED = 56;
+
+    const PROPERTY_BINARY_LIMIT = 57;
+
+    const PROPERTY_BIDI_CLASS = 4096;
+
+    const PROPERTY_INT_START = 4096;
+
+    const PROPERTY_BLOCK = 4097;
+
+    const PROPERTY_CANONICAL_COMBINING_CLASS = 4098;
+
+    const PROPERTY_DECOMPOSITION_TYPE = 4099;
+
+    const PROPERTY_EAST_ASIAN_WIDTH = 4100;
+
+    const PROPERTY_GENERAL_CATEGORY = 4101;
+
+    const PROPERTY_JOINING_GROUP = 4102;
+
+    const PROPERTY_JOINING_TYPE = 4103;
+
+    const PROPERTY_LINE_BREAK = 4104;
+
+    const PROPERTY_NUMERIC_TYPE = 4105;
+
+    const PROPERTY_SCRIPT = 4106;
+
+    const PROPERTY_HANGUL_SYLLABLE_TYPE = 4107;
+
+    const PROPERTY_NFD_QUICK_CHECK = 4108;
+
+    const PROPERTY_NFKD_QUICK_CHECK = 4109;
+
+    const PROPERTY_NFC_QUICK_CHECK = 4110;
+
+    const PROPERTY_NFKC_QUICK_CHECK = 4111;
+
+    const PROPERTY_LEAD_CANONICAL_COMBINING_CLASS = 4112;
+
+    const PROPERTY_TRAIL_CANONICAL_COMBINING_CLASS = 4113;
+
+    const PROPERTY_GRAPHEME_CLUSTER_BREAK = 4114;
+
+    const PROPERTY_SENTENCE_BREAK = 4115;
+
+    const PROPERTY_WORD_BREAK = 4116;
+
+    const PROPERTY_BIDI_PAIRED_BRACKET_TYPE = 4117;
+
+    const PROPERTY_INT_LIMIT = 4118;
+
+    const PROPERTY_GENERAL_CATEGORY_MASK = 8192;
+
+    const PROPERTY_MASK_START = 8192;
+
+    const PROPERTY_MASK_LIMIT = 8193;
+
+    const PROPERTY_NUMERIC_VALUE = 12288;
+
+    const PROPERTY_DOUBLE_START = 12288;
+
+    const PROPERTY_DOUBLE_LIMIT = 12289;
+
+    const PROPERTY_AGE = 16384;
+
+    const PROPERTY_STRING_START = 16384;
+
+    const PROPERTY_BIDI_MIRRORING_GLYPH = 16385;
+
+    const PROPERTY_CASE_FOLDING = 16386;
+
+    const PROPERTY_ISO_COMMENT = 16387;
+
+    const PROPERTY_LOWERCASE_MAPPING = 16388;
+
+    const PROPERTY_NAME = 16389;
+
+    const PROPERTY_SIMPLE_CASE_FOLDING = 16390;
+
+    const PROPERTY_SIMPLE_LOWERCASE_MAPPING = 16391;
+
+    const PROPERTY_SIMPLE_TITLECASE_MAPPING = 16392;
+
+    const PROPERTY_SIMPLE_UPPERCASE_MAPPING = 16393;
+
+    const PROPERTY_TITLECASE_MAPPING = 16394;
+
+    const PROPERTY_UNICODE_1_NAME = 16395;
+
+    const PROPERTY_UPPERCASE_MAPPING = 16396;
+
+    const PROPERTY_BIDI_PAIRED_BRACKET = 16397;
+
+    const PROPERTY_STRING_LIMIT = 16398;
+
+    const PROPERTY_SCRIPT_EXTENSIONS = 28672;
+
+    const PROPERTY_OTHER_PROPERTY_START = 28672;
+
+    const PROPERTY_OTHER_PROPERTY_LIMIT = 28673;
+
+    const PROPERTY_INVALID_CODE = -1;
+
+    const CHAR_CATEGORY_UNASSIGNED = 0;
+
+    const CHAR_CATEGORY_GENERAL_OTHER_TYPES = 0;
+
+    const CHAR_CATEGORY_UPPERCASE_LETTER = 1;
+
+    const CHAR_CATEGORY_LOWERCASE_LETTER = 2;
+
+    const CHAR_CATEGORY_TITLECASE_LETTER = 3;
+
+    const CHAR_CATEGORY_MODIFIER_LETTER = 4;
+
+    const CHAR_CATEGORY_OTHER_LETTER = 5;
+
+    const CHAR_CATEGORY_NON_SPACING_MARK = 6;
+
+    const CHAR_CATEGORY_ENCLOSING_MARK = 7;
+
+    const CHAR_CATEGORY_COMBINING_SPACING_MARK = 8;
+
+    const CHAR_CATEGORY_DECIMAL_DIGIT_NUMBER = 9;
+
+    const CHAR_CATEGORY_LETTER_NUMBER = 10;
+
+    const CHAR_CATEGORY_OTHER_NUMBER = 11;
+
+    const CHAR_CATEGORY_SPACE_SEPARATOR = 12;
+
+    const CHAR_CATEGORY_LINE_SEPARATOR = 13;
+
+    const CHAR_CATEGORY_PARAGRAPH_SEPARATOR = 14;
+
+    const CHAR_CATEGORY_CONTROL_CHAR = 15;
+
+    const CHAR_CATEGORY_FORMAT_CHAR = 16;
+
+    const CHAR_CATEGORY_PRIVATE_USE_CHAR = 17;
+
+    const CHAR_CATEGORY_SURROGATE = 18;
+
+    const CHAR_CATEGORY_DASH_PUNCTUATION = 19;
+
+    const CHAR_CATEGORY_START_PUNCTUATION = 20;
+
+    const CHAR_CATEGORY_END_PUNCTUATION = 21;
+
+    const CHAR_CATEGORY_CONNECTOR_PUNCTUATION = 22;
+
+    const CHAR_CATEGORY_OTHER_PUNCTUATION = 23;
+
+    const CHAR_CATEGORY_MATH_SYMBOL = 24;
+
+    const CHAR_CATEGORY_CURRENCY_SYMBOL = 25;
+
+    const CHAR_CATEGORY_MODIFIER_SYMBOL = 26;
+
+    const CHAR_CATEGORY_OTHER_SYMBOL = 27;
+
+    const CHAR_CATEGORY_INITIAL_PUNCTUATION = 28;
+
+    const CHAR_CATEGORY_FINAL_PUNCTUATION = 29;
+
+    const CHAR_CATEGORY_CHAR_CATEGORY_COUNT = 30;
+
+    const CHAR_DIRECTION_LEFT_TO_RIGHT = 0;
+
+    const CHAR_DIRECTION_RIGHT_TO_LEFT = 1;
+
+    const CHAR_DIRECTION_EUROPEAN_NUMBER = 2;
+
+    const CHAR_DIRECTION_EUROPEAN_NUMBER_SEPARATOR = 3;
+
+    const CHAR_DIRECTION_EUROPEAN_NUMBER_TERMINATOR = 4;
+
+    const CHAR_DIRECTION_ARABIC_NUMBER = 5;
+
+    const CHAR_DIRECTION_COMMON_NUMBER_SEPARATOR = 6;
+
+    const CHAR_DIRECTION_BLOCK_SEPARATOR = 7;
+
+    const CHAR_DIRECTION_SEGMENT_SEPARATOR = 8;
+
+    const CHAR_DIRECTION_WHITE_SPACE_NEUTRAL = 9;
+
+    const CHAR_DIRECTION_OTHER_NEUTRAL = 10;
+
+    const CHAR_DIRECTION_LEFT_TO_RIGHT_EMBEDDING = 11;
+
+    const CHAR_DIRECTION_LEFT_TO_RIGHT_OVERRIDE = 12;
+
+    const CHAR_DIRECTION_RIGHT_TO_LEFT_ARABIC = 13;
+
+    const CHAR_DIRECTION_RIGHT_TO_LEFT_EMBEDDING = 14;
+
+    const CHAR_DIRECTION_RIGHT_TO_LEFT_OVERRIDE = 15;
+
+    const CHAR_DIRECTION_POP_DIRECTIONAL_FORMAT = 16;
+
+    const CHAR_DIRECTION_DIR_NON_SPACING_MARK = 17;
+
+    const CHAR_DIRECTION_BOUNDARY_NEUTRAL = 18;
+
+    const CHAR_DIRECTION_FIRST_STRONG_ISOLATE = 19;
+
+    const CHAR_DIRECTION_LEFT_TO_RIGHT_ISOLATE = 20;
+
+    const CHAR_DIRECTION_RIGHT_TO_LEFT_ISOLATE = 21;
+
+    const CHAR_DIRECTION_POP_DIRECTIONAL_ISOLATE = 22;
+
+    const CHAR_DIRECTION_CHAR_DIRECTION_COUNT = 23;
+
+    const BLOCK_CODE_NO_BLOCK = 0;
+
+    const BLOCK_CODE_BASIC_LATIN = 1;
+
+    const BLOCK_CODE_LATIN_1_SUPPLEMENT = 2;
+
+    const BLOCK_CODE_LATIN_EXTENDED_A = 3;
+
+    const BLOCK_CODE_LATIN_EXTENDED_B = 4;
+
+    const BLOCK_CODE_IPA_EXTENSIONS = 5;
+
+    const BLOCK_CODE_SPACING_MODIFIER_LETTERS = 6;
+
+    const BLOCK_CODE_COMBINING_DIACRITICAL_MARKS = 7;
+
+    const BLOCK_CODE_GREEK = 8;
+
+    const BLOCK_CODE_CYRILLIC = 9;
+
+    const BLOCK_CODE_ARMENIAN = 10;
+
+    const BLOCK_CODE_HEBREW = 11;
+
+    const BLOCK_CODE_ARABIC = 12;
+
+    const BLOCK_CODE_SYRIAC = 13;
+
+    const BLOCK_CODE_THAANA = 14;
+
+    const BLOCK_CODE_DEVANAGARI = 15;
+
+    const BLOCK_CODE_BENGALI = 16;
+
+    const BLOCK_CODE_GURMUKHI = 17;
+
+    const BLOCK_CODE_GUJARATI = 18;
+
+    const BLOCK_CODE_ORIYA = 19;
+
+    const BLOCK_CODE_TAMIL = 20;
+
+    const BLOCK_CODE_TELUGU = 21;
+
+    const BLOCK_CODE_KANNADA = 22;
+
+    const BLOCK_CODE_MALAYALAM = 23;
+
+    const BLOCK_CODE_SINHALA = 24;
+
+    const BLOCK_CODE_THAI = 25;
+
+    const BLOCK_CODE_LAO = 26;
+
+    const BLOCK_CODE_TIBETAN = 27;
+
+    const BLOCK_CODE_MYANMAR = 28;
+
+    const BLOCK_CODE_GEORGIAN = 29;
+
+    const BLOCK_CODE_HANGUL_JAMO = 30;
+
+    const BLOCK_CODE_ETHIOPIC = 31;
+
+    const BLOCK_CODE_CHEROKEE = 32;
+
+    const BLOCK_CODE_UNIFIED_CANADIAN_ABORIGINAL_SYLLABICS = 33;
+
+    const BLOCK_CODE_OGHAM = 34;
+
+    const BLOCK_CODE_RUNIC = 35;
+
+    const BLOCK_CODE_KHMER = 36;
+
+    const BLOCK_CODE_MONGOLIAN = 37;
+
+    const BLOCK_CODE_LATIN_EXTENDED_ADDITIONAL = 38;
+
+    const BLOCK_CODE_GREEK_EXTENDED = 39;
+
+    const BLOCK_CODE_GENERAL_PUNCTUATION = 40;
+
+    const BLOCK_CODE_SUPERSCRIPTS_AND_SUBSCRIPTS = 41;
+
+    const BLOCK_CODE_CURRENCY_SYMBOLS = 42;
+
+    const BLOCK_CODE_COMBINING_MARKS_FOR_SYMBOLS = 43;
+
+    const BLOCK_CODE_LETTERLIKE_SYMBOLS = 44;
+
+    const BLOCK_CODE_NUMBER_FORMS = 45;
+
+    const BLOCK_CODE_ARROWS = 46;
+
+    const BLOCK_CODE_MATHEMATICAL_OPERATORS = 47;
+
+    const BLOCK_CODE_MISCELLANEOUS_TECHNICAL = 48;
+
+    const BLOCK_CODE_CONTROL_PICTURES = 49;
+
+    const BLOCK_CODE_OPTICAL_CHARACTER_RECOGNITION = 50;
+
+    const BLOCK_CODE_ENCLOSED_ALPHANUMERICS = 51;
+
+    const BLOCK_CODE_BOX_DRAWING = 52;
+
+    const BLOCK_CODE_BLOCK_ELEMENTS = 53;
+
+    const BLOCK_CODE_GEOMETRIC_SHAPES = 54;
+
+    const BLOCK_CODE_MISCELLANEOUS_SYMBOLS = 55;
+
+    const BLOCK_CODE_DINGBATS = 56;
+
+    const BLOCK_CODE_BRAILLE_PATTERNS = 57;
+
+    const BLOCK_CODE_CJK_RADICALS_SUPPLEMENT = 58;
+
+    const BLOCK_CODE_KANGXI_RADICALS = 59;
+
+    const BLOCK_CODE_IDEOGRAPHIC_DESCRIPTION_CHARACTERS = 60;
+
+    const BLOCK_CODE_CJK_SYMBOLS_AND_PUNCTUATION = 61;
+
+    const BLOCK_CODE_HIRAGANA = 62;
+
+    const BLOCK_CODE_KATAKANA = 63;
+
+    const BLOCK_CODE_BOPOMOFO = 64;
+
+    const BLOCK_CODE_HANGUL_COMPATIBILITY_JAMO = 65;
+
+    const BLOCK_CODE_KANBUN = 66;
+
+    const BLOCK_CODE_BOPOMOFO_EXTENDED = 67;
+
+    const BLOCK_CODE_ENCLOSED_CJK_LETTERS_AND_MONTHS = 68;
+
+    const BLOCK_CODE_CJK_COMPATIBILITY = 69;
+
+    const BLOCK_CODE_CJK_UNIFIED_IDEOGRAPHS_EXTENSION_A = 70;
+
+    const BLOCK_CODE_CJK_UNIFIED_IDEOGRAPHS = 71;
+
+    const BLOCK_CODE_YI_SYLLABLES = 72;
+
+    const BLOCK_CODE_YI_RADICALS = 73;
+
+    const BLOCK_CODE_HANGUL_SYLLABLES = 74;
+
+    const BLOCK_CODE_HIGH_SURROGATES = 75;
+
+    const BLOCK_CODE_HIGH_PRIVATE_USE_SURROGATES = 76;
+
+    const BLOCK_CODE_LOW_SURROGATES = 77;
+
+    const BLOCK_CODE_PRIVATE_USE_AREA = 78;
+
+    const BLOCK_CODE_PRIVATE_USE = 78;
+
+    const BLOCK_CODE_CJK_COMPATIBILITY_IDEOGRAPHS = 79;
+
+    const BLOCK_CODE_ALPHABETIC_PRESENTATION_FORMS = 80;
+
+    const BLOCK_CODE_ARABIC_PRESENTATION_FORMS_A = 81;
+
+    const BLOCK_CODE_COMBINING_HALF_MARKS = 82;
+
+    const BLOCK_CODE_CJK_COMPATIBILITY_FORMS = 83;
+
+    const BLOCK_CODE_SMALL_FORM_VARIANTS = 84;
+
+    const BLOCK_CODE_ARABIC_PRESENTATION_FORMS_B = 85;
+
+    const BLOCK_CODE_SPECIALS = 86;
+
+    const BLOCK_CODE_HALFWIDTH_AND_FULLWIDTH_FORMS = 87;
+
+    const BLOCK_CODE_OLD_ITALIC = 88;
+
+    const BLOCK_CODE_GOTHIC = 89;
+
+    const BLOCK_CODE_DESERET = 90;
+
+    const BLOCK_CODE_BYZANTINE_MUSICAL_SYMBOLS = 91;
+
+    const BLOCK_CODE_MUSICAL_SYMBOLS = 92;
+
+    const BLOCK_CODE_MATHEMATICAL_ALPHANUMERIC_SYMBOLS = 93;
+
+    const BLOCK_CODE_CJK_UNIFIED_IDEOGRAPHS_EXTENSION_B = 94;
+
+    const BLOCK_CODE_CJK_COMPATIBILITY_IDEOGRAPHS_SUPPLEMENT = 95;
+
+    const BLOCK_CODE_TAGS = 96;
+
+    const BLOCK_CODE_CYRILLIC_SUPPLEMENT = 97;
+
+    const BLOCK_CODE_CYRILLIC_SUPPLEMENTARY = 97;
+
+    const BLOCK_CODE_TAGALOG = 98;
+
+    const BLOCK_CODE_HANUNOO = 99;
+
+    const BLOCK_CODE_BUHID = 100;
+
+    const BLOCK_CODE_TAGBANWA = 101;
+
+    const BLOCK_CODE_MISCELLANEOUS_MATHEMATICAL_SYMBOLS_A = 102;
+
+    const BLOCK_CODE_SUPPLEMENTAL_ARROWS_A = 103;
+
+    const BLOCK_CODE_SUPPLEMENTAL_ARROWS_B = 104;
+
+    const BLOCK_CODE_MISCELLANEOUS_MATHEMATICAL_SYMBOLS_B = 105;
+
+    const BLOCK_CODE_SUPPLEMENTAL_MATHEMATICAL_OPERATORS = 106;
+
+    const BLOCK_CODE_KATAKANA_PHONETIC_EXTENSIONS = 107;
+
+    const BLOCK_CODE_VARIATION_SELECTORS = 108;
+
+    const BLOCK_CODE_SUPPLEMENTARY_PRIVATE_USE_AREA_A = 109;
+
+    const BLOCK_CODE_SUPPLEMENTARY_PRIVATE_USE_AREA_B = 110;
+
+    const BLOCK_CODE_LIMBU = 111;
+
+    const BLOCK_CODE_TAI_LE = 112;
+
+    const BLOCK_CODE_KHMER_SYMBOLS = 113;
+
+    const BLOCK_CODE_PHONETIC_EXTENSIONS = 114;
+
+    const BLOCK_CODE_MISCELLANEOUS_SYMBOLS_AND_ARROWS = 115;
+
+    const BLOCK_CODE_YIJING_HEXAGRAM_SYMBOLS = 116;
+
+    const BLOCK_CODE_LINEAR_B_SYLLABARY = 117;
+
+    const BLOCK_CODE_LINEAR_B_IDEOGRAMS = 118;
+
+    const BLOCK_CODE_AEGEAN_NUMBERS = 119;
+
+    const BLOCK_CODE_UGARITIC = 120;
+
+    const BLOCK_CODE_SHAVIAN = 121;
+
+    const BLOCK_CODE_OSMANYA = 122;
+
+    const BLOCK_CODE_CYPRIOT_SYLLABARY = 123;
+
+    const BLOCK_CODE_TAI_XUAN_JING_SYMBOLS = 124;
+
+    const BLOCK_CODE_VARIATION_SELECTORS_SUPPLEMENT = 125;
+
+    const BLOCK_CODE_ANCIENT_GREEK_MUSICAL_NOTATION = 126;
+
+    const BLOCK_CODE_ANCIENT_GREEK_NUMBERS = 127;
+
+    const BLOCK_CODE_ARABIC_SUPPLEMENT = 128;
+
+    const BLOCK_CODE_BUGINESE = 129;
+
+    const BLOCK_CODE_CJK_STROKES = 130;
+
+    const BLOCK_CODE_COMBINING_DIACRITICAL_MARKS_SUPPLEMENT = 131;
+
+    const BLOCK_CODE_COPTIC = 132;
+
+    const BLOCK_CODE_ETHIOPIC_EXTENDED = 133;
+
+    const BLOCK_CODE_ETHIOPIC_SUPPLEMENT = 134;
+
+    const BLOCK_CODE_GEORGIAN_SUPPLEMENT = 135;
+
+    const BLOCK_CODE_GLAGOLITIC = 136;
+
+    const BLOCK_CODE_KHAROSHTHI = 137;
+
+    const BLOCK_CODE_MODIFIER_TONE_LETTERS = 138;
+
+    const BLOCK_CODE_NEW_TAI_LUE = 139;
+
+    const BLOCK_CODE_OLD_PERSIAN = 140;
+
+    const BLOCK_CODE_PHONETIC_EXTENSIONS_SUPPLEMENT = 141;
+
+    const BLOCK_CODE_SUPPLEMENTAL_PUNCTUATION = 142;
+
+    const BLOCK_CODE_SYLOTI_NAGRI = 143;
+
+    const BLOCK_CODE_TIFINAGH = 144;
+
+    const BLOCK_CODE_VERTICAL_FORMS = 145;
+
+    const BLOCK_CODE_NKO = 146;
+
+    const BLOCK_CODE_BALINESE = 147;
+
+    const BLOCK_CODE_LATIN_EXTENDED_C = 148;
+
+    const BLOCK_CODE_LATIN_EXTENDED_D = 149;
+
+    const BLOCK_CODE_PHAGS_PA = 150;
+
+    const BLOCK_CODE_PHOENICIAN = 151;
+
+    const BLOCK_CODE_CUNEIFORM = 152;
+
+    const BLOCK_CODE_CUNEIFORM_NUMBERS_AND_PUNCTUATION = 153;
+
+    const BLOCK_CODE_COUNTING_ROD_NUMERALS = 154;
+
+    const BLOCK_CODE_SUNDANESE = 155;
+
+    const BLOCK_CODE_LEPCHA = 156;
+
+    const BLOCK_CODE_OL_CHIKI = 157;
+
+    const BLOCK_CODE_CYRILLIC_EXTENDED_A = 158;
+
+    const BLOCK_CODE_VAI = 159;
+
+    const BLOCK_CODE_CYRILLIC_EXTENDED_B = 160;
+
+    const BLOCK_CODE_SAURASHTRA = 161;
+
+    const BLOCK_CODE_KAYAH_LI = 162;
+
+    const BLOCK_CODE_REJANG = 163;
+
+    const BLOCK_CODE_CHAM = 164;
+
+    const BLOCK_CODE_ANCIENT_SYMBOLS = 165;
+
+    const BLOCK_CODE_PHAISTOS_DISC = 166;
+
+    const BLOCK_CODE_LYCIAN = 167;
+
+    const BLOCK_CODE_CARIAN = 168;
+
+    const BLOCK_CODE_LYDIAN = 169;
+
+    const BLOCK_CODE_MAHJONG_TILES = 170;
+
+    const BLOCK_CODE_DOMINO_TILES = 171;
+
+    const BLOCK_CODE_SAMARITAN = 172;
+
+    const BLOCK_CODE_UNIFIED_CANADIAN_ABORIGINAL_SYLLABICS_EXTENDED = 173;
+
+    const BLOCK_CODE_TAI_THAM = 174;
+
+    const BLOCK_CODE_VEDIC_EXTENSIONS = 175;
+
+    const BLOCK_CODE_LISU = 176;
+
+    const BLOCK_CODE_BAMUM = 177;
+
+    const BLOCK_CODE_COMMON_INDIC_NUMBER_FORMS = 178;
+
+    const BLOCK_CODE_DEVANAGARI_EXTENDED = 179;
+
+    const BLOCK_CODE_HANGUL_JAMO_EXTENDED_A = 180;
+
+    const BLOCK_CODE_JAVANESE = 181;
+
+    const BLOCK_CODE_MYANMAR_EXTENDED_A = 182;
+
+    const BLOCK_CODE_TAI_VIET = 183;
+
+    const BLOCK_CODE_MEETEI_MAYEK = 184;
+
+    const BLOCK_CODE_HANGUL_JAMO_EXTENDED_B = 185;
+
+    const BLOCK_CODE_IMPERIAL_ARAMAIC = 186;
+
+    const BLOCK_CODE_OLD_SOUTH_ARABIAN = 187;
+
+    const BLOCK_CODE_AVESTAN = 188;
+
+    const BLOCK_CODE_INSCRIPTIONAL_PARTHIAN = 189;
+
+    const BLOCK_CODE_INSCRIPTIONAL_PAHLAVI = 190;
+
+    const BLOCK_CODE_OLD_TURKIC = 191;
+
+    const BLOCK_CODE_RUMI_NUMERAL_SYMBOLS = 192;
+
+    const BLOCK_CODE_KAITHI = 193;
+
+    const BLOCK_CODE_EGYPTIAN_HIEROGLYPHS = 194;
+
+    const BLOCK_CODE_ENCLOSED_ALPHANUMERIC_SUPPLEMENT = 195;
+
+    const BLOCK_CODE_ENCLOSED_IDEOGRAPHIC_SUPPLEMENT = 196;
+
+    const BLOCK_CODE_CJK_UNIFIED_IDEOGRAPHS_EXTENSION_C = 197;
+
+    const BLOCK_CODE_MANDAIC = 198;
+
+    const BLOCK_CODE_BATAK = 199;
+
+    const BLOCK_CODE_ETHIOPIC_EXTENDED_A = 200;
+
+    const BLOCK_CODE_BRAHMI = 201;
+
+    const BLOCK_CODE_BAMUM_SUPPLEMENT = 202;
+
+    const BLOCK_CODE_KANA_SUPPLEMENT = 203;
+
+    const BLOCK_CODE_PLAYING_CARDS = 204;
+
+    const BLOCK_CODE_MISCELLANEOUS_SYMBOLS_AND_PICTOGRAPHS = 205;
+
+    const BLOCK_CODE_EMOTICONS = 206;
+
+    const BLOCK_CODE_TRANSPORT_AND_MAP_SYMBOLS = 207;
+
+    const BLOCK_CODE_ALCHEMICAL_SYMBOLS = 208;
+
+    const BLOCK_CODE_CJK_UNIFIED_IDEOGRAPHS_EXTENSION_D = 209;
+
+    const BLOCK_CODE_ARABIC_EXTENDED_A = 210;
+
+    const BLOCK_CODE_ARABIC_MATHEMATICAL_ALPHABETIC_SYMBOLS = 211;
+
+    const BLOCK_CODE_CHAKMA = 212;
+
+    const BLOCK_CODE_MEETEI_MAYEK_EXTENSIONS = 213;
+
+    const BLOCK_CODE_MEROITIC_CURSIVE = 214;
+
+    const BLOCK_CODE_MEROITIC_HIEROGLYPHS = 215;
+
+    const BLOCK_CODE_MIAO = 216;
+
+    const BLOCK_CODE_SHARADA = 217;
+
+    const BLOCK_CODE_SORA_SOMPENG = 218;
+
+    const BLOCK_CODE_SUNDANESE_SUPPLEMENT = 219;
+
+    const BLOCK_CODE_TAKRI = 220;
+
+    const BLOCK_CODE_BASSA_VAH = 221;
+
+    const BLOCK_CODE_CAUCASIAN_ALBANIAN = 222;
+
+    const BLOCK_CODE_COPTIC_EPACT_NUMBERS = 223;
+
+    const BLOCK_CODE_COMBINING_DIACRITICAL_MARKS_EXTENDED = 224;
+
+    const BLOCK_CODE_DUPLOYAN = 225;
+
+    const BLOCK_CODE_ELBASAN = 226;
+
+    const BLOCK_CODE_GEOMETRIC_SHAPES_EXTENDED = 227;
+
+    const BLOCK_CODE_GRANTHA = 228;
+
+    const BLOCK_CODE_KHOJKI = 229;
+
+    const BLOCK_CODE_KHUDAWADI = 230;
+
+    const BLOCK_CODE_LATIN_EXTENDED_E = 231;
+
+    const BLOCK_CODE_LINEAR_A = 232;
+
+    const BLOCK_CODE_MAHAJANI = 233;
+
+    const BLOCK_CODE_MANICHAEAN = 234;
+
+    const BLOCK_CODE_MENDE_KIKAKUI = 235;
+
+    const BLOCK_CODE_MODI = 236;
+
+    const BLOCK_CODE_MRO = 237;
+
+    const BLOCK_CODE_MYANMAR_EXTENDED_B = 238;
+
+    const BLOCK_CODE_NABATAEAN = 239;
+
+    const BLOCK_CODE_OLD_NORTH_ARABIAN = 240;
+
+    const BLOCK_CODE_OLD_PERMIC = 241;
+
+    const BLOCK_CODE_ORNAMENTAL_DINGBATS = 242;
+
+    const BLOCK_CODE_PAHAWH_HMONG = 243;
+
+    const BLOCK_CODE_PALMYRENE = 244;
+
+    const BLOCK_CODE_PAU_CIN_HAU = 245;
+
+    const BLOCK_CODE_PSALTER_PAHLAVI = 246;
+
+    const BLOCK_CODE_SHORTHAND_FORMAT_CONTROLS = 247;
+
+    const BLOCK_CODE_SIDDHAM = 248;
+
+    const BLOCK_CODE_SINHALA_ARCHAIC_NUMBERS = 249;
+
+    const BLOCK_CODE_SUPPLEMENTAL_ARROWS_C = 250;
+
+    const BLOCK_CODE_TIRHUTA = 251;
+
+    const BLOCK_CODE_WARANG_CITI = 252;
+
+    const BLOCK_CODE_COUNT = 253;
+
+    const BLOCK_CODE_INVALID_CODE = -1;
+
+    const BPT_NONE = 0;
+
+    const BPT_OPEN = 1;
+
+    const BPT_CLOSE = 2;
+
+    const BPT_COUNT = 3;
+
+    const EA_NEUTRAL = 0;
+
+    const EA_AMBIGUOUS = 1;
+
+    const EA_HALFWIDTH = 2;
+
+    const EA_FULLWIDTH = 3;
+
+    const EA_NARROW = 4;
+
+    const EA_WIDE = 5;
+
+    const EA_COUNT = 6;
+
+    const UNICODE_CHAR_NAME = 0;
+
+    const UNICODE_10_CHAR_NAME = 1;
+
+    const EXTENDED_CHAR_NAME = 2;
+
+    const CHAR_NAME_ALIAS = 3;
+
+    const CHAR_NAME_CHOICE_COUNT = 4;
+
+    const SHORT_PROPERTY_NAME = 0;
+
+    const LONG_PROPERTY_NAME = 1;
+
+    const PROPERTY_NAME_CHOICE_COUNT = 2;
+
+    const DT_NONE = 0;
+
+    const DT_CANONICAL = 1;
+
+    const DT_COMPAT = 2;
+
+    const DT_CIRCLE = 3;
+
+    const DT_FINAL = 4;
+
+    const DT_FONT = 5;
+
+    const DT_FRACTION = 6;
+
+    const DT_INITIAL = 7;
+
+    const DT_ISOLATED = 8;
+
+    const DT_MEDIAL = 9;
+
+    const DT_NARROW = 10;
+
+    const DT_NOBREAK = 11;
+
+    const DT_SMALL = 12;
+
+    const DT_SQUARE = 13;
+
+    const DT_SUB = 14;
+
+    const DT_SUPER = 15;
+
+    const DT_VERTICAL = 16;
+
+    const DT_WIDE = 17;
+
+    const DT_COUNT = 18;
+
+    const JT_NON_JOINING = 0;
+
+    const JT_JOIN_CAUSING = 1;
+
+    const JT_DUAL_JOINING = 2;
+
+    const JT_LEFT_JOINING = 3;
+
+    const JT_RIGHT_JOINING = 4;
+
+    const JT_TRANSPARENT = 5;
+
+    const JT_COUNT = 6;
+
+    const JG_NO_JOINING_GROUP = 0;
+
+    const JG_AIN = 1;
+
+    const JG_ALAPH = 2;
+
+    const JG_ALEF = 3;
+
+    const JG_BEH = 4;
+
+    const JG_BETH = 5;
+
+    const JG_DAL = 6;
+
+    const JG_DALATH_RISH = 7;
+
+    const JG_E = 8;
+
+    const JG_FEH = 9;
+
+    const JG_FINAL_SEMKATH = 10;
+
+    const JG_GAF = 11;
+
+    const JG_GAMAL = 12;
+
+    const JG_HAH = 13;
+
+    const JG_TEH_MARBUTA_GOAL = 14;
+
+    const JG_HAMZA_ON_HEH_GOAL = 14;
+
+    const JG_HE = 15;
+
+    const JG_HEH = 16;
+
+    const JG_HEH_GOAL = 17;
+
+    const JG_HETH = 18;
+
+    const JG_KAF = 19;
+
+    const JG_KAPH = 20;
+
+    const JG_KNOTTED_HEH = 21;
+
+    const JG_LAM = 22;
+
+    const JG_LAMADH = 23;
+
+    const JG_MEEM = 24;
+
+    const JG_MIM = 25;
+
+    const JG_NOON = 26;
+
+    const JG_NUN = 27;
+
+    const JG_PE = 28;
+
+    const JG_QAF = 29;
+
+    const JG_QAPH = 30;
+
+    const JG_REH = 31;
+
+    const JG_REVERSED_PE = 32;
+
+    const JG_SAD = 33;
+
+    const JG_SADHE = 34;
+
+    const JG_SEEN = 35;
+
+    const JG_SEMKATH = 36;
+
+    const JG_SHIN = 37;
+
+    const JG_SWASH_KAF = 38;
+
+    const JG_SYRIAC_WAW = 39;
+
+    const JG_TAH = 40;
+
+    const JG_TAW = 41;
+
+    const JG_TEH_MARBUTA = 42;
+
+    const JG_TETH = 43;
+
+    const JG_WAW = 44;
+
+    const JG_YEH = 45;
+
+    const JG_YEH_BARREE = 46;
+
+    const JG_YEH_WITH_TAIL = 47;
+
+    const JG_YUDH = 48;
+
+    const JG_YUDH_HE = 49;
+
+    const JG_ZAIN = 50;
+
+    const JG_FE = 51;
+
+    const JG_KHAPH = 52;
+
+    const JG_ZHAIN = 53;
+
+    const JG_BURUSHASKI_YEH_BARREE = 54;
+
+    const JG_FARSI_YEH = 55;
+
+    const JG_NYA = 56;
+
+    const JG_ROHINGYA_YEH = 57;
+
+    const JG_MANICHAEAN_ALEPH = 58;
+
+    const JG_MANICHAEAN_AYIN = 59;
+
+    const JG_MANICHAEAN_BETH = 60;
+
+    const JG_MANICHAEAN_DALETH = 61;
+
+    const JG_MANICHAEAN_DHAMEDH = 62;
+
+    const JG_MANICHAEAN_FIVE = 63;
+
+    const JG_MANICHAEAN_GIMEL = 64;
+
+    const JG_MANICHAEAN_HETH = 65;
+
+    const JG_MANICHAEAN_HUNDRED = 66;
+
+    const JG_MANICHAEAN_KAPH = 67;
+
+    const JG_MANICHAEAN_LAMEDH = 68;
+
+    const JG_MANICHAEAN_MEM = 69;
+
+    const JG_MANICHAEAN_NUN = 70;
+
+    const JG_MANICHAEAN_ONE = 71;
+
+    const JG_MANICHAEAN_PE = 72;
+
+    const JG_MANICHAEAN_QOPH = 73;
+
+    const JG_MANICHAEAN_RESH = 74;
+
+    const JG_MANICHAEAN_SADHE = 75;
+
+    const JG_MANICHAEAN_SAMEKH = 76;
+
+    const JG_MANICHAEAN_TAW = 77;
+
+    const JG_MANICHAEAN_TEN = 78;
+
+    const JG_MANICHAEAN_TETH = 79;
+
+    const JG_MANICHAEAN_THAMEDH = 80;
+
+    const JG_MANICHAEAN_TWENTY = 81;
+
+    const JG_MANICHAEAN_WAW = 82;
+
+    const JG_MANICHAEAN_YODH = 83;
+
+    const JG_MANICHAEAN_ZAYIN = 84;
+
+    const JG_STRAIGHT_WAW = 85;
+
+    const JG_COUNT = 86;
+
+    const GCB_OTHER = 0;
+
+    const GCB_CONTROL = 1;
+
+    const GCB_CR = 2;
+
+    const GCB_EXTEND = 3;
+
+    const GCB_L = 4;
+
+    const GCB_LF = 5;
+
+    const GCB_LV = 6;
+
+    const GCB_LVT = 7;
+
+    const GCB_T = 8;
+
+    const GCB_V = 9;
+
+    const GCB_SPACING_MARK = 10;
+
+    const GCB_PREPEND = 11;
+
+    const GCB_REGIONAL_INDICATOR = 12;
+
+    const GCB_COUNT = 13;
+
+    const WB_OTHER = 0;
+
+    const WB_ALETTER = 1;
+
+    const WB_FORMAT = 2;
+
+    const WB_KATAKANA = 3;
+
+    const WB_MIDLETTER = 4;
+
+    const WB_MIDNUM = 5;
+
+    const WB_NUMERIC = 6;
+
+    const WB_EXTENDNUMLET = 7;
+
+    const WB_CR = 8;
+
+    const WB_EXTEND = 9;
+
+    const WB_LF = 10;
+
+    const WB_MIDNUMLET = 11;
+
+    const WB_NEWLINE = 12;
+
+    const WB_REGIONAL_INDICATOR = 13;
+
+    const WB_HEBREW_LETTER = 14;
+
+    const WB_SINGLE_QUOTE = 15;
+
+    const WB_DOUBLE_QUOTE = 16;
+
+    const WB_COUNT = 17;
+
+    const SB_OTHER = 0;
+
+    const SB_ATERM = 1;
+
+    const SB_CLOSE = 2;
+
+    const SB_FORMAT = 3;
+
+    const SB_LOWER = 4;
+
+    const SB_NUMERIC = 5;
+
+    const SB_OLETTER = 6;
+
+    const SB_SEP = 7;
+
+    const SB_SP = 8;
+
+    const SB_STERM = 9;
+
+    const SB_UPPER = 10;
+
+    const SB_CR = 11;
+
+    const SB_EXTEND = 12;
+
+    const SB_LF = 13;
+
+    const SB_SCONTINUE = 14;
+
+    const SB_COUNT = 15;
+
+    const LB_UNKNOWN = 0;
+
+    const LB_AMBIGUOUS = 1;
+
+    const LB_ALPHABETIC = 2;
+
+    const LB_BREAK_BOTH = 3;
+
+    const LB_BREAK_AFTER = 4;
+
+    const LB_BREAK_BEFORE = 5;
+
+    const LB_MANDATORY_BREAK = 6;
+
+    const LB_CONTINGENT_BREAK = 7;
+
+    const LB_CLOSE_PUNCTUATION = 8;
+
+    const LB_COMBINING_MARK = 9;
+
+    const LB_CARRIAGE_RETURN = 10;
+
+    const LB_EXCLAMATION = 11;
+
+    const LB_GLUE = 12;
+
+    const LB_HYPHEN = 13;
+
+    const LB_IDEOGRAPHIC = 14;
+
+    const LB_INSEPARABLE = 15;
+
+    const LB_INSEPERABLE = 15;
+
+    const LB_INFIX_NUMERIC = 16;
+
+    const LB_LINE_FEED = 17;
+
+    const LB_NONSTARTER = 18;
+
+    const LB_NUMERIC = 19;
+
+    const LB_OPEN_PUNCTUATION = 20;
+
+    const LB_POSTFIX_NUMERIC = 21;
+
+    const LB_PREFIX_NUMERIC = 22;
+
+    const LB_QUOTATION = 23;
+
+    const LB_COMPLEX_CONTEXT = 24;
+
+    const LB_SURROGATE = 25;
+
+    const LB_SPACE = 26;
+
+    const LB_BREAK_SYMBOLS = 27;
+
+    const LB_ZWSPACE = 28;
+
+    const LB_NEXT_LINE = 29;
+
+    const LB_WORD_JOINER = 30;
+
+    const LB_H2 = 31;
+
+    const LB_H3 = 32;
+
+    const LB_JL = 33;
+
+    const LB_JT = 34;
+
+    const LB_JV = 35;
+
+    const LB_CLOSE_PARENTHESIS = 36;
+
+    const LB_CONDITIONAL_JAPANESE_STARTER = 37;
+
+    const LB_HEBREW_LETTER = 38;
+
+    const LB_REGIONAL_INDICATOR = 39;
+
+    const LB_COUNT = 40;
+
+    const NT_NONE = 0;
+
+    const NT_DECIMAL = 1;
+
+    const NT_DIGIT = 2;
+
+    const NT_NUMERIC = 3;
+
+    const NT_COUNT = 4;
+
+    const HST_NOT_APPLICABLE = 0;
+
+    const HST_LEADING_JAMO = 1;
+
+    const HST_VOWEL_JAMO = 2;
+
+    const HST_TRAILING_JAMO = 3;
+
+    const HST_LV_SYLLABLE = 4;
+
+    const HST_LVT_SYLLABLE = 5;
+
+    const HST_COUNT = 6;
+
+    public static function chr($codepoint)
+    {
+    }
+
+    public static function ord($character)
+    {
+    }
+
+    public static function hasBinaryProperty($codepoint, $property)
+    {
+    }
+
+    public static function isUAlphabetic($codepoint)
+    {
+    }
+
+    public static function isULowercase($codepoint)
+    {
+    }
+
+    public static function isUUppercase($codepoint)
+    {
+    }
+
+    public static function isUWhiteSpace($codepoint)
+    {
+    }
+
+    public static function getIntPropertyValue($codepoint, $property)
+    {
+    }
+
+    public static function getIntPropertyMinValue($property)
+    {
+    }
+
+    public static function getIntPropertyMaxValue($property)
+    {
+    }
+
+    public static function getNumericValue($codepoint)
+    {
+    }
+
+    public static function islower($codepoint)
+    {
+    }
+
+    public static function isupper($codepoint)
+    {
+    }
+
+    public static function istitle($codepoint)
+    {
+    }
+
+    public static function isdigit($codepoint)
+    {
+    }
+
+    public static function isalpha($codepoint)
+    {
+    }
+
+    public static function isalnum($codepoint)
+    {
+    }
+
+    public static function isxdigit($codepoint)
+    {
+    }
+
+    public static function ispunct($codepoint)
+    {
+    }
+
+    public static function isgraph($codepoint)
+    {
+    }
+
+    public static function isblank($codepoint)
+    {
+    }
+
+    public static function isdefined($codepoint)
+    {
+    }
+
+    public static function isspace($codepoint)
+    {
+    }
+
+    public static function isJavaSpaceChar($codepoint)
+    {
+    }
+
+    public static function isWhitespace($codepoint)
+    {
+    }
+
+    public static function iscntrl($codepoint)
+    {
+    }
+
+    public static function isISOControl($codepoint)
+    {
+    }
+
+    public static function isprint($codepoint)
+    {
+    }
+
+    public static function isbase($codepoint)
+    {
+    }
+
+    public static function charDirection($codepoint)
+    {
+    }
+
+    public static function isMirrored($codepoint)
+    {
+    }
+
+    public static function charMirror($codepoint)
+    {
+    }
+
+    public static function getBidiPairedBracket($codepoint)
+    {
+    }
+
+    public static function charType($codepoint)
+    {
+    }
+
+    public static function enumCharTypes($callback = null)
+    {
+    }
+
+    public static function getCombiningClass($codepoint)
+    {
+    }
+
+    public static function charDigitValue($codepoint)
+    {
+    }
+
+    public static function getBlockCode($codepoint)
+    {
+    }
+
+    public static function charName($codepoint, $nameChoice = IntlChar::UNICODE_CHAR_NAME)
+    {
+    }
+
+    public static function charFromName($characterName, $nameChoice = IntlChar::UNICODE_CHAR_NAME)
+    {
+    }
+
+    public static function enumCharNames($start, $limit, $callback, $nameChoice = IntlChar::UNICODE_CHAR_NAME)
+    {
+    }
+
+    public static function getPropertyName($property, $nameChoice = IntlChar::LONG_PROPERTY_NAME)
+    {
+    }
+
+    public static function getPropertyEnum($alias)
+    {
+    }
+
+    public static function getPropertyValueName($property, $value, $nameChoice = IntlChar::LONG_PROPERTY_NAME)
+    {
+    }
+
+    public static function getPropertyValueEnum($property, $name)
+    {
+    }
+
+    public static function isIDStart($codepoint)
+    {
+    }
+
+    public static function isIDPart($codepoint)
+    {
+    }
+
+    public static function isIDIgnorable($codepoint)
+    {
+    }
+
+    public static function isJavaIDStart($codepoint)
+    {
+    }
+
+    public static function isJavaIDPart($codepoint)
+    {
+    }
+
+    public static function tolower($codepoint)
+    {
+    }
+
+    public static function toupper($codepoint)
+    {
+    }
+
+    public static function totitle($codepoint)
+    {
+    }
+
+    public static function foldCase($foldCase)
+    {
+    }
+
+    public static function digit($codepoint, $radix = 10)
+    {
+    }
+
+    public static function forDigit($digit, $radix = 10)
+    {
+    }
+
+    public static function charAge($codepoint)
+    {
+    }
+
+    public static function getUnicodeVersion()
+    {
+    }
+
+    public static function getFC_NFKC_Closure($codepoint)
+    {
+    }
+
+
+}

--- a/stub/IntlDateFormatter.stub
+++ b/stub/IntlDateFormatter.stub
@@ -1,0 +1,105 @@
+<?php
+
+class IntlDateFormatter
+{
+
+    const FULL = 0;
+
+    const LONG = 1;
+
+    const MEDIUM = 2;
+
+    const SHORT = 3;
+
+    const NONE = -1;
+
+    const GREGORIAN = 1;
+
+    const TRADITIONAL = 0;
+
+    public function __construct($locale, $datetype, $timetype, $timezone = NULL, $calendar = NULL, $pattern = '')
+    {
+    }
+
+    public static function create($locale, $datetype, $timetype, $timezone = NULL, $calendar = NULL, $pattern = '')
+    {
+    }
+
+    public function getDateType()
+    {
+    }
+
+    public function getTimeType()
+    {
+    }
+
+    public function getCalendar()
+    {
+    }
+
+    public function getCalendarObject()
+    {
+    }
+
+    public function setCalendar($which)
+    {
+    }
+
+    public function getTimeZoneId()
+    {
+    }
+
+    public function getTimeZone()
+    {
+    }
+
+    public function setTimeZone($zone)
+    {
+    }
+
+    public function setPattern($pattern)
+    {
+    }
+
+    public function getPattern()
+    {
+    }
+
+    public function getLocale()
+    {
+    }
+
+    public function setLenient($lenient)
+    {
+    }
+
+    public function isLenient()
+    {
+    }
+
+    public function format($args = null, $array = null)
+    {
+    }
+
+    public static function formatObject($object, $format = NULL, $locale = NULL)
+    {
+    }
+
+    public function parse($string, &$position = null)
+    {
+    }
+
+    public function localtime($string, &$position = null)
+    {
+    }
+
+    public function getErrorCode()
+    {
+    }
+
+    public function getErrorMessage()
+    {
+    }
+
+
+}

--- a/stub/IntlDateFormatter.stub
+++ b/stub/IntlDateFormatter.stub
@@ -1,5 +1,3 @@
-<?php
-
 class IntlDateFormatter
 {
 

--- a/stub/IntlGregorianCalendar.stub
+++ b/stub/IntlGregorianCalendar.stub
@@ -1,0 +1,21 @@
+class IntlGregorianCalendar extends IntlCalendar
+{
+
+    public function __construct($timeZoneOrYear = null, $localeOrMonth = null, $dayOfMonth = null, $hour = null, $minute = null, $second = null)
+    {
+    }
+
+    public function setGregorianChange($date)
+    {
+    }
+
+    public function getGregorianChange()
+    {
+    }
+
+    public function isLeapYear($year)
+    {
+    }
+
+
+}

--- a/stub/IntlRuleBasedBreakIterator.stub
+++ b/stub/IntlRuleBasedBreakIterator.stub
@@ -1,5 +1,3 @@
-<?php
-
 class IntlRuleBasedBreakIterator extends IntlBreakIterator
 {
 

--- a/stub/IntlRuleBasedBreakIterator.stub
+++ b/stub/IntlRuleBasedBreakIterator.stub
@@ -1,0 +1,65 @@
+<?php
+
+class IntlRuleBasedBreakIterator extends IntlBreakIterator
+{
+
+    const DONE = -1;
+
+    const WORD_NONE = 0;
+
+    const WORD_NONE_LIMIT = 100;
+
+    const WORD_NUMBER = 100;
+
+    const WORD_NUMBER_LIMIT = 200;
+
+    const WORD_LETTER = 200;
+
+    const WORD_LETTER_LIMIT = 300;
+
+    const WORD_KANA = 300;
+
+    const WORD_KANA_LIMIT = 400;
+
+    const WORD_IDEO = 400;
+
+    const WORD_IDEO_LIMIT = 500;
+
+    const LINE_SOFT = 0;
+
+    const LINE_SOFT_LIMIT = 100;
+
+    const LINE_HARD = 100;
+
+    const LINE_HARD_LIMIT = 200;
+
+    const SENTENCE_TERM = 0;
+
+    const SENTENCE_TERM_LIMIT = 100;
+
+    const SENTENCE_SEP = 100;
+
+    const SENTENCE_SEP_LIMIT = 200;
+
+    public function __construct($rules, $areCompiled = null)
+    {
+    }
+
+    public function getRules()
+    {
+    }
+
+    public function getRuleStatus()
+    {
+    }
+
+    public function getRuleStatusVec()
+    {
+    }
+
+    public function getBinaryRules()
+    {
+    }
+
+
+}

--- a/stub/IntlTimeZone.stub
+++ b/stub/IntlTimeZone.stub
@@ -1,5 +1,3 @@
-<?php
-
 class IntlTimeZone
 {
 

--- a/stub/IntlTimeZone.stub
+++ b/stub/IntlTimeZone.stub
@@ -1,0 +1,121 @@
+<?php
+
+class IntlTimeZone
+{
+
+    const DISPLAY_SHORT = 1;
+
+    const DISPLAY_LONG = 2;
+
+    const DISPLAY_SHORT_GENERIC = 3;
+
+    const DISPLAY_LONG_GENERIC = 4;
+
+    const DISPLAY_SHORT_GMT = 5;
+
+    const DISPLAY_LONG_GMT = 6;
+
+    const DISPLAY_SHORT_COMMONLY_USED = 7;
+
+    const DISPLAY_GENERIC_LOCATION = 8;
+
+    const TYPE_ANY = 0;
+
+    const TYPE_CANONICAL = 1;
+
+    const TYPE_CANONICAL_LOCATION = 2;
+
+    private function __construct()
+    {
+    }
+
+    public static function createTimeZone($zoneId)
+    {
+    }
+
+    public static function fromDateTimeZone($zoneId)
+    {
+    }
+
+    public static function createDefault()
+    {
+    }
+
+    public static function getGMT()
+    {
+    }
+
+    public static function getUnknown()
+    {
+    }
+
+    public static function createEnumeration($countryOrRawOffset = null)
+    {
+    }
+
+    public static function countEquivalentIDs($zoneId)
+    {
+    }
+
+    public static function createTimeZoneIDEnumeration($zoneType, $region = null, $rawOffset = null)
+    {
+    }
+
+    public static function getCanonicalID($zoneId, &$isSystemID = null)
+    {
+    }
+
+    public static function getRegion($zoneId)
+    {
+    }
+
+    public static function getTZDataVersion()
+    {
+    }
+
+    public static function getEquivalentID($zoneId, $index)
+    {
+    }
+
+    public function getID()
+    {
+    }
+
+    public function useDaylightTime()
+    {
+    }
+
+    public function getOffset($date, $local, &$rawOffset, &$dstOffset)
+    {
+    }
+
+    public function getRawOffset()
+    {
+    }
+
+    public function hasSameRules(\IntlTimeZone $otherTimeZone)
+    {
+    }
+
+    public function getDisplayName($isDaylight = null, $style = null, $locale = null)
+    {
+    }
+
+    public function getDSTSavings()
+    {
+    }
+
+    public function toDateTimeZone()
+    {
+    }
+
+    public function getErrorCode()
+    {
+    }
+
+    public function getErrorMessage()
+    {
+    }
+
+
+}

--- a/stub/LimitIterator.stub
+++ b/stub/LimitIterator.stub
@@ -1,0 +1,43 @@
+<?php
+
+class LimitIterator extends IteratorIterator
+{
+
+    public function __construct(\Iterator $iterator, $offset = 0, $count = -1)
+    {
+    }
+
+    public function rewind()
+    {
+    }
+
+    public function valid()
+    {
+    }
+
+    public function key()
+    {
+    }
+
+    public function current()
+    {
+    }
+
+    public function next()
+    {
+    }
+
+    public function seek($position)
+    {
+    }
+
+    public function getPosition()
+    {
+    }
+
+    public function getInnerIterator()
+    {
+    }
+
+
+}

--- a/stub/LimitIterator.stub
+++ b/stub/LimitIterator.stub
@@ -1,5 +1,3 @@
-<?php
-
 class LimitIterator extends IteratorIterator
 {
 

--- a/stub/MultipleIterator.stub
+++ b/stub/MultipleIterator.stub
@@ -1,0 +1,63 @@
+<?php
+
+class MultipleIterator implements Iterator, Traversable
+{
+
+    const MIT_NEED_ANY = 0;
+
+    const MIT_NEED_ALL = 1;
+
+    const MIT_KEYS_NUMERIC = 0;
+
+    const MIT_KEYS_ASSOC = 2;
+
+    public function __construct($flags)
+    {
+    }
+
+    public function getFlags()
+    {
+    }
+
+    public function setFlags($flags)
+    {
+    }
+
+    public function attachIterator(\Iterator $iterator, $infos = null)
+    {
+    }
+
+    public function detachIterator(\Iterator $iterator)
+    {
+    }
+
+    public function containsIterator(\Iterator $iterator)
+    {
+    }
+
+    public function countIterators()
+    {
+    }
+
+    public function rewind()
+    {
+    }
+
+    public function valid()
+    {
+    }
+
+    public function key()
+    {
+    }
+
+    public function current()
+    {
+    }
+
+    public function next()
+    {
+    }
+
+
+}

--- a/stub/MultipleIterator.stub
+++ b/stub/MultipleIterator.stub
@@ -1,5 +1,3 @@
-<?php
-
 class MultipleIterator implements Iterator, Traversable
 {
 

--- a/stub/NumberFormatter.stub
+++ b/stub/NumberFormatter.stub
@@ -1,5 +1,3 @@
-<?php
-
 class NumberFormatter
 {
 

--- a/stub/NumberFormatter.stub
+++ b/stub/NumberFormatter.stub
@@ -1,0 +1,221 @@
+<?php
+
+class NumberFormatter
+{
+
+    const PATTERN_DECIMAL = 0;
+
+    const DECIMAL = 1;
+
+    const CURRENCY = 2;
+
+    const PERCENT = 3;
+
+    const SCIENTIFIC = 4;
+
+    const SPELLOUT = 5;
+
+    const ORDINAL = 6;
+
+    const DURATION = 7;
+
+    const PATTERN_RULEBASED = 9;
+
+    const IGNORE = 0;
+
+    const DEFAULT_STYLE = 1;
+
+    const ROUND_CEILING = 0;
+
+    const ROUND_FLOOR = 1;
+
+    const ROUND_DOWN = 2;
+
+    const ROUND_UP = 3;
+
+    const ROUND_HALFEVEN = 4;
+
+    const ROUND_HALFDOWN = 5;
+
+    const ROUND_HALFUP = 6;
+
+    const PAD_BEFORE_PREFIX = 0;
+
+    const PAD_AFTER_PREFIX = 1;
+
+    const PAD_BEFORE_SUFFIX = 2;
+
+    const PAD_AFTER_SUFFIX = 3;
+
+    const PARSE_INT_ONLY = 0;
+
+    const GROUPING_USED = 1;
+
+    const DECIMAL_ALWAYS_SHOWN = 2;
+
+    const MAX_INTEGER_DIGITS = 3;
+
+    const MIN_INTEGER_DIGITS = 4;
+
+    const INTEGER_DIGITS = 5;
+
+    const MAX_FRACTION_DIGITS = 6;
+
+    const MIN_FRACTION_DIGITS = 7;
+
+    const FRACTION_DIGITS = 8;
+
+    const MULTIPLIER = 9;
+
+    const GROUPING_SIZE = 10;
+
+    const ROUNDING_MODE = 11;
+
+    const ROUNDING_INCREMENT = 12;
+
+    const FORMAT_WIDTH = 13;
+
+    const PADDING_POSITION = 14;
+
+    const SECONDARY_GROUPING_SIZE = 15;
+
+    const SIGNIFICANT_DIGITS_USED = 16;
+
+    const MIN_SIGNIFICANT_DIGITS = 17;
+
+    const MAX_SIGNIFICANT_DIGITS = 18;
+
+    const LENIENT_PARSE = 19;
+
+    const POSITIVE_PREFIX = 0;
+
+    const POSITIVE_SUFFIX = 1;
+
+    const NEGATIVE_PREFIX = 2;
+
+    const NEGATIVE_SUFFIX = 3;
+
+    const PADDING_CHARACTER = 4;
+
+    const CURRENCY_CODE = 5;
+
+    const DEFAULT_RULESET = 6;
+
+    const PUBLIC_RULESETS = 7;
+
+    const DECIMAL_SEPARATOR_SYMBOL = 0;
+
+    const GROUPING_SEPARATOR_SYMBOL = 1;
+
+    const PATTERN_SEPARATOR_SYMBOL = 2;
+
+    const PERCENT_SYMBOL = 3;
+
+    const ZERO_DIGIT_SYMBOL = 4;
+
+    const DIGIT_SYMBOL = 5;
+
+    const MINUS_SIGN_SYMBOL = 6;
+
+    const PLUS_SIGN_SYMBOL = 7;
+
+    const CURRENCY_SYMBOL = 8;
+
+    const INTL_CURRENCY_SYMBOL = 9;
+
+    const MONETARY_SEPARATOR_SYMBOL = 10;
+
+    const EXPONENTIAL_SYMBOL = 11;
+
+    const PERMILL_SYMBOL = 12;
+
+    const PAD_ESCAPE_SYMBOL = 13;
+
+    const INFINITY_SYMBOL = 14;
+
+    const NAN_SYMBOL = 15;
+
+    const SIGNIFICANT_DIGIT_SYMBOL = 16;
+
+    const MONETARY_GROUPING_SEPARATOR_SYMBOL = 17;
+
+    const TYPE_DEFAULT = 0;
+
+    const TYPE_INT32 = 1;
+
+    const TYPE_INT64 = 2;
+
+    const TYPE_DOUBLE = 3;
+
+    const TYPE_CURRENCY = 4;
+
+    public function __construct($locale, $style, $pattern = null)
+    {
+    }
+
+    public static function create($locale, $style, $pattern = null)
+    {
+    }
+
+    public function format($num, $type = null)
+    {
+    }
+
+    public function parse($string, $type = null, &$position = null)
+    {
+    }
+
+    public function formatCurrency($num, $currency)
+    {
+    }
+
+    public function parseCurrency($string, &$currency, &$position = null)
+    {
+    }
+
+    public function setAttribute($attr, $value)
+    {
+    }
+
+    public function getAttribute($attr)
+    {
+    }
+
+    public function setTextAttribute($attr, $value)
+    {
+    }
+
+    public function getTextAttribute($attr)
+    {
+    }
+
+    public function setSymbol($attr, $symbol)
+    {
+    }
+
+    public function getSymbol($attr)
+    {
+    }
+
+    public function setPattern($pattern)
+    {
+    }
+
+    public function getPattern()
+    {
+    }
+
+    public function getLocale($type = null)
+    {
+    }
+
+    public function getErrorCode()
+    {
+    }
+
+    public function getErrorMessage()
+    {
+    }
+
+
+}

--- a/stub/PDO.stub
+++ b/stub/PDO.stub
@@ -1,0 +1,251 @@
+class PDO
+{
+
+    const PARAM_BOOL = 5;
+
+    const PARAM_NULL = 0;
+
+    const PARAM_INT = 1;
+
+    const PARAM_STR = 2;
+
+    const PARAM_LOB = 3;
+
+    const PARAM_STMT = 4;
+
+    const PARAM_INPUT_OUTPUT = 2147483648;
+
+    const PARAM_EVT_ALLOC = 0;
+
+    const PARAM_EVT_FREE = 1;
+
+    const PARAM_EVT_EXEC_PRE = 2;
+
+    const PARAM_EVT_EXEC_POST = 3;
+
+    const PARAM_EVT_FETCH_PRE = 4;
+
+    const PARAM_EVT_FETCH_POST = 5;
+
+    const PARAM_EVT_NORMALIZE = 6;
+
+    const FETCH_LAZY = 1;
+
+    const FETCH_ASSOC = 2;
+
+    const FETCH_NUM = 3;
+
+    const FETCH_BOTH = 4;
+
+    const FETCH_OBJ = 5;
+
+    const FETCH_BOUND = 6;
+
+    const FETCH_COLUMN = 7;
+
+    const FETCH_CLASS = 8;
+
+    const FETCH_INTO = 9;
+
+    const FETCH_FUNC = 10;
+
+    const FETCH_GROUP = 65536;
+
+    const FETCH_UNIQUE = 196608;
+
+    const FETCH_KEY_PAIR = 12;
+
+    const FETCH_CLASSTYPE = 262144;
+
+    const FETCH_SERIALIZE = 524288;
+
+    const FETCH_PROPS_LATE = 1048576;
+
+    const FETCH_NAMED = 11;
+
+    const ATTR_AUTOCOMMIT = 0;
+
+    const ATTR_PREFETCH = 1;
+
+    const ATTR_TIMEOUT = 2;
+
+    const ATTR_ERRMODE = 3;
+
+    const ATTR_SERVER_VERSION = 4;
+
+    const ATTR_CLIENT_VERSION = 5;
+
+    const ATTR_SERVER_INFO = 6;
+
+    const ATTR_CONNECTION_STATUS = 7;
+
+    const ATTR_CASE = 8;
+
+    const ATTR_CURSOR_NAME = 9;
+
+    const ATTR_CURSOR = 10;
+
+    const ATTR_ORACLE_NULLS = 11;
+
+    const ATTR_PERSISTENT = 12;
+
+    const ATTR_STATEMENT_CLASS = 13;
+
+    const ATTR_FETCH_TABLE_NAMES = 14;
+
+    const ATTR_FETCH_CATALOG_NAMES = 15;
+
+    const ATTR_DRIVER_NAME = 16;
+
+    const ATTR_STRINGIFY_FETCHES = 17;
+
+    const ATTR_MAX_COLUMN_LEN = 18;
+
+    const ATTR_EMULATE_PREPARES = 20;
+
+    const ATTR_DEFAULT_FETCH_MODE = 19;
+
+    const ERRMODE_SILENT = 0;
+
+    const ERRMODE_WARNING = 1;
+
+    const ERRMODE_EXCEPTION = 2;
+
+    const CASE_NATURAL = 0;
+
+    const CASE_LOWER = 2;
+
+    const CASE_UPPER = 1;
+
+    const NULL_NATURAL = 0;
+
+    const NULL_EMPTY_STRING = 1;
+
+    const NULL_TO_STRING = 2;
+
+    const ERR_NONE = '00000';
+
+    const FETCH_ORI_NEXT = 0;
+
+    const FETCH_ORI_PRIOR = 1;
+
+    const FETCH_ORI_FIRST = 2;
+
+    const FETCH_ORI_LAST = 3;
+
+    const FETCH_ORI_ABS = 4;
+
+    const FETCH_ORI_REL = 5;
+
+    const CURSOR_FWDONLY = 0;
+
+    const CURSOR_SCROLL = 1;
+
+    const MYSQL_ATTR_USE_BUFFERED_QUERY = 1000;
+
+    const MYSQL_ATTR_LOCAL_INFILE = 1001;
+
+    const MYSQL_ATTR_INIT_COMMAND = 1002;
+
+    const MYSQL_ATTR_COMPRESS = 1003;
+
+    const MYSQL_ATTR_DIRECT_QUERY = 1004;
+
+    const MYSQL_ATTR_FOUND_ROWS = 1005;
+
+    const MYSQL_ATTR_IGNORE_SPACE = 1006;
+
+    const MYSQL_ATTR_SSL_KEY = 1007;
+
+    const MYSQL_ATTR_SSL_CERT = 1008;
+
+    const MYSQL_ATTR_SSL_CA = 1009;
+
+    const MYSQL_ATTR_SSL_CAPATH = 1010;
+
+    const MYSQL_ATTR_SSL_CIPHER = 1011;
+
+    const MYSQL_ATTR_SERVER_PUBLIC_KEY = 1012;
+
+    const MYSQL_ATTR_MULTI_STATEMENTS = 1013;
+
+    const ODBC_ATTR_USE_CURSOR_LIBRARY = 1000;
+
+    const ODBC_ATTR_ASSUME_UTF8 = 1001;
+
+    const ODBC_SQL_USE_IF_NEEDED = 0;
+
+    const ODBC_SQL_USE_DRIVER = 2;
+
+    const ODBC_SQL_USE_ODBC = 1;
+
+    public function __construct($dsn, $username = null, $passwd = null, $options = null)
+    {
+    }
+
+    public function prepare($statement, $options = array())
+    {
+    }
+
+    public function beginTransaction()
+    {
+    }
+
+    public function commit()
+    {
+    }
+
+    public function rollBack()
+    {
+    }
+
+    public function inTransaction()
+    {
+    }
+
+    public function setAttribute($attribute, $value)
+    {
+    }
+
+    public function exec($query)
+    {
+    }
+
+    public function query()
+    {
+    }
+
+    public function lastInsertId($seqname = null)
+    {
+    }
+
+    public function errorCode()
+    {
+    }
+
+    public function errorInfo()
+    {
+    }
+
+    public function getAttribute($attribute)
+    {
+    }
+
+    public function quote($string, $paramtype = PDO::PARAM_STR)
+    {
+    }
+
+    final public function __wakeup()
+    {
+    }
+
+    final public function __sleep()
+    {
+    }
+
+    public static function getAvailableDrivers()
+    {
+    }
+
+
+}

--- a/stub/PDOStatement.stub
+++ b/stub/PDOStatement.stub
@@ -1,0 +1,91 @@
+class PDOStatement implements Traversable
+{
+
+    public $queryString = null;
+
+    public function execute($bound_input_params = null)
+    {
+    }
+
+    public function fetch($how = null, $orientation = PDO::FETCH_ORI_NEXT, $offset = 0)
+    {
+    }
+
+    public function bindParam($paramno, &$param, $type = PDO::PARAM_STR, $maxlen = null, $driverdata = null)
+    {
+    }
+
+    public function bindColumn($column, &$param, $type = null, $maxlen = null, $driverdata = null)
+    {
+    }
+
+    public function bindValue($paramno, $param, $type = PDO::PARAM_STR)
+    {
+    }
+
+    public function rowCount()
+    {
+    }
+
+    public function fetchColumn($column_number = 0)
+    {
+    }
+
+    public function fetchAll($how = null, $class_name = null, $ctor_args = array())
+    {
+    }
+
+    public function fetchObject($class_name = 'stdClass', $ctor_args = null)
+    {
+    }
+
+    public function errorCode()
+    {
+    }
+
+    public function errorInfo()
+    {
+    }
+
+    public function setAttribute($attribute, $value)
+    {
+    }
+
+    public function getAttribute($attribute)
+    {
+    }
+
+    public function columnCount()
+    {
+    }
+
+    public function getColumnMeta($column)
+    {
+    }
+
+    public function setFetchMode($mode, $params = null)
+    {
+    }
+
+    public function nextRowset()
+    {
+    }
+
+    public function closeCursor()
+    {
+    }
+
+    public function debugDumpParams()
+    {
+    }
+
+    final public function __wakeup()
+    {
+    }
+
+    final public function __sleep()
+    {
+    }
+
+
+}

--- a/stub/Phar.stub
+++ b/stub/Phar.stub
@@ -1,0 +1,281 @@
+class Phar extends RecursiveDirectoryIterator implements Countable, ArrayAccess
+{
+
+    const CURRENT_MODE_MASK = 240;
+
+    const CURRENT_AS_PATHNAME = 32;
+
+    const CURRENT_AS_FILEINFO = 0;
+
+    const CURRENT_AS_SELF = 16;
+
+    const KEY_MODE_MASK = 3840;
+
+    const KEY_AS_PATHNAME = 0;
+
+    const FOLLOW_SYMLINKS = 512;
+
+    const KEY_AS_FILENAME = 256;
+
+    const NEW_CURRENT_AND_KEY = 256;
+
+    const OTHER_MODE_MASK = 12288;
+
+    const SKIP_DOTS = 4096;
+
+    const UNIX_PATHS = 8192;
+
+    const BZ2 = 8192;
+
+    const GZ = 4096;
+
+    const NONE = 0;
+
+    const PHAR = 1;
+
+    const TAR = 2;
+
+    const ZIP = 3;
+
+    const COMPRESSED = 61440;
+
+    const PHP = 0;
+
+    const PHPS = 1;
+
+    const MD5 = 1;
+
+    const OPENSSL = 16;
+
+    const SHA1 = 2;
+
+    const SHA256 = 3;
+
+    const SHA512 = 4;
+
+    public function __construct($filename, $flags = null, $alias = null, $fileformat = null)
+    {
+    }
+
+    public function __destruct()
+    {
+    }
+
+    public function addEmptyDir($dirname = null)
+    {
+    }
+
+    public function addFile($filename, $localname = null)
+    {
+    }
+
+    public function addFromString($localname, $contents = null)
+    {
+    }
+
+    public function buildFromDirectory($base_dir, $regex = null)
+    {
+    }
+
+    public function buildFromIterator($iterator, $base_directory = null)
+    {
+    }
+
+    public function compressFiles($compression_type)
+    {
+    }
+
+    public function decompressFiles()
+    {
+    }
+
+    public function compress($compression_type, $file_ext = null)
+    {
+    }
+
+    public function decompress($file_ext = null)
+    {
+    }
+
+    public function convertToExecutable($format = 9021976, $compression_type = 9021976, $file_ext = null)
+    {
+    }
+
+    public function convertToData($format = 9021976, $compression_type = 9021976, $file_ext = null)
+    {
+    }
+
+    public function copy($newfile, $oldfile)
+    {
+    }
+
+    public function count()
+    {
+    }
+
+    public function delete($entry)
+    {
+    }
+
+    public function delMetadata()
+    {
+    }
+
+    public function extractTo($pathto, $files = null, $overwrite = false)
+    {
+    }
+
+    public function getAlias()
+    {
+    }
+
+    public function getPath()
+    {
+    }
+
+    public function getMetadata()
+    {
+    }
+
+    public function getModified()
+    {
+    }
+
+    public function getSignature()
+    {
+    }
+
+    public function getStub()
+    {
+    }
+
+    public function getVersion()
+    {
+    }
+
+    public function hasMetadata()
+    {
+    }
+
+    public function isBuffering()
+    {
+    }
+
+    public function isCompressed()
+    {
+    }
+
+    public function isFileFormat($fileformat)
+    {
+    }
+
+    public function isWritable()
+    {
+    }
+
+    public function offsetExists($entry)
+    {
+    }
+
+    public function offsetGet($entry)
+    {
+    }
+
+    public function offsetSet($entry, $value)
+    {
+    }
+
+    public function offsetUnset($entry)
+    {
+    }
+
+    public function setAlias($alias)
+    {
+    }
+
+    public function setDefaultStub($index = null, $webindex = null)
+    {
+    }
+
+    public function setMetadata($metadata)
+    {
+    }
+
+    public function setSignatureAlgorithm($algorithm, $privatekey = null)
+    {
+    }
+
+    public function setStub($newstub, $maxlen = -1)
+    {
+    }
+
+    public function startBuffering()
+    {
+    }
+
+    public function stopBuffering()
+    {
+    }
+
+    final public static function apiVersion()
+    {
+    }
+
+    final public static function canCompress($method = 0)
+    {
+    }
+
+    final public static function canWrite()
+    {
+    }
+
+    final public static function createDefaultStub($index = null, $webindex = null)
+    {
+    }
+
+    final public static function getSupportedCompression()
+    {
+    }
+
+    final public static function getSupportedSignatures()
+    {
+    }
+
+    final public static function interceptFileFuncs()
+    {
+    }
+
+    final public static function isValidPharFilename($filename, $executable = true)
+    {
+    }
+
+    final public static function loadPhar($filename, $alias = null)
+    {
+    }
+
+    final public static function mapPhar($alias = null, $offset = 0)
+    {
+    }
+
+    final public static function running($retphar)
+    {
+    }
+
+    final public static function mount($inphar, $externalfile)
+    {
+    }
+
+    final public static function mungServer($munglist)
+    {
+    }
+
+    final public static function unlinkArchive($archive)
+    {
+    }
+
+    final public static function webPhar($alias = null, $index = 'index.php', $f404 = null, $mimetypes = null, $rewrites = null)
+    {
+    }
+
+
+}

--- a/stub/PharData.stub
+++ b/stub/PharData.stub
@@ -1,0 +1,253 @@
+class PharData extends RecursiveDirectoryIterator implements Countable, ArrayAccess
+{
+
+    const CURRENT_MODE_MASK = 240;
+
+    const CURRENT_AS_PATHNAME = 32;
+
+    const CURRENT_AS_FILEINFO = 0;
+
+    const CURRENT_AS_SELF = 16;
+
+    const KEY_MODE_MASK = 3840;
+
+    const KEY_AS_PATHNAME = 0;
+
+    const FOLLOW_SYMLINKS = 512;
+
+    const KEY_AS_FILENAME = 256;
+
+    const NEW_CURRENT_AND_KEY = 256;
+
+    const OTHER_MODE_MASK = 12288;
+
+    const SKIP_DOTS = 4096;
+
+    const UNIX_PATHS = 8192;
+
+    public function __construct($filename, $flags = null, $alias = null, $fileformat = Phar::TAR)
+    {
+    }
+
+    public function __destruct()
+    {
+    }
+
+    public function addEmptyDir($dirname = null)
+    {
+    }
+
+    public function addFile($filename, $localname = null)
+    {
+    }
+
+    public function addFromString($localname, $contents = null)
+    {
+    }
+
+    public function buildFromDirectory($base_dir, $regex = null)
+    {
+    }
+
+    public function buildFromIterator($iterator, $base_directory = null)
+    {
+    }
+
+    public function compressFiles($compression_type)
+    {
+    }
+
+    public function decompressFiles()
+    {
+    }
+
+    public function compress($compression_type, $file_ext = null)
+    {
+    }
+
+    public function decompress($file_ext = null)
+    {
+    }
+
+    public function convertToExecutable($format = null, $compression_type = null, $file_ext = null)
+    {
+    }
+
+    public function convertToData($format = null, $compression_type = null, $file_ext = null)
+    {
+    }
+
+    public function copy($newfile, $oldfile)
+    {
+    }
+
+    public function count()
+    {
+    }
+
+    public function delete($entry)
+    {
+    }
+
+    public function delMetadata()
+    {
+    }
+
+    public function extractTo($pathto, $files = null, $overwrite = false)
+    {
+    }
+
+    public function getAlias()
+    {
+    }
+
+    public function getPath()
+    {
+    }
+
+    public function getMetadata()
+    {
+    }
+
+    public function getModified()
+    {
+    }
+
+    public function getSignature()
+    {
+    }
+
+    public function getStub()
+    {
+    }
+
+    public function getVersion()
+    {
+    }
+
+    public function hasMetadata()
+    {
+    }
+
+    public function isBuffering()
+    {
+    }
+
+    public function isCompressed()
+    {
+    }
+
+    public function isFileFormat($fileformat)
+    {
+    }
+
+    public function isWritable()
+    {
+    }
+
+    public function offsetExists($entry)
+    {
+    }
+
+    public function offsetGet($entry)
+    {
+    }
+
+    public function offsetSet($entry, $value)
+    {
+    }
+
+    public function offsetUnset($entry)
+    {
+    }
+
+    public function setAlias($alias)
+    {
+    }
+
+    public function setDefaultStub($index = null, $webindex = null)
+    {
+    }
+
+    public function setMetadata($metadata)
+    {
+    }
+
+    public function setSignatureAlgorithm($algorithm, $privatekey = null)
+    {
+    }
+
+    public function setStub($newstub, $maxlen = -1)
+    {
+    }
+
+    public function startBuffering()
+    {
+    }
+
+    public function stopBuffering()
+    {
+    }
+
+    final public static function apiVersion()
+    {
+    }
+
+    final public static function canCompress($method = 0)
+    {
+    }
+
+    final public static function canWrite()
+    {
+    }
+
+    final public static function createDefaultStub($index = null, $webindex = null)
+    {
+    }
+
+    final public static function getSupportedCompression()
+    {
+    }
+
+    final public static function getSupportedSignatures()
+    {
+    }
+
+    final public static function interceptFileFuncs()
+    {
+    }
+
+    final public static function isValidPharFilename($filename, $executable = true)
+    {
+    }
+
+    final public static function loadPhar($filename, $alias = null)
+    {
+    }
+
+    final public static function mapPhar($alias = null, $offset = 0)
+    {
+    }
+
+    final public static function running($retphar)
+    {
+    }
+
+    final public static function mount($inphar, $externalfile)
+    {
+    }
+
+    final public static function mungServer($munglist)
+    {
+    }
+
+    final public static function unlinkArchive($archive)
+    {
+    }
+
+    final public static function webPhar($alias = null, $index = 'index.php', $f404 = null, $mimetypes = null, $rewrites = null)
+    {
+    }
+
+
+}

--- a/stub/PharFileInfo.stub
+++ b/stub/PharFileInfo.stub
@@ -1,0 +1,67 @@
+<?php
+
+class PharFileInfo extends SplFileInfo
+{
+
+    public function __construct($filename)
+    {
+    }
+
+    public function __destruct()
+    {
+    }
+
+    public function chmod($perms)
+    {
+    }
+
+    public function compress($compression_type)
+    {
+    }
+
+    public function decompress()
+    {
+    }
+
+    public function delMetadata()
+    {
+    }
+
+    public function getCompressedSize()
+    {
+    }
+
+    public function getCRC32()
+    {
+    }
+
+    public function getContent()
+    {
+    }
+
+    public function getMetadata()
+    {
+    }
+
+    public function getPharFlags()
+    {
+    }
+
+    public function hasMetadata()
+    {
+    }
+
+    public function isCompressed($compression_type = 9021976)
+    {
+    }
+
+    public function isCRCChecked()
+    {
+    }
+
+    public function setMetadata($metadata)
+    {
+    }
+
+
+}

--- a/stub/PharFileInfo.stub
+++ b/stub/PharFileInfo.stub
@@ -1,5 +1,3 @@
-<?php
-
 class PharFileInfo extends SplFileInfo
 {
 

--- a/stub/RecursiveCachingIterator.stub
+++ b/stub/RecursiveCachingIterator.stub
@@ -1,5 +1,3 @@
-<?php
-
 class RecursiveCachingIterator extends CachingIterator implements RecursiveIterator
 {
 

--- a/stub/RecursiveCachingIterator.stub
+++ b/stub/RecursiveCachingIterator.stub
@@ -1,0 +1,31 @@
+<?php
+
+class RecursiveCachingIterator extends CachingIterator implements RecursiveIterator
+{
+
+    const CALL_TOSTRING = 1;
+
+    const CATCH_GET_CHILD = 16;
+
+    const TOSTRING_USE_KEY = 2;
+
+    const TOSTRING_USE_CURRENT = 4;
+
+    const TOSTRING_USE_INNER = 8;
+
+    const FULL_CACHE = 256;
+
+    public function __construct(\Iterator $iterator, $flags = self::CALL_TOSTRING)
+    {
+    }
+
+    public function hasChildren()
+    {
+    }
+
+    public function getChildren()
+    {
+    }
+
+
+}

--- a/stub/RecursiveDirectoryIterator.stub
+++ b/stub/RecursiveDirectoryIterator.stub
@@ -1,5 +1,3 @@
-<?php
-
 class RecursiveDirectoryIterator extends FilesystemIterator implements RecursiveIterator
 {
 

--- a/stub/RecursiveDirectoryIterator.stub
+++ b/stub/RecursiveDirectoryIterator.stub
@@ -1,0 +1,51 @@
+<?php
+
+class RecursiveDirectoryIterator extends FilesystemIterator implements RecursiveIterator
+{
+
+    const CURRENT_MODE_MASK = 240;
+
+    const CURRENT_AS_PATHNAME = 32;
+
+    const CURRENT_AS_FILEINFO = 0;
+
+    const CURRENT_AS_SELF = 16;
+
+    const KEY_MODE_MASK = 3840;
+
+    const KEY_AS_PATHNAME = 0;
+
+    const FOLLOW_SYMLINKS = 512;
+
+    const KEY_AS_FILENAME = 256;
+
+    const NEW_CURRENT_AND_KEY = 256;
+
+    const OTHER_MODE_MASK = 12288;
+
+    const SKIP_DOTS = 4096;
+
+    const UNIX_PATHS = 8192;
+
+    public function __construct($path, $flags = FilesystemIterator::KEY_AS_PATHNAME | FilesystemIterator::CURRENT_AS_FILEINFO)
+    {
+    }
+
+    public function hasChildren($allow_links = false)
+    {
+    }
+
+    public function getChildren()
+    {
+    }
+
+    public function getSubPath()
+    {
+    }
+
+    public function getSubPathname()
+    {
+    }
+
+
+}

--- a/stub/RecursiveIteratorIterator.stub
+++ b/stub/RecursiveIteratorIterator.stub
@@ -1,0 +1,87 @@
+<?php
+
+class RecursiveIteratorIterator implements Iterator, Traversable, OuterIterator
+{
+
+    const LEAVES_ONLY = 0;
+
+    const SELF_FIRST = 1;
+
+    const CHILD_FIRST = 2;
+
+    const CATCH_GET_CHILD = 16;
+
+    public function __construct(\Traversable $iterator, $mode = RecursiveIteratorIterator::LEAVES_ONLY, $flags = 0)
+    {
+    }
+
+    public function rewind()
+    {
+    }
+
+    public function valid()
+    {
+    }
+
+    public function key()
+    {
+    }
+
+    public function current()
+    {
+    }
+
+    public function next()
+    {
+    }
+
+    public function getDepth()
+    {
+    }
+
+    public function getSubIterator($level = null)
+    {
+    }
+
+    public function getInnerIterator()
+    {
+    }
+
+    public function beginIteration()
+    {
+    }
+
+    public function endIteration()
+    {
+    }
+
+    public function callHasChildren()
+    {
+    }
+
+    public function callGetChildren()
+    {
+    }
+
+    public function beginChildren()
+    {
+    }
+
+    public function endChildren()
+    {
+    }
+
+    public function nextElement()
+    {
+    }
+
+    public function setMaxDepth($max_depth = -1)
+    {
+    }
+
+    public function getMaxDepth()
+    {
+    }
+
+
+}

--- a/stub/RecursiveIteratorIterator.stub
+++ b/stub/RecursiveIteratorIterator.stub
@@ -1,5 +1,3 @@
-<?php
-
 class RecursiveIteratorIterator implements Iterator, Traversable, OuterIterator
 {
 

--- a/stub/RecursiveRegexIterator.stub
+++ b/stub/RecursiveRegexIterator.stub
@@ -1,0 +1,37 @@
+<?php
+
+class RecursiveRegexIterator extends RegexIterator implements RecursiveIterator
+{
+
+    const USE_KEY = 1;
+
+    const INVERT_MATCH = 2;
+
+    const MATCH = 0;
+
+    const GET_MATCH = 1;
+
+    const ALL_MATCHES = 2;
+
+    const SPLIT = 3;
+
+    const REPLACE = 4;
+
+    public function __construct(\RecursiveIterator $iterator, $regex, $mode = self::MATCH, $flags = 0, $preg_flags = 0)
+    {
+    }
+
+    public function accept()
+    {
+    }
+
+    public function hasChildren()
+    {
+    }
+
+    public function getChildren()
+    {
+    }
+
+
+}

--- a/stub/RecursiveRegexIterator.stub
+++ b/stub/RecursiveRegexIterator.stub
@@ -1,5 +1,3 @@
-<?php
-
 class RecursiveRegexIterator extends RegexIterator implements RecursiveIterator
 {
 

--- a/stub/RecursiveTreeIterator.stub
+++ b/stub/RecursiveTreeIterator.stub
@@ -1,0 +1,101 @@
+class RecursiveTreeIterator extends RecursiveIteratorIterator
+{
+
+    const LEAVES_ONLY = 0;
+
+    const SELF_FIRST = 1;
+
+    const CHILD_FIRST = 2;
+
+    const CATCH_GET_CHILD = 16;
+
+    const BYPASS_CURRENT = 4;
+
+    const BYPASS_KEY = 8;
+
+    const PREFIX_LEFT = 0;
+
+    const PREFIX_MID_HAS_NEXT = 1;
+
+    const PREFIX_MID_LAST = 2;
+
+    const PREFIX_END_HAS_NEXT = 3;
+
+    const PREFIX_END_LAST = 4;
+
+    const PREFIX_RIGHT = 5;
+
+    public function __construct(\Traversable $iterator, $flags = RecursiveTreeIterator::BYPASS_KEY, $caching_it_flags = CachingIterator::CATCH_GET_CHILD, $mode = RecursiveIteratorIterator::SELF_FIRST)
+    {
+    }
+
+    public function rewind()
+    {
+    }
+
+    public function valid()
+    {
+    }
+
+    public function key()
+    {
+    }
+
+    public function current()
+    {
+    }
+
+    public function next()
+    {
+    }
+
+    public function beginIteration()
+    {
+    }
+
+    public function endIteration()
+    {
+    }
+
+    public function callHasChildren()
+    {
+    }
+
+    public function callGetChildren()
+    {
+    }
+
+    public function beginChildren()
+    {
+    }
+
+    public function endChildren()
+    {
+    }
+
+    public function nextElement()
+    {
+    }
+
+    public function getPrefix()
+    {
+    }
+
+    public function setPrefixPart($part, $value)
+    {
+    }
+
+    public function getEntry()
+    {
+    }
+
+    public function setPostfix()
+    {
+    }
+
+    public function getPostfix()
+    {
+    }
+
+
+}

--- a/stub/Reflection.stub
+++ b/stub/Reflection.stub
@@ -1,5 +1,3 @@
-<?php
-
 class Reflection
 {
 

--- a/stub/Reflection.stub
+++ b/stub/Reflection.stub
@@ -1,0 +1,15 @@
+<?php
+
+class Reflection
+{
+
+    public static function getModifierNames($modifiers)
+    {
+    }
+
+    public static function export(\Reflector $reflector, $return = false)
+    {
+    }
+
+
+}

--- a/stub/ReflectionClass.stub
+++ b/stub/ReflectionClass.stub
@@ -1,0 +1,217 @@
+class ReflectionClass implements Reflector
+{
+
+    const IS_IMPLICIT_ABSTRACT = 16;
+
+    const IS_EXPLICIT_ABSTRACT = 32;
+
+    const IS_FINAL = 4;
+
+    public $name = '';
+
+    final private function __clone()
+    {
+    }
+
+    public static function export($argument, $return = false)
+    {
+    }
+
+    public function __construct($argument)
+    {
+    }
+
+    public function __toString()
+    {
+    }
+
+    public function getName()
+    {
+    }
+
+    public function isInternal()
+    {
+    }
+
+    public function isUserDefined()
+    {
+    }
+
+    public function isAnonymous()
+    {
+    }
+
+    public function isInstantiable()
+    {
+    }
+
+    public function isCloneable()
+    {
+    }
+
+    public function getFileName()
+    {
+    }
+
+    public function getStartLine()
+    {
+    }
+
+    public function getEndLine()
+    {
+    }
+
+    public function getDocComment()
+    {
+    }
+
+    public function getConstructor()
+    {
+    }
+
+    public function hasMethod($name)
+    {
+    }
+
+    public function getMethod($name)
+    {
+    }
+
+    public function getMethods($filter = null)
+    {
+    }
+
+    public function hasProperty($name)
+    {
+    }
+
+    public function getProperty($name)
+    {
+    }
+
+    public function getProperties($filter = null)
+    {
+    }
+
+    public function hasConstant($name)
+    {
+    }
+
+    public function getConstants()
+    {
+    }
+
+    public function getConstant($name)
+    {
+    }
+
+    public function getInterfaces()
+    {
+    }
+
+    public function getInterfaceNames()
+    {
+    }
+
+    public function isInterface()
+    {
+    }
+
+    public function getTraits()
+    {
+    }
+
+    public function getTraitNames()
+    {
+    }
+
+    public function getTraitAliases()
+    {
+    }
+
+    public function isTrait()
+    {
+    }
+
+    public function isAbstract()
+    {
+    }
+
+    public function isFinal()
+    {
+    }
+
+    public function getModifiers()
+    {
+    }
+
+    public function isInstance($object)
+    {
+    }
+
+    public function newInstance($args)
+    {
+    }
+
+    public function newInstanceWithoutConstructor()
+    {
+    }
+
+    public function newInstanceArgs(array $args = null)
+    {
+    }
+
+    public function getParentClass()
+    {
+    }
+
+    public function isSubclassOf($class)
+    {
+    }
+
+    public function getStaticProperties()
+    {
+    }
+
+    public function getStaticPropertyValue($name, $default = null)
+    {
+    }
+
+    public function setStaticPropertyValue($name, $value)
+    {
+    }
+
+    public function getDefaultProperties()
+    {
+    }
+
+    public function isIterateable()
+    {
+    }
+
+    public function implementsInterface($interface)
+    {
+    }
+
+    public function getExtension()
+    {
+    }
+
+    public function getExtensionName()
+    {
+    }
+
+    public function inNamespace()
+    {
+    }
+
+    public function getNamespaceName()
+    {
+    }
+
+    public function getShortName()
+    {
+    }
+
+
+}

--- a/stub/ReflectionExtension.stub
+++ b/stub/ReflectionExtension.stub
@@ -1,0 +1,69 @@
+<?php
+
+class ReflectionExtension implements Reflector
+{
+
+    public $name = '';
+
+    final private function __clone()
+    {
+    }
+
+    public static function export($name, $return = false)
+    {
+    }
+
+    public function __construct($name)
+    {
+    }
+
+    public function __toString()
+    {
+    }
+
+    public function getName()
+    {
+    }
+
+    public function getVersion()
+    {
+    }
+
+    public function getFunctions()
+    {
+    }
+
+    public function getConstants()
+    {
+    }
+
+    public function getINIEntries()
+    {
+    }
+
+    public function getClasses()
+    {
+    }
+
+    public function getClassNames()
+    {
+    }
+
+    public function getDependencies()
+    {
+    }
+
+    public function info()
+    {
+    }
+
+    public function isPersistent()
+    {
+    }
+
+    public function isTemporary()
+    {
+    }
+
+
+}

--- a/stub/ReflectionExtension.stub
+++ b/stub/ReflectionExtension.stub
@@ -1,5 +1,3 @@
-<?php
-
 class ReflectionExtension implements Reflector
 {
 

--- a/stub/ReflectionFunction.stub
+++ b/stub/ReflectionFunction.stub
@@ -1,0 +1,37 @@
+class ReflectionFunction extends ReflectionFunctionAbstract
+{
+
+    const IS_DEPRECATED = 262144;
+
+    public $name = '';
+
+    public function __construct($name)
+    {
+    }
+
+    public function __toString()
+    {
+    }
+
+    public static function export($name, $return = null)
+    {
+    }
+
+    public function isDisabled()
+    {
+    }
+
+    public function invoke($args = null)
+    {
+    }
+
+    public function invokeArgs(array $args)
+    {
+    }
+
+    public function getClosure()
+    {
+    }
+
+
+}

--- a/stub/ReflectionGenerator.stub
+++ b/stub/ReflectionGenerator.stub
@@ -1,0 +1,30 @@
+class ReflectionGenerator
+{
+    public function __construct($generator)
+    {
+    }
+
+    public function getExecutingFile()
+    {
+    }
+
+    public function getExecutingGenerator()
+    {
+    }
+
+    public function getExecutingLine()
+    {
+    }
+
+    public function getFunction ()
+    {
+    }
+
+    public function getThis()
+    {
+    }
+
+    public function getTrace ($options = DEBUG_BACKTRACE_PROVIDE_OBJECT)
+    {
+    }
+}

--- a/stub/ReflectionMethod.stub
+++ b/stub/ReflectionMethod.stub
@@ -1,0 +1,93 @@
+class ReflectionMethod extends ReflectionFunctionAbstract
+{
+
+    const IS_STATIC = 1;
+
+    const IS_PUBLIC = 256;
+
+    const IS_PROTECTED = 512;
+
+    const IS_PRIVATE = 1024;
+
+    const IS_ABSTRACT = 2;
+
+    const IS_FINAL = 4;
+
+    public $name = '';
+
+    public $class = '';
+
+    public static function export($class, $name, $return = false)
+    {
+    }
+
+    public function __construct($class_or_method, $name = null)
+    {
+    }
+
+    public function __toString()
+    {
+    }
+
+    public function isPublic()
+    {
+    }
+
+    public function isPrivate()
+    {
+    }
+
+    public function isProtected()
+    {
+    }
+
+    public function isAbstract()
+    {
+    }
+
+    public function isFinal()
+    {
+    }
+
+    public function isStatic()
+    {
+    }
+
+    public function isConstructor()
+    {
+    }
+
+    public function isDestructor()
+    {
+    }
+
+    public function getClosure($object)
+    {
+    }
+
+    public function getModifiers()
+    {
+    }
+
+    public function invoke($object, $args)
+    {
+    }
+
+    public function invokeArgs($object, array $args)
+    {
+    }
+
+    public function getDeclaringClass()
+    {
+    }
+
+    public function getPrototype()
+    {
+    }
+
+    public function setAccessible($value)
+    {
+    }
+
+
+}

--- a/stub/ReflectionObject.stub
+++ b/stub/ReflectionObject.stub
@@ -5,7 +5,7 @@ class ReflectionObject extends ReflectionClass
 
     const IS_EXPLICIT_ABSTRACT = 32;
 
-    const IS_FINAL = 64;
+    const IS_FINAL = 4;
 
     public static function export($argument, $return = null)
     {

--- a/stub/ReflectionObject.stub
+++ b/stub/ReflectionObject.stub
@@ -1,5 +1,3 @@
-<?php
-
 class ReflectionObject extends ReflectionClass
 {
 

--- a/stub/ReflectionObject.stub
+++ b/stub/ReflectionObject.stub
@@ -1,0 +1,21 @@
+<?php
+
+class ReflectionObject extends ReflectionClass
+{
+
+    const IS_IMPLICIT_ABSTRACT = 16;
+
+    const IS_EXPLICIT_ABSTRACT = 32;
+
+    const IS_FINAL = 64;
+
+    public static function export($argument, $return = null)
+    {
+    }
+
+    public function __construct($argument)
+    {
+    }
+
+
+}

--- a/stub/ReflectionParameter.stub
+++ b/stub/ReflectionParameter.stub
@@ -59,11 +59,11 @@ class ReflectionParameter implements Reflector
     {
     }
 
-    public getType()
+    public function getType()
     {
     }
 
-    public hasType()
+    public function hasType()
     {
     }
 

--- a/stub/ReflectionParameter.stub
+++ b/stub/ReflectionParameter.stub
@@ -59,6 +59,14 @@ class ReflectionParameter implements Reflector
     {
     }
 
+    public getType()
+    {
+    }
+
+    public bool hasType()
+    {
+    }
+
     public function isOptional()
     {
     }

--- a/stub/ReflectionParameter.stub
+++ b/stub/ReflectionParameter.stub
@@ -63,7 +63,7 @@ class ReflectionParameter implements Reflector
     {
     }
 
-    public bool hasType()
+    public hasType()
     {
     }
 

--- a/stub/ReflectionParameter.stub
+++ b/stub/ReflectionParameter.stub
@@ -1,0 +1,89 @@
+<?php
+
+class ReflectionParameter implements Reflector
+{
+
+    public $name = '';
+
+    final private function __clone()
+    {
+    }
+
+    public static function export($function, $parameter, $return = null)
+    {
+    }
+
+    public function __construct($function, $parameter)
+    {
+    }
+
+    public function __toString()
+    {
+    }
+
+    public function getName()
+    {
+    }
+
+    public function isPassedByReference()
+    {
+    }
+
+    public function canBePassedByValue()
+    {
+    }
+
+    public function getDeclaringFunction()
+    {
+    }
+
+    public function getDeclaringClass()
+    {
+    }
+
+    public function getClass()
+    {
+    }
+
+    public function isArray()
+    {
+    }
+
+    public function isCallable()
+    {
+    }
+
+    public function allowsNull()
+    {
+    }
+
+    public function getPosition()
+    {
+    }
+
+    public function isOptional()
+    {
+    }
+
+    public function isDefaultValueAvailable()
+    {
+    }
+
+    public function getDefaultValue()
+    {
+    }
+
+    public function isDefaultValueConstant()
+    {
+    }
+
+    public function getDefaultValueConstantName()
+    {
+    }
+
+    public function isVariadic()
+    {
+    }
+
+
+}

--- a/stub/ReflectionParameter.stub
+++ b/stub/ReflectionParameter.stub
@@ -1,5 +1,3 @@
-<?php
-
 class ReflectionParameter implements Reflector
 {
 

--- a/stub/ReflectionProperty.stub
+++ b/stub/ReflectionProperty.stub
@@ -1,0 +1,81 @@
+class ReflectionProperty implements Reflector
+{
+
+    const IS_STATIC = 1;
+
+    const IS_PUBLIC = 256;
+
+    const IS_PROTECTED = 512;
+
+    const IS_PRIVATE = 1024;
+
+    public $name = '';
+
+    public $class = '';
+
+    final private function __clone()
+    {
+    }
+
+    public static function export($class, $name, $return = null)
+    {
+    }
+
+    public function __construct($class, $name)
+    {
+    }
+
+    public function __toString()
+    {
+    }
+
+    public function getName()
+    {
+    }
+
+    public function getValue($object = null)
+    {
+    }
+
+    public function setValue($object, $value = null)
+    {
+    }
+
+    public function isPublic()
+    {
+    }
+
+    public function isPrivate()
+    {
+    }
+
+    public function isProtected()
+    {
+    }
+
+    public function isStatic()
+    {
+    }
+
+    public function isDefault()
+    {
+    }
+
+    public function getModifiers()
+    {
+    }
+
+    public function getDeclaringClass()
+    {
+    }
+
+    public function getDocComment()
+    {
+    }
+
+    public function setAccessible($visible)
+    {
+    }
+
+
+}

--- a/stub/ReflectionZendExtension.stub
+++ b/stub/ReflectionZendExtension.stub
@@ -1,5 +1,3 @@
-<?php
-
 class ReflectionZendExtension implements Reflector
 {
 

--- a/stub/ReflectionZendExtension.stub
+++ b/stub/ReflectionZendExtension.stub
@@ -1,0 +1,45 @@
+<?php
+
+class ReflectionZendExtension implements Reflector
+{
+
+    public $name = '';
+
+    final private function __clone()
+    {
+    }
+
+    public static function export($name, $return = null)
+    {
+    }
+
+    public function __construct($name)
+    {
+    }
+
+    public function __toString()
+    {
+    }
+
+    public function getName()
+    {
+    }
+
+    public function getVersion()
+    {
+    }
+
+    public function getAuthor()
+    {
+    }
+
+    public function getURL()
+    {
+    }
+
+    public function getCopyright()
+    {
+    }
+
+
+}

--- a/stub/RegexIterator.stub
+++ b/stub/RegexIterator.stub
@@ -1,5 +1,3 @@
-<?php
-
 class RegexIterator extends FilterIterator
 {
 

--- a/stub/RegexIterator.stub
+++ b/stub/RegexIterator.stub
@@ -1,0 +1,59 @@
+<?php
+
+class RegexIterator extends FilterIterator
+{
+
+    const USE_KEY = 1;
+
+    const INVERT_MATCH = 2;
+
+    const MATCH = 0;
+
+    const GET_MATCH = 1;
+
+    const ALL_MATCHES = 2;
+
+    const SPLIT = 3;
+
+    const REPLACE = 4;
+
+    public $replacement = null;
+
+    public function __construct(\Iterator $iterator, $regex, $mode = self::MATCH, $flags = 0, $preg_flags = 0)
+    {
+    }
+
+    public function accept()
+    {
+    }
+
+    public function getMode()
+    {
+    }
+
+    public function setMode($mode)
+    {
+    }
+
+    public function getFlags()
+    {
+    }
+
+    public function setFlags($flags)
+    {
+    }
+
+    public function getPregFlags()
+    {
+    }
+
+    public function setPregFlags($preg_flags)
+    {
+    }
+
+    public function getRegex()
+    {
+    }
+
+
+}

--- a/stub/ResourceBundle.stub
+++ b/stub/ResourceBundle.stub
@@ -1,0 +1,33 @@
+class ResourceBundle implements Traversable
+{
+
+    public function __construct($locale, $bundlename, $fallback = null)
+    {
+    }
+
+    public static function create($locale, $bundlename, $fallback = null)
+    {
+    }
+
+    public function get($index, $fallback = null)
+    {
+    }
+
+    public function count()
+    {
+    }
+
+    public static function getLocales($bundlename)
+    {
+    }
+
+    public function getErrorCode()
+    {
+    }
+
+    public function getErrorMessage()
+    {
+    }
+
+
+}

--- a/stub/SQLite3.stub
+++ b/stub/SQLite3.stub
@@ -1,0 +1,87 @@
+<?php
+
+class SQLite3
+{
+
+    public function open($filename, $flags = SQLITE3_OPEN_READWRITE | SQLITE3_OPEN_CREATE, $encryption_key = null)
+    {
+    }
+
+    public function close()
+    {
+    }
+
+    public function exec($query)
+    {
+    }
+
+    public static function version()
+    {
+    }
+
+    public function lastInsertRowID()
+    {
+    }
+
+    public function lastErrorCode()
+    {
+    }
+
+    public function lastErrorMsg()
+    {
+    }
+
+    public function busyTimeout($ms)
+    {
+    }
+
+    public function loadExtension($shared_library)
+    {
+    }
+
+    public function changes()
+    {
+    }
+
+    public static function escapeString($value)
+    {
+    }
+
+    public function prepare($query)
+    {
+    }
+
+    public function query($query)
+    {
+    }
+
+    public function querySingle($query, $entire_row = false)
+    {
+    }
+
+    public function createFunction($name, $callback, $argument_count = -1)
+    {
+    }
+
+    public function createAggregate($name, $step_callback, $final_callback, $argument_count = -1)
+    {
+    }
+
+    public function createCollation($name, $callback)
+    {
+    }
+
+    public function openBlob($table, $column, $rowid, $dbname = null)
+    {
+    }
+
+    public function enableExceptions($enableExceptions)
+    {
+    }
+
+    public function __construct($filename, $flags = null, $encryption_key = null)
+    {
+    }
+
+
+}

--- a/stub/SQLite3.stub
+++ b/stub/SQLite3.stub
@@ -1,5 +1,3 @@
-<?php
-
 class SQLite3
 {
 

--- a/stub/SQLite3Result.stub
+++ b/stub/SQLite3Result.stub
@@ -1,5 +1,3 @@
-<?php
-
 class SQLite3Result
 {
 

--- a/stub/SQLite3Result.stub
+++ b/stub/SQLite3Result.stub
@@ -1,0 +1,35 @@
+<?php
+
+class SQLite3Result
+{
+
+    public function numColumns()
+    {
+    }
+
+    public function columnName($column_number)
+    {
+    }
+
+    public function columnType($column_number)
+    {
+    }
+
+    public function fetchArray($mode = SQLITE3_BOTH)
+    {
+    }
+
+    public function reset()
+    {
+    }
+
+    public function finalize()
+    {
+    }
+
+    private function __construct()
+    {
+    }
+
+
+}

--- a/stub/SQLite3Stmt.stub
+++ b/stub/SQLite3Stmt.stub
@@ -1,0 +1,43 @@
+<?php
+
+class SQLite3Stmt
+{
+
+    public function paramCount()
+    {
+    }
+
+    public function close()
+    {
+    }
+
+    public function reset()
+    {
+    }
+
+    public function clear()
+    {
+    }
+
+    public function execute()
+    {
+    }
+
+    public function bindParam($param_number, &$param, $type = null)
+    {
+    }
+
+    public function bindValue($param_number, $param, $type = null)
+    {
+    }
+
+    public function readOnly()
+    {
+    }
+
+    private function __construct($sqlite3)
+    {
+    }
+
+
+}

--- a/stub/SQLite3Stmt.stub
+++ b/stub/SQLite3Stmt.stub
@@ -1,5 +1,3 @@
-<?php
-
 class SQLite3Stmt
 {
 

--- a/stub/SimpleXMLElement.stub
+++ b/stub/SimpleXMLElement.stub
@@ -1,0 +1,61 @@
+class SimpleXMLElement implements Traversable
+{
+
+    final public function __construct($data, $options = 0, $data_is_url = false, $ns = '', $is_prefix = false)
+    {
+    }
+
+    public function asXML($filename = null)
+    {
+    }
+
+    public function saveXML($filename = null)
+    {
+    }
+
+    public function xpath($path)
+    {
+    }
+
+    public function registerXPathNamespace($prefix, $ns)
+    {
+    }
+
+    public function attributes($ns = null, $is_prefix = false)
+    {
+    }
+
+    public function children($ns = null, $is_prefix = false)
+    {
+    }
+
+    public function getNamespaces($recursve = false)
+    {
+    }
+
+    public function getDocNamespaces($recursve = false, $from_root = true)
+    {
+    }
+
+    public function getName()
+    {
+    }
+
+    public function addChild($name, $value = null, $ns = null)
+    {
+    }
+
+    public function addAttribute($name, $value = null, $ns = null)
+    {
+    }
+
+    public function __toString()
+    {
+    }
+
+    public function count()
+    {
+    }
+
+
+}

--- a/stub/SoapClient.stub
+++ b/stub/SoapClient.stub
@@ -1,0 +1,63 @@
+<?php
+
+class SoapClient
+{
+
+    public function SoapClient($wsdl, $options = null)
+    {
+    }
+
+    public function __call($function_name, $arguments)
+    {
+    }
+
+    public function __soapCall($function_name, $arguments, $options = null, $input_headers = null, &$output_headers = null)
+    {
+    }
+
+    public function __getLastRequest()
+    {
+    }
+
+    public function __getLastResponse()
+    {
+    }
+
+    public function __getLastRequestHeaders()
+    {
+    }
+
+    public function __getLastResponseHeaders()
+    {
+    }
+
+    public function __getFunctions()
+    {
+    }
+
+    public function __getTypes()
+    {
+    }
+
+    public function __doRequest($request, $location, $action, $version, $one_way = 0)
+    {
+    }
+
+    public function __setCookie($name, $value = null)
+    {
+    }
+
+    public function __getCookies()
+    {
+    }
+
+    public function __setLocation($new_location = null)
+    {
+    }
+
+    public function __setSoapHeaders($soapheaders)
+    {
+    }
+
+
+}

--- a/stub/SoapClient.stub
+++ b/stub/SoapClient.stub
@@ -1,5 +1,3 @@
-<?php
-
 class SoapClient
 {
 

--- a/stub/SoapFault.stub
+++ b/stub/SoapFault.stub
@@ -1,0 +1,15 @@
+<?php
+
+class SoapFault extends Exception
+{
+
+    public function SoapFault($faultcode, $faultstring, $faultactor = null, $detail = null, $faultname = null, $headerfault = null)
+    {
+    }
+
+    public function __toString()
+    {
+    }
+
+
+}

--- a/stub/SoapFault.stub
+++ b/stub/SoapFault.stub
@@ -1,5 +1,3 @@
-<?php
-
 class SoapFault extends Exception
 {
 

--- a/stub/SoapHeader.stub
+++ b/stub/SoapHeader.stub
@@ -1,0 +1,11 @@
+<?php
+
+class SoapHeader
+{
+
+    public function SoapHeader($namespace, $name, $data = null, $mustunderstand = false, $actor = null)
+    {
+    }
+
+
+}

--- a/stub/SoapHeader.stub
+++ b/stub/SoapHeader.stub
@@ -1,5 +1,3 @@
-<?php
-
 class SoapHeader
 {
 

--- a/stub/SoapServer.stub
+++ b/stub/SoapServer.stub
@@ -1,5 +1,3 @@
-<?php
-
 class SoapServer
 {
 

--- a/stub/SoapServer.stub
+++ b/stub/SoapServer.stub
@@ -1,0 +1,43 @@
+<?php
+
+class SoapServer
+{
+
+    public function SoapServer($wsdl, $options = null)
+    {
+    }
+
+    public function setPersistence($mode)
+    {
+    }
+
+    public function setClass($class_name, $args = null)
+    {
+    }
+
+    public function setObject($object)
+    {
+    }
+
+    public function addFunction($functions)
+    {
+    }
+
+    public function getFunctions()
+    {
+    }
+
+    public function handle($soap_request = null)
+    {
+    }
+
+    public function fault($code, $string, $actor = null, $details = null, $name = null)
+    {
+    }
+
+    public function addSoapHeader($object)
+    {
+    }
+
+
+}

--- a/stub/SoapVar.stub
+++ b/stub/SoapVar.stub
@@ -1,5 +1,3 @@
-<?php
-
 class SoapVar
 {
 

--- a/stub/SoapVar.stub
+++ b/stub/SoapVar.stub
@@ -1,0 +1,11 @@
+<?php
+
+class SoapVar
+{
+
+    public function SoapVar($data, $encoding, $type_name = null, $type_namespace = null, $node_name = null, $node_namespace = null)
+    {
+    }
+
+
+}

--- a/stub/SplFileInfo.stub
+++ b/stub/SplFileInfo.stub
@@ -1,0 +1,125 @@
+class SplFileInfo
+{
+
+    public function __construct($file_name)
+    {
+    }
+
+    public function getPath()
+    {
+    }
+
+    public function getFilename()
+    {
+    }
+
+    public function getExtension()
+    {
+    }
+
+    public function getBasename($suffix = null)
+    {
+    }
+
+    public function getPathname()
+    {
+    }
+
+    public function getPerms()
+    {
+    }
+
+    public function getInode()
+    {
+    }
+
+    public function getSize()
+    {
+    }
+
+    public function getOwner()
+    {
+    }
+
+    public function getGroup()
+    {
+    }
+
+    public function getATime()
+    {
+    }
+
+    public function getMTime()
+    {
+    }
+
+    public function getCTime()
+    {
+    }
+
+    public function getType()
+    {
+    }
+
+    public function isWritable()
+    {
+    }
+
+    public function isReadable()
+    {
+    }
+
+    public function isExecutable()
+    {
+    }
+
+    public function isFile()
+    {
+    }
+
+    public function isDir()
+    {
+    }
+
+    public function isLink()
+    {
+    }
+
+    public function getLinkTarget()
+    {
+    }
+
+    public function getRealPath()
+    {
+    }
+
+    public function getFileInfo($class_name = null)
+    {
+    }
+
+    public function getPathInfo($class_name = null)
+    {
+    }
+
+    public function openFile($open_mode = 'r', $use_include_path = false, $context = null)
+    {
+    }
+
+    public function setFileClass($class_name = 'SplFileObject')
+    {
+    }
+
+    public function setInfoClass($class_name = 'SplFileInfo')
+    {
+    }
+
+    final public function _bad_state_ex()
+    {
+    }
+
+    public function __toString()
+    {
+    }
+
+
+}

--- a/stub/SplFileObject.stub
+++ b/stub/SplFileObject.stub
@@ -1,0 +1,147 @@
+<?php
+
+class SplFileObject extends SplFileInfo implements RecursiveIterator, Traversable, Iterator, SeekableIterator
+{
+
+    const DROP_NEW_LINE = 1;
+
+    const READ_AHEAD = 2;
+
+    const SKIP_EMPTY = 4;
+
+    const READ_CSV = 8;
+
+    public function __construct($file_name, $open_mode = 'r', $use_include_path = false, $context = null)
+    {
+    }
+
+    public function rewind()
+    {
+    }
+
+    public function eof()
+    {
+    }
+
+    public function valid()
+    {
+    }
+
+    public function fgets()
+    {
+    }
+
+    public function fgetcsv($delimiter = ',', $enclosure = '"', $escape = '\\')
+    {
+    }
+
+    public function fputcsv($fields, $delimiter = ',', $enclosure = '"', $escape = '\\')
+    {
+    }
+
+    public function setCsvControl($delimiter = ',', $enclosure = '"', $escape = '\\')
+    {
+    }
+
+    public function getCsvControl()
+    {
+    }
+
+    public function flock($operation, &$wouldblock = null)
+    {
+    }
+
+    public function fflush()
+    {
+    }
+
+    public function ftell()
+    {
+    }
+
+    public function fseek($pos, $whence = SEEK_SET)
+    {
+    }
+
+    public function fgetc()
+    {
+    }
+
+    public function fpassthru()
+    {
+    }
+
+    public function fgetss($allowable_tags = null)
+    {
+    }
+
+    public function fscanf($format, &$vars = null)
+    {
+    }
+
+    public function fwrite($str, $length = null)
+    {
+    }
+
+    public function fread($length)
+    {
+    }
+
+    public function fstat()
+    {
+    }
+
+    public function ftruncate($size)
+    {
+    }
+
+    public function current()
+    {
+    }
+
+    public function key()
+    {
+    }
+
+    public function next()
+    {
+    }
+
+    public function setFlags($flags)
+    {
+    }
+
+    public function getFlags()
+    {
+    }
+
+    public function setMaxLineLen($max_len)
+    {
+    }
+
+    public function getMaxLineLen()
+    {
+    }
+
+    public function hasChildren()
+    {
+    }
+
+    public function getChildren()
+    {
+    }
+
+    public function seek($line_pos)
+    {
+    }
+
+    public function getCurrentLine()
+    {
+    }
+
+    public function __toString()
+    {
+    }
+
+
+}

--- a/stub/SplFileObject.stub
+++ b/stub/SplFileObject.stub
@@ -73,7 +73,7 @@ class SplFileObject extends SplFileInfo implements RecursiveIterator, Traversabl
     {
     }
 
-    public function fscanf($format, &$vars = null)
+    public function fscanf($format, & ...$vars)
     {
     }
 

--- a/stub/SplFileObject.stub
+++ b/stub/SplFileObject.stub
@@ -1,5 +1,3 @@
-<?php
-
 class SplFileObject extends SplFileInfo implements RecursiveIterator, Traversable, Iterator, SeekableIterator
 {
 

--- a/stub/SplFixedArray.stub
+++ b/stub/SplFixedArray.stub
@@ -1,5 +1,3 @@
-<?php
-
 class SplFixedArray implements Iterator, Traversable, ArrayAccess, Countable
 {
 

--- a/stub/SplFixedArray.stub
+++ b/stub/SplFixedArray.stub
@@ -1,0 +1,71 @@
+<?php
+
+class SplFixedArray implements Iterator, Traversable, ArrayAccess, Countable
+{
+
+    public function __construct($size = 0)
+    {
+    }
+
+    public function __wakeup()
+    {
+    }
+
+    public function count()
+    {
+    }
+
+    public function toArray()
+    {
+    }
+
+    public static function fromArray($data, $save_indexes = true)
+    {
+    }
+
+    public function getSize()
+    {
+    }
+
+    public function setSize($value)
+    {
+    }
+
+    public function offsetExists($index)
+    {
+    }
+
+    public function offsetGet($index)
+    {
+    }
+
+    public function offsetSet($index, $newval)
+    {
+    }
+
+    public function offsetUnset($index)
+    {
+    }
+
+    public function rewind()
+    {
+    }
+
+    public function current()
+    {
+    }
+
+    public function key()
+    {
+    }
+
+    public function next()
+    {
+    }
+
+    public function valid()
+    {
+    }
+
+
+}

--- a/stub/SplObjectStorage.stub
+++ b/stub/SplObjectStorage.stub
@@ -1,0 +1,89 @@
+class SplObjectStorage implements Countable, Iterator, Traversable, Serializable, ArrayAccess
+{
+
+    public function attach($object, $inf = null)
+    {
+    }
+
+    public function detach($object)
+    {
+    }
+
+    public function contains($object)
+    {
+    }
+
+    public function addAll($object)
+    {
+    }
+
+    public function removeAll($object)
+    {
+    }
+
+    public function removeAllExcept($object)
+    {
+    }
+
+    public function getInfo()
+    {
+    }
+
+    public function setInfo($info)
+    {
+    }
+
+    public function getHash($object)
+    {
+    }
+
+    public function count()
+    {
+    }
+
+    public function rewind()
+    {
+    }
+
+    public function valid()
+    {
+    }
+
+    public function key()
+    {
+    }
+
+    public function current()
+    {
+    }
+
+    public function next()
+    {
+    }
+
+    public function unserialize($serialized)
+    {
+    }
+
+    public function serialize()
+    {
+    }
+
+    public function offsetExists($object)
+    {
+    }
+
+    public function offsetSet($object, $inf = null)
+    {
+    }
+
+    public function offsetUnset($object)
+    {
+    }
+
+    public function offsetGet($object)
+    {
+    }
+
+
+}

--- a/stub/SplTempFileObject.stub
+++ b/stub/SplTempFileObject.stub
@@ -1,0 +1,19 @@
+<?php
+
+class SplTempFileObject extends SplFileObject
+{
+
+    const DROP_NEW_LINE = 1;
+
+    const READ_AHEAD = 2;
+
+    const SKIP_EMPTY = 4;
+
+    const READ_CSV = 8;
+
+    public function __construct($max_memory = null)
+    {
+    }
+
+
+}

--- a/stub/SplTempFileObject.stub
+++ b/stub/SplTempFileObject.stub
@@ -1,5 +1,3 @@
-<?php
-
 class SplTempFileObject extends SplFileObject
 {
 

--- a/stub/Spoofchecker.stub
+++ b/stub/Spoofchecker.stub
@@ -1,0 +1,41 @@
+<?php
+
+class Spoofchecker
+{
+
+    const SINGLE_SCRIPT_CONFUSABLE = 1;
+
+    const MIXED_SCRIPT_CONFUSABLE = 2;
+
+    const WHOLE_SCRIPT_CONFUSABLE = 4;
+
+    const ANY_CASE = 8;
+
+    const SINGLE_SCRIPT = 16;
+
+    const INVISIBLE = 32;
+
+    const CHAR_LIMIT = 64;
+
+    public function __construct()
+    {
+    }
+
+    public function isSuspicious($text, &$error = null)
+    {
+    }
+
+    public function areConfusable($s1, $s2, &$error = null)
+    {
+    }
+
+    public function setAllowedLocales($locale_list)
+    {
+    }
+
+    public function setChecks($checks)
+    {
+    }
+
+
+}

--- a/stub/Spoofchecker.stub
+++ b/stub/Spoofchecker.stub
@@ -1,5 +1,3 @@
-<?php
-
 class Spoofchecker
 {
 

--- a/stub/Transliterator.stub
+++ b/stub/Transliterator.stub
@@ -1,0 +1,45 @@
+<?php
+
+class Transliterator
+{
+
+    const FORWARD = 0;
+
+    const REVERSE = 1;
+
+    public $id = null;
+
+    final private function __construct()
+    {
+    }
+
+    public static function create($id, $direction = null)
+    {
+    }
+
+    public static function createFromRules($rules, $direction = null)
+    {
+    }
+
+    public function createInverse()
+    {
+    }
+
+    public static function listIDs()
+    {
+    }
+
+    public function transliterate($subject, $start = null, $end = null)
+    {
+    }
+
+    public function getErrorCode()
+    {
+    }
+
+    public function getErrorMessage()
+    {
+    }
+
+
+}

--- a/stub/Transliterator.stub
+++ b/stub/Transliterator.stub
@@ -1,5 +1,3 @@
-<?php
-
 class Transliterator
 {
 

--- a/stub/UConverter.stub
+++ b/stub/UConverter.stub
@@ -1,5 +1,3 @@
-<?php
-
 class UConverter
 {
 

--- a/stub/UConverter.stub
+++ b/stub/UConverter.stub
@@ -1,0 +1,165 @@
+<?php
+
+class UConverter
+{
+
+    const REASON_UNASSIGNED = 0;
+
+    const REASON_ILLEGAL = 1;
+
+    const REASON_IRREGULAR = 2;
+
+    const REASON_RESET = 3;
+
+    const REASON_CLOSE = 4;
+
+    const REASON_CLONE = 5;
+
+    const UNSUPPORTED_CONVERTER = -1;
+
+    const SBCS = 0;
+
+    const DBCS = 1;
+
+    const MBCS = 2;
+
+    const LATIN_1 = 3;
+
+    const UTF8 = 4;
+
+    const UTF16_BigEndian = 5;
+
+    const UTF16_LittleEndian = 6;
+
+    const UTF32_BigEndian = 7;
+
+    const UTF32_LittleEndian = 8;
+
+    const EBCDIC_STATEFUL = 9;
+
+    const ISO_2022 = 10;
+
+    const LMBCS_1 = 11;
+
+    const LMBCS_2 = 12;
+
+    const LMBCS_3 = 13;
+
+    const LMBCS_4 = 14;
+
+    const LMBCS_5 = 15;
+
+    const LMBCS_6 = 16;
+
+    const LMBCS_8 = 17;
+
+    const LMBCS_11 = 18;
+
+    const LMBCS_16 = 19;
+
+    const LMBCS_17 = 20;
+
+    const LMBCS_18 = 21;
+
+    const LMBCS_19 = 22;
+
+    const LMBCS_LAST = 22;
+
+    const HZ = 23;
+
+    const SCSU = 24;
+
+    const ISCII = 25;
+
+    const US_ASCII = 26;
+
+    const UTF7 = 27;
+
+    const BOCU1 = 28;
+
+    const UTF16 = 29;
+
+    const UTF32 = 30;
+
+    const CESU8 = 31;
+
+    const IMAP_MAILBOX = 32;
+
+    public function __construct($destination_encoding = null, $source_encoding = null)
+    {
+    }
+
+    public function setSourceEncoding($encoding)
+    {
+    }
+
+    public function setDestinationEncoding($encoding)
+    {
+    }
+
+    public function getSourceEncoding()
+    {
+    }
+
+    public function getDestinationEncoding()
+    {
+    }
+
+    public function getSourceType()
+    {
+    }
+
+    public function getDestinationType()
+    {
+    }
+
+    public function getSubstChars()
+    {
+    }
+
+    public function setSubstChars($chars)
+    {
+    }
+
+    public function toUCallback($reason, $source, $codeUnits, &$error)
+    {
+    }
+
+    public function fromUCallback($reason, $source, $codePoint, &$error)
+    {
+    }
+
+    public function convert($str, $reverse = null)
+    {
+    }
+
+    public static function transcode($str, $toEncoding, $fromEncoding, array $options = null)
+    {
+    }
+
+    public function getErrorCode()
+    {
+    }
+
+    public function getErrorMessage()
+    {
+    }
+
+    public static function reasonText($reason = null)
+    {
+    }
+
+    public static function getAvailable()
+    {
+    }
+
+    public static function getAliases($name = null)
+    {
+    }
+
+    public static function getStandards()
+    {
+    }
+
+
+}

--- a/stub/XMLReader.stub
+++ b/stub/XMLReader.stub
@@ -1,5 +1,3 @@
-<?php
-
 class XMLReader
 {
 

--- a/stub/XMLReader.stub
+++ b/stub/XMLReader.stub
@@ -1,0 +1,151 @@
+<?php
+
+class XMLReader
+{
+
+    const NONE = 0;
+
+    const ELEMENT = 1;
+
+    const ATTRIBUTE = 2;
+
+    const TEXT = 3;
+
+    const CDATA = 4;
+
+    const ENTITY_REF = 5;
+
+    const ENTITY = 6;
+
+    const PI = 7;
+
+    const COMMENT = 8;
+
+    const DOC = 9;
+
+    const DOC_TYPE = 10;
+
+    const DOC_FRAGMENT = 11;
+
+    const NOTATION = 12;
+
+    const WHITESPACE = 13;
+
+    const SIGNIFICANT_WHITESPACE = 14;
+
+    const END_ELEMENT = 15;
+
+    const END_ENTITY = 16;
+
+    const XML_DECLARATION = 17;
+
+    const LOADDTD = 1;
+
+    const DEFAULTATTRS = 2;
+
+    const VALIDATE = 3;
+
+    const SUBST_ENTITIES = 4;
+
+    public function close()
+    {
+    }
+
+    public function getAttribute($name)
+    {
+    }
+
+    public function getAttributeNo($index)
+    {
+    }
+
+    public function getAttributeNs($name, $namespaceURI)
+    {
+    }
+
+    public function getParserProperty($property)
+    {
+    }
+
+    public function isValid()
+    {
+    }
+
+    public function lookupNamespace($prefix)
+    {
+    }
+
+    public function moveToAttributeNo($index)
+    {
+    }
+
+    public function moveToAttribute($name)
+    {
+    }
+
+    public function moveToAttributeNs($name, $namespaceURI)
+    {
+    }
+
+    public function moveToElement()
+    {
+    }
+
+    public function moveToFirstAttribute()
+    {
+    }
+
+    public function moveToNextAttribute()
+    {
+    }
+
+    public function open($URI, $encoding = null, $options = 0)
+    {
+    }
+
+    public function read()
+    {
+    }
+
+    public function next($localname = null)
+    {
+    }
+
+    public function readInnerXml()
+    {
+    }
+
+    public function readOuterXml()
+    {
+    }
+
+    public function readString()
+    {
+    }
+
+    public function setSchema($filename)
+    {
+    }
+
+    public function setParserProperty($property, $value)
+    {
+    }
+
+    public function setRelaxNGSchema($filename)
+    {
+    }
+
+    public function setRelaxNGSchemaSource($source)
+    {
+    }
+
+    public function XML($source, $encoding = null, $options = 0)
+    {
+    }
+
+    public function expand()
+    {
+    }
+
+
+}

--- a/stub/XMLWriter.stub
+++ b/stub/XMLWriter.stub
@@ -1,0 +1,173 @@
+class XMLWriter
+{
+
+    public function openUri($uri)
+    {
+    }
+
+    public function openMemory()
+    {
+    }
+
+    public function setIndent($indent)
+    {
+    }
+
+    public function setIndentString($indentString)
+    {
+    }
+
+    public function startComment()
+    {
+    }
+
+    public function endComment()
+    {
+    }
+
+    public function startAttribute($name)
+    {
+    }
+
+    public function endAttribute()
+    {
+    }
+
+    public function writeAttribute($name, $value)
+    {
+    }
+
+    public function startAttributeNs($prefix, $name, $uri)
+    {
+    }
+
+    public function writeAttributeNs($prefix, $name, $uri, $content)
+    {
+    }
+
+    public function startElement($name)
+    {
+    }
+
+    public function endElement()
+    {
+    }
+
+    public function fullEndElement()
+    {
+    }
+
+    public function startElementNs($prefix, $name, $uri)
+    {
+    }
+
+    public function writeElement($name, $content = null)
+    {
+    }
+
+    public function writeElementNs($prefix, $name, $uri, $content = null)
+    {
+    }
+
+    public function startPi($target)
+    {
+    }
+
+    public function endPi()
+    {
+    }
+
+    public function writePi($target, $content)
+    {
+    }
+
+    public function startCdata()
+    {
+    }
+
+    public function endCdata()
+    {
+    }
+
+    public function writeCdata($content)
+    {
+    }
+
+    public function text($content)
+    {
+    }
+
+    public function writeRaw($content)
+    {
+    }
+
+    public function startDocument($version = 1, $encoding = null, $standalone = null)
+    {
+    }
+
+    public function endDocument()
+    {
+    }
+
+    public function writeComment($content)
+    {
+    }
+
+    public function startDtd($qualifiedName, $publicId = null, $systemId = null)
+    {
+    }
+
+    public function endDtd()
+    {
+    }
+
+    public function writeDtd($name, $publicId = null, $systemId = null, $subset = null)
+    {
+    }
+
+    public function startDtdElement($qualifiedName)
+    {
+    }
+
+    public function endDtdElement()
+    {
+    }
+
+    public function writeDtdElement($name, $content)
+    {
+    }
+
+    public function startDtdAttlist($name)
+    {
+    }
+
+    public function endDtdAttlist()
+    {
+    }
+
+    public function writeDtdAttlist($name, $content)
+    {
+    }
+
+    public function startDtdEntity($name, $isparam)
+    {
+    }
+
+    public function endDtdEntity()
+    {
+    }
+
+    public function writeDtdEntity($name, $content)
+    {
+    }
+
+    public function outputMemory($flush = true)
+    {
+    }
+
+    public function flush($empty = true)
+    {
+    }
+
+
+}

--- a/stub/XSLTProcessor.stub
+++ b/stub/XSLTProcessor.stub
@@ -1,0 +1,53 @@
+class XSLTProcessor
+{
+
+    public function importStylesheet($doc)
+    {
+    }
+
+    public function transformToDoc($doc)
+    {
+    }
+
+    public function transformToUri($doc, $uri)
+    {
+    }
+
+    public function transformToXml($doc)
+    {
+    }
+
+    public function setParameter($namespace, $name, $value = null)
+    {
+    }
+
+    public function getParameter($namespace, $name)
+    {
+    }
+
+    public function removeParameter($namespace, $name)
+    {
+    }
+
+    public function hasExsltSupport()
+    {
+    }
+
+    public function registerPHPFunctions($restrict = null)
+    {
+    }
+
+    public function setProfiling($filename)
+    {
+    }
+
+    public function setSecurityPrefs($securityPrefs)
+    {
+    }
+
+    public function getSecurityPrefs()
+    {
+    }
+
+
+}

--- a/stub/ZipArchive.stub
+++ b/stub/ZipArchive.stub
@@ -1,0 +1,293 @@
+class ZipArchive
+{
+
+    const CREATE = 1;
+
+    const EXCL = 2;
+
+    const CHECKCONS = 4;
+
+    const OVERWRITE = 8;
+
+    const FL_NOCASE = 1;
+
+    const FL_NODIR = 2;
+
+    const FL_COMPRESSED = 4;
+
+    const FL_UNCHANGED = 8;
+
+    const CM_DEFAULT = -1;
+
+    const CM_STORE = 0;
+
+    const CM_SHRINK = 1;
+
+    const CM_REDUCE_1 = 2;
+
+    const CM_REDUCE_2 = 3;
+
+    const CM_REDUCE_3 = 4;
+
+    const CM_REDUCE_4 = 5;
+
+    const CM_IMPLODE = 6;
+
+    const CM_DEFLATE = 8;
+
+    const CM_DEFLATE64 = 9;
+
+    const CM_PKWARE_IMPLODE = 10;
+
+    const CM_BZIP2 = 12;
+
+    const CM_LZMA = 14;
+
+    const CM_TERSE = 18;
+
+    const CM_LZ77 = 19;
+
+    const CM_WAVPACK = 97;
+
+    const CM_PPMD = 98;
+
+    const ER_OK = 0;
+
+    const ER_MULTIDISK = 1;
+
+    const ER_RENAME = 2;
+
+    const ER_CLOSE = 3;
+
+    const ER_SEEK = 4;
+
+    const ER_READ = 5;
+
+    const ER_WRITE = 6;
+
+    const ER_CRC = 7;
+
+    const ER_ZIPCLOSED = 8;
+
+    const ER_NOENT = 9;
+
+    const ER_EXISTS = 10;
+
+    const ER_OPEN = 11;
+
+    const ER_TMPOPEN = 12;
+
+    const ER_ZLIB = 13;
+
+    const ER_MEMORY = 14;
+
+    const ER_CHANGED = 15;
+
+    const ER_COMPNOTSUPP = 16;
+
+    const ER_EOF = 17;
+
+    const ER_INVAL = 18;
+
+    const ER_NOZIP = 19;
+
+    const ER_INTERNAL = 20;
+
+    const ER_INCONS = 21;
+
+    const ER_REMOVE = 22;
+
+    const ER_DELETED = 23;
+
+    const OPSYS_DOS = 0;
+
+    const OPSYS_AMIGA = 1;
+
+    const OPSYS_OPENVMS = 2;
+
+    const OPSYS_UNIX = 3;
+
+    const OPSYS_VM_CMS = 4;
+
+    const OPSYS_ATARI_ST = 5;
+
+    const OPSYS_OS_2 = 6;
+
+    const OPSYS_MACINTOSH = 7;
+
+    const OPSYS_Z_SYSTEM = 8;
+
+    const OPSYS_Z_CPM = 9;
+
+    const OPSYS_WINDOWS_NTFS = 10;
+
+    const OPSYS_MVS = 11;
+
+    const OPSYS_VSE = 12;
+
+    const OPSYS_ACORN_RISC = 13;
+
+    const OPSYS_VFAT = 14;
+
+    const OPSYS_ALTERNATE_MVS = 15;
+
+    const OPSYS_BEOS = 16;
+
+    const OPSYS_TANDEM = 17;
+
+    const OPSYS_OS_400 = 18;
+
+    const OPSYS_OS_X = 19;
+
+    const OPSYS_DEFAULT = 3;
+
+    public function open($filename, $flags = null)
+    {
+    }
+
+    public function setPassword($password)
+    {
+    }
+
+    public function close()
+    {
+    }
+
+    public function getStatusString()
+    {
+    }
+
+    public function addEmptyDir($dirname)
+    {
+    }
+
+    public function addFromString($name, $content)
+    {
+    }
+
+    public function addFile($filepath, $entryname = null, $start = 0, $length = 0)
+    {
+    }
+
+    public function addGlob($pattern, $flags = 0, $options = array())
+    {
+    }
+
+    public function addPattern($pattern, $path = '.', $options = array())
+    {
+    }
+
+    public function renameIndex($index, $new_name)
+    {
+    }
+
+    public function renameName($name, $new_name)
+    {
+    }
+
+    public function setArchiveComment($comment)
+    {
+    }
+
+    public function getArchiveComment($flags = null)
+    {
+    }
+
+    public function setCommentIndex($index, $comment)
+    {
+    }
+
+    public function setCommentName($name, $comment)
+    {
+    }
+
+    public function getCommentIndex($index, $flags = null)
+    {
+    }
+
+    public function getCommentName($name, $flags = null)
+    {
+    }
+
+    public function deleteIndex($index)
+    {
+    }
+
+    public function deleteName($name)
+    {
+    }
+
+    public function statName($filename, $flags = null)
+    {
+    }
+
+    public function statIndex($index, $flags = null)
+    {
+    }
+
+    public function locateName($filename, $flags = null)
+    {
+    }
+
+    public function getNameIndex($index, $flags = null)
+    {
+    }
+
+    public function unchangeArchive()
+    {
+    }
+
+    public function unchangeAll()
+    {
+    }
+
+    public function unchangeIndex($index)
+    {
+    }
+
+    public function unchangeName($name)
+    {
+    }
+
+    public function extractTo($pathto, $files = null)
+    {
+    }
+
+    public function getFromName($entryname, $len = 0, $flags = null)
+    {
+    }
+
+    public function getFromIndex($index, $len = 0, $flags = null)
+    {
+    }
+
+    public function getStream($entryname)
+    {
+    }
+
+    public function setExternalAttributesName($name, $opsys, $attr, $flags = null)
+    {
+    }
+
+    public function setExternalAttributesIndex($index, $opsys, $attr, $flags = null)
+    {
+    }
+
+    public function getExternalAttributesName($name, &$opsys, &$attr, $flags = null)
+    {
+    }
+
+    public function getExternalAttributesIndex($index, &$opsys, &$attr, $flags = null)
+    {
+    }
+
+    public function setCompressionName($name, $method, $compflags = 0)
+    {
+    }
+
+    public function setCompressionIndex($index, $method, $compflags = 0)
+    {
+    }
+
+
+}

--- a/stub/finfo.stub
+++ b/stub/finfo.stub
@@ -1,0 +1,21 @@
+class finfo
+{
+
+    public function finfo($options = FILEINFO_NONE, $arg = null)
+    {
+    }
+
+    public function set_flags($options)
+    {
+    }
+
+    public function file($filename, $options = FILEINFO_NONE, $context = null)
+    {
+    }
+
+    public function buffer($string, $options = FILEINFO_NONE, $context = null)
+    {
+    }
+
+
+}

--- a/stub/mysqli.stub
+++ b/stub/mysqli.stub
@@ -1,0 +1,215 @@
+class mysqli
+{
+
+    public $affected_rows = null;
+
+    public $client_info = null;
+
+    public $client_version = null;
+
+    public $connect_errno = null;
+
+    public $connect_error = null;
+
+    public $errno = null;
+
+    public $error = null;
+
+    public $error_list = null;
+
+    public $field_count = null;
+
+    public $host_info = null;
+
+    public $info = null;
+
+    public $insert_id = null;
+
+    public $server_info = null;
+
+    public $server_version = null;
+
+    public $stat = null;
+
+    public $sqlstate = null;
+
+    public $protocol_version = null;
+
+    public $thread_id = null;
+
+    public $warning_count = null;
+
+    public function autocommit($mode)
+    {
+    }
+
+    public function begin_transaction($flags = null, $name = null)
+    {
+    }
+
+    public function change_user($user, $password, $database)
+    {
+    }
+
+    public function character_set_name()
+    {
+    }
+
+    public function close()
+    {
+    }
+
+    public function commit($flags = null, $name = null)
+    {
+    }
+
+    public function connect($host = null, $user = null, $password = null, $database = '', $port = null, $socket = null)
+    {
+    }
+
+    public function dump_debug_info()
+    {
+    }
+
+    public function debug($debug_options)
+    {
+    }
+
+    public function get_charset()
+    {
+    }
+
+    public function get_client_info()
+    {
+    }
+
+    public function get_connection_stats()
+    {
+    }
+
+    public function get_server_info()
+    {
+    }
+
+    public function get_warnings()
+    {
+    }
+
+    public function init()
+    {
+    }
+
+    public function kill($connection_id)
+    {
+    }
+
+    public function multi_query($query)
+    {
+    }
+
+    public function mysqli($host = null, $user = null, $password = null, $database = '', $port = null, $socket = null)
+    {
+    }
+
+    public function more_results()
+    {
+    }
+
+    public function next_result()
+    {
+    }
+
+    public function options($option, $value)
+    {
+    }
+
+    public function ping()
+    {
+    }
+
+    public static function poll(array &$read, array &$write, array &$error, $sec, $usec = null)
+    {
+    }
+
+    public function prepare($query)
+    {
+    }
+
+    public function query($query)
+    {
+    }
+
+    public function real_connect($host = null, $user = null, $password = null, $database = null, $port = null, $socket = null, $flags = null)
+    {
+    }
+
+    public function real_escape_string($string_to_escape)
+    {
+    }
+
+    public function reap_async_query()
+    {
+    }
+
+    public function escape_string($string_to_escape)
+    {
+    }
+
+    public function real_query($query)
+    {
+    }
+
+    public function release_savepoint($name)
+    {
+    }
+
+    public function rollback($flags = null, $name = null)
+    {
+    }
+
+    public function savepoint($name)
+    {
+    }
+
+    public function select_db($database)
+    {
+    }
+
+    public function set_charset($charset)
+    {
+    }
+
+    public function set_opt($option, $value)
+    {
+    }
+
+    public function ssl_set($key, $cert, $certificate_authority, $certificate_authority_path, $cipher)
+    {
+    }
+
+    public function stat()
+    {
+    }
+
+    public function stmt_init()
+    {
+    }
+
+    public function store_result($flags = null)
+    {
+    }
+
+    public function thread_safe()
+    {
+    }
+
+    public function use_result()
+    {
+    }
+
+    public function refresh($options)
+    {
+    }
+
+
+}

--- a/stub/mysqli_result.stub
+++ b/stub/mysqli_result.stub
@@ -1,0 +1,73 @@
+<?php
+
+class mysqli_result implements Traversable
+{
+
+    public $current_field = null;
+
+    public $field_count = null;
+
+    public $lengths = null;
+
+    public $num_rows = null;
+
+    public $type = null;
+
+    public function __construct()
+    {
+    }
+
+    public function close()
+    {
+    }
+
+    public function free()
+    {
+    }
+
+    public function data_seek($offset)
+    {
+    }
+
+    public function fetch_field()
+    {
+    }
+
+    public function fetch_fields()
+    {
+    }
+
+    public function fetch_field_direct($field_nr)
+    {
+    }
+
+    public function fetch_all()
+    {
+    }
+
+    public function fetch_array($result_type = MYSQLI_BOTH)
+    {
+    }
+
+    public function fetch_assoc()
+    {
+    }
+
+    public function fetch_object($class_name = 'stdClass', array $params = null)
+    {
+    }
+
+    public function fetch_row()
+    {
+    }
+
+    public function field_seek($field_nr)
+    {
+    }
+
+    public function free_result()
+    {
+    }
+
+
+}

--- a/test/unit/Reflection/ReflectionMethodTest.php
+++ b/test/unit/Reflection/ReflectionMethodTest.php
@@ -261,7 +261,7 @@ class ReflectionMethodTest extends \PHPUnit_Framework_TestCase
 
     public function methodStringRepresentations()
     {
-        return [
+        $methods = [
             ['__construct', "Method [ <user, ctor> public method __construct ] {\n  @@ %s/test/unit/Fixture/Methods.php 11 - 13\n}"],
             ['publicMethod', "Method [ <user> public method publicMethod ] {\n  @@ %s/test/unit/Fixture/Methods.php 15 - 17\n}"],
             ['privateMethod', "Method [ <user> private method privateMethod ] {\n  @@ %s/test/unit/Fixture/Methods.php 19 - 21\n}"],
@@ -279,6 +279,16 @@ class ReflectionMethodTest extends \PHPUnit_Framework_TestCase
             ['methodWithNonOptionalDefaultValue', "Method [ <user> public method methodWithNonOptionalDefaultValue ] {\n  @@ %s/test/unit/Fixture/Methods.php 74 - 76\n\n  - Parameters [2] {\n    Parameter #0 [ <required> \$firstParameter ]\n    Parameter #1 [ <required> \$secondParameter ]\n  }\n}"],
             ['methodToCheckAllowsNull', "Method [ <user> public method methodToCheckAllowsNull ] {\n  @@ %s/test/unit/Fixture/Methods.php 78 - 80\n\n  - Parameters [3] {\n    Parameter #0 [ <required> \$allowsNull ]\n    Parameter #1 [ <required> stdClass \$hintDisallowNull ]\n    Parameter #2 [ <optional> stdClass or NULL \$hintAllowNull = NULL ]\n  }\n}"],
         ];
+
+        return array_combine(
+            array_map(
+                function (array $methodData) {
+                    return $methodData[0];
+                },
+                $methods
+            ),
+            $methods
+        );
     }
 
     /**

--- a/test/unit/Reflection/ReflectionParameterTest.php
+++ b/test/unit/Reflection/ReflectionParameterTest.php
@@ -455,7 +455,7 @@ class ReflectionParameterTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @group 107
+     * @group 109
      */
     public function testVariadicParametersAreAlsoImplicitlyOptional()
     {

--- a/test/unit/Reflection/ReflectionParameterTest.php
+++ b/test/unit/Reflection/ReflectionParameterTest.php
@@ -453,22 +453,4 @@ class ReflectionParameterTest extends \PHPUnit_Framework_TestCase
         $this->setExpectedException(Uncloneable::class);
         $unused = clone $paramInfo;
     }
-
-    /**
-     * @group 109
-     */
-    public function testVariadicParametersAreAlsoImplicitlyOptional()
-    {
-        $classInfo = $this->reflector->reflect('\BetterReflectionTest\Fixture\Methods');
-
-        $method = $classInfo->getMethod('methodWithVariadic');
-
-        $nonVariadicParam = $method->getParameter('nonVariadicParameter');
-        $this->assertFalse($nonVariadicParam->isVariadic());
-        $this->assertFalse($nonVariadicParam->isOptional());
-
-        $variadicParam = $method->getParameter('variadicParameter');
-        $this->assertTrue($variadicParam->isVariadic());
-        $this->assertTrue($variadicParam->isOptional());
-    }
 }

--- a/test/unit/Reflection/ReflectionParameterTest.php
+++ b/test/unit/Reflection/ReflectionParameterTest.php
@@ -453,4 +453,22 @@ class ReflectionParameterTest extends \PHPUnit_Framework_TestCase
         $this->setExpectedException(Uncloneable::class);
         $unused = clone $paramInfo;
     }
+
+    /**
+     * @group 107
+     */
+    public function testVariadicParametersAreAlsoImplicitlyOptional()
+    {
+        $classInfo = $this->reflector->reflect('\BetterReflectionTest\Fixture\Methods');
+
+        $method = $classInfo->getMethod('methodWithVariadic');
+
+        $nonVariadicParam = $method->getParameter('nonVariadicParameter');
+        $this->assertFalse($nonVariadicParam->isVariadic());
+        $this->assertFalse($nonVariadicParam->isOptional());
+
+        $variadicParam = $method->getParameter('variadicParameter');
+        $this->assertTrue($variadicParam->isVariadic());
+        $this->assertTrue($variadicParam->isOptional());
+    }
 }

--- a/test/unit/SourceLocator/Type/PhpInternalSourceLocatorTest.php
+++ b/test/unit/SourceLocator/Type/PhpInternalSourceLocatorTest.php
@@ -151,6 +151,8 @@ class PhpInternalSourceLocatorTest extends \PHPUnit_Framework_TestCase
      * @dataProvider stubbedClassesProvider
      *
      * @param string $className
+     *
+     * @coversNothing
      */
     public function testAllGeneratedStubsAreInSyncWithInternalReflectionClasses($className)
     {

--- a/test/unit/SourceLocator/Type/PhpInternalSourceLocatorTest.php
+++ b/test/unit/SourceLocator/Type/PhpInternalSourceLocatorTest.php
@@ -173,7 +173,7 @@ class PhpInternalSourceLocatorTest extends \PHPUnit_Framework_TestCase
     public function stubbedClassesProvider()
     {
         $classNames = array_filter(
-            str_replace('.stub', '', scandir(__DIR__ . '/../../../stub')),
+            str_replace('.stub', '', scandir(__DIR__ . '/../../../../stub')),
             function ($fileName) {
                 return trim($fileName, '.');
             }

--- a/test/unit/SourceLocator/Type/PhpInternalSourceLocatorTest.php
+++ b/test/unit/SourceLocator/Type/PhpInternalSourceLocatorTest.php
@@ -209,7 +209,24 @@ class PhpInternalSourceLocatorTest extends \PHPUnit_Framework_TestCase
             }
         );
 
-        $this->assertCount(count($originalMethods), $stubbed->getMethods()); // @TODO see #107
+        $originalMethodNames = array_map(
+            function (\ReflectionMethod $method) {
+                return $method->getName();
+            },
+            $originalMethods
+        );
+
+        $stubbedMethodNames = array_map(
+            function (ReflectionMethod $method) {
+                return $method->getName();
+            },
+            $stubbed->getMethods() // @TODO see #107
+        );
+
+        sort($originalMethodNames);
+        sort($stubbedMethodNames);
+
+        $this->assertSame($originalMethodNames, $stubbedMethodNames);
         $this->assertEquals($original->getConstants(), $stubbed->getConstants());
 
         foreach ($originalMethods as $method) {
@@ -219,7 +236,20 @@ class PhpInternalSourceLocatorTest extends \PHPUnit_Framework_TestCase
 
     private function assertSameMethodAttributes(\ReflectionMethod $original, ReflectionMethod $stubbed)
     {
-        $this->assertCount(count($original->getParameters()), $stubbed->getParameters());
+        $this->assertSame(
+            array_map(
+                function (\ReflectionParameter $parameter) {
+                    return $parameter->getName();
+                },
+                $original->getParameters()
+            ),
+            array_map(
+                function (ReflectionParameter $parameter) {
+                    return $parameter->getName();
+                },
+                $stubbed->getParameters()
+            )
+        );
 
         foreach ($original->getParameters() as $parameter) {
             $this->assertSameParameterAttributes($parameter, $stubbed->getParameter($parameter->getName()));

--- a/test/unit/SourceLocator/Type/PhpInternalSourceLocatorTest.php
+++ b/test/unit/SourceLocator/Type/PhpInternalSourceLocatorTest.php
@@ -239,13 +239,13 @@ class PhpInternalSourceLocatorTest extends \PHPUnit_Framework_TestCase
         $this->assertSame(
             array_map(
                 function (\ReflectionParameter $parameter) {
-                    return $parameter->getName();
+                    return $parameter->getDeclaringFunction()->getName() . '.' . $parameter->getName();
                 },
                 $original->getParameters()
             ),
             array_map(
                 function (ReflectionParameter $parameter) {
-                    return $parameter->getName();
+                    return $parameter->getDeclaringFunction()->getName() . '.' . $parameter->getName();
                 },
                 $stubbed->getParameters()
             )
@@ -265,6 +265,7 @@ class PhpInternalSourceLocatorTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($original->canBePassedByValue(), $stubbed->canBePassedByValue());
         $this->assertSame($original->isOptional(), $stubbed->isOptional());
         $this->assertSame($original->isPassedByReference(), $stubbed->isPassedByReference());
+        $this->assertSame($original->isVariadic(), $stubbed->isVariadic());
 
         if ($class = $original->getClass()) {
             $stubbedClass = $stubbed->getClass();

--- a/test/unit/SourceLocator/Type/PhpInternalSourceLocatorTest.php
+++ b/test/unit/SourceLocator/Type/PhpInternalSourceLocatorTest.php
@@ -5,6 +5,7 @@ namespace BetterReflectionTest\SourceLocator\Type;
 use BetterReflection\Identifier\Identifier;
 use BetterReflection\Identifier\IdentifierType;
 use BetterReflection\Reflection\ReflectionClass;
+use BetterReflection\Reflection\ReflectionMethod;
 use BetterReflection\Reflector\ClassReflector;
 use BetterReflection\Reflector\Reflector;
 use BetterReflection\SourceLocator\Located\InternalLocatedSource;
@@ -143,5 +144,73 @@ class PhpInternalSourceLocatorTest extends \PHPUnit_Framework_TestCase
                 )
             )
         );
+    }
+
+    /**
+     * @dataProvider stubbedClassesProvider
+     *
+     * @param string $className
+     */
+    public function testAllGeneratedStubsAreInSyncWithInternalReflectionClasses($className)
+    {
+        if (! (
+            class_exists($className, false)
+            || interface_exists($className, false)
+            || trait_exists($className, false)
+        )) {
+            $this->markTestSkipped(sprintf('Class "%s" is not available in this environment', $className));
+        }
+
+        $reflector = new ClassReflector(new PhpInternalSourceLocator());
+
+        $this->assertSameClassAttributes(new \ReflectionClass($className), $reflector->reflect($className));
+    }
+
+    /**
+     * @return string[][]
+     */
+    public function stubbedClassesProvider()
+    {
+        $classNames = array_filter(
+            str_replace('.stub', '', scandir(__DIR__ . '/../../../stub')),
+            function ($fileName) {
+                return trim($fileName, '.');
+            }
+        );
+
+        return array_combine(
+            $classNames,
+            array_map(
+                function ($fileName) {
+                    return [$fileName];
+                },
+                $classNames
+            )
+        );
+    }
+
+    private function assertSameClassAttributes(\ReflectionClass $original, ReflectionClass $stubbed)
+    {
+        $this->assertSame($original->getName(), $stubbed->getName());
+
+        $internalParent     = $original->getParentClass();
+        $betterParent       = $stubbed->getParentClass();
+        $internalParentName = $internalParent ? $internalParent->getName() : null;
+        $betterParentName   = $betterParent ? $betterParent->getName() : null;
+
+        $this->assertSame($internalParentName, $betterParentName);
+        //$this->assertCount(count($original->getMethods()), $stubbed->getMethods());
+
+        $this->assertEquals($original->getConstants(), $stubbed->getConstants());
+
+        foreach ($original->getMethods() as $method) {
+            $this->assertSameMethodAttributes($method, $stubbed->getMethod($method->getName()));
+        }
+    }
+
+    private function assertSameMethodAttributes(\ReflectionMethod $original, ReflectionMethod $stubbed)
+    {
+        $this->markTestIncomplete('TBD - #107 required');
+        // @TODO once https://github.com/Roave/BetterReflection/issues/107 is handled
     }
 }

--- a/test/unit/SourceLocator/Type/PhpInternalSourceLocatorTest.php
+++ b/test/unit/SourceLocator/Type/PhpInternalSourceLocatorTest.php
@@ -254,6 +254,13 @@ class PhpInternalSourceLocatorTest extends \PHPUnit_Framework_TestCase
         foreach ($original->getParameters() as $parameter) {
             $this->assertSameParameterAttributes($parameter, $stubbed->getParameter($parameter->getName()));
         }
+
+        $this->assertSame($original->isPublic(), $stubbed->isPublic());
+        $this->assertSame($original->isPrivate(), $stubbed->isPrivate());
+        $this->assertSame($original->isProtected(), $stubbed->isProtected());
+        $this->assertSame($original->returnsReference(), $stubbed->returnsReference());
+        $this->assertSame($original->isStatic(), $stubbed->isStatic());
+        $this->assertSame($original->isFinal(), $stubbed->isFinal());
     }
 
     private function assertSameParameterAttributes(\ReflectionParameter $original, ReflectionParameter $stubbed)

--- a/test/unit/SourceLocator/Type/PhpInternalSourceLocatorTest.php
+++ b/test/unit/SourceLocator/Type/PhpInternalSourceLocatorTest.php
@@ -201,13 +201,7 @@ class PhpInternalSourceLocatorTest extends \PHPUnit_Framework_TestCase
 
         $this->assertSame($internalParentName, $betterParentName);
 
-        // @TODO to be removed once #107 is merged
-        $originalMethods = array_filter(
-            $original->getMethods(),
-            function (\ReflectionMethod $method) use ($original) {
-                return $method->getDeclaringClass()->getName() === $original->getName();
-            }
-        );
+        $originalMethods = $original->getMethods();
 
         $originalMethodNames = array_map(
             function (\ReflectionMethod $method) {


### PR DESCRIPTION
See #87 

 - [x] parse phpdoc files from the php-src documentation
 - [x] generate stubs for classes with methods with default parameters in the phpdoc
 - [x] handle quirks in documentation
 - [x] write/commit stubs
 - [ ] ~~convert to method-only stubs (the stub is just the method, nothing else, eventually consider handling parameter-only stubs)~~ - not worth the amount of effort atm: we can easily do this by reproducing methods via `Zend\Code` tho.
 - [ ] ~~convert the source locator to replace "magically" reflected method stubs with the method stubs that are in the repository~~ - strictly related to previous point: not relevant right now.