### PR TITLE
Implement [g|s]etStaticPropertyValue in ReflectionClass

### DIFF
--- a/src/Reflection/Exception/ClassDoesNotExist.php
+++ b/src/Reflection/Exception/ClassDoesNotExist.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace BetterReflection\Reflection\Exception;
+
+class ClassDoesNotExist extends \RuntimeException
+{
+}

--- a/src/Reflection/Exception/PropertyDoesNotExist.php
+++ b/src/Reflection/Exception/PropertyDoesNotExist.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace BetterReflection\Reflection\Exception;
+
+class PropertyDoesNotExist extends \RuntimeException
+{
+}

--- a/src/Reflection/Exception/PropertyNotPublic.php
+++ b/src/Reflection/Exception/PropertyNotPublic.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace BetterReflection\Reflection\Exception;
+
+class PropertyNotPublic extends \RuntimeException
+{
+}

--- a/src/Reflection/ReflectionClass.php
+++ b/src/Reflection/ReflectionClass.php
@@ -1055,6 +1055,13 @@ class ReflectionClass implements Reflection, \Reflector
             throw new Exception\PropertyDoesNotExist('Property does not exist on class or is not static');
         }
 
+        // PHP behaviour is to simply say "property does not exist" if accessing
+        // protected or private values. Here we be a little more explicit in
+        // reasoning...
+        if (!$this->getProperty($propertyName)->isPublic()) {
+            throw new Exception\PropertyNotPublic('Property is not public');
+        }
+
         $className = $this->getName();
         return $className::${$propertyName};
     }
@@ -1074,6 +1081,13 @@ class ReflectionClass implements Reflection, \Reflector
 
         if (!$this->hasProperty($propertyName) || !$this->getProperty($propertyName)->isStatic()) {
             throw new Exception\PropertyDoesNotExist('Property does not exist on class or is not static');
+        }
+
+        // PHP behaviour is to simply say "property does not exist" if accessing
+        // protected or private values. Here we be a little more explicit in
+        // reasoning...
+        if (!$this->getProperty($propertyName)->isPublic()) {
+            throw new Exception\PropertyNotPublic('Property is not public');
         }
 
         $className = $this->getName();

--- a/src/Reflection/ReflectionClass.php
+++ b/src/Reflection/ReflectionClass.php
@@ -1036,4 +1036,48 @@ class ReflectionClass implements Reflection, \Reflector
     {
         throw Exception\Uncloneable::fromClass(__CLASS__);
     }
+
+    /**
+     * Get the value of a static property, if it exists. Throws a
+     * PropertyDoesNotExist exception if it does not exist or is not static.
+     * (note, differs very slightly from internal reflection behaviour)
+     *
+     * @param string $propertyName
+     * @return mixed
+     */
+    public function getStaticPropertyValue($propertyName)
+    {
+        if (!class_exists($this->getName(), false)) {
+            throw new Exception\ClassDoesNotExist('Class does not exist to retrieve property');
+        }
+
+        if (!$this->hasProperty($propertyName) || !$this->getProperty($propertyName)->isStatic()) {
+            throw new Exception\PropertyDoesNotExist('Property does not exist or is not static');
+        }
+
+        $className = $this->getName();
+        return $className::${$propertyName};
+    }
+
+    /**
+     * Set the value of a static property
+     *
+     * @param string $propertyName
+     * @param mixed $value
+     * @return void
+     */
+    public function setStaticPropertyValue($propertyName, $value)
+    {
+        if (!class_exists($this->getName(), false)) {
+            throw new Exception\ClassDoesNotExist('Class does not exist to retrieve property');
+        }
+
+        if (!$this->hasProperty($propertyName) || !$this->getProperty($propertyName)->isStatic()) {
+            throw new Exception\PropertyDoesNotExist('Property does not exist or is not static');
+        }
+
+        $className = $this->getName();
+        $className::${$propertyName} = $value;
+        return;
+    }
 }

--- a/src/Reflection/ReflectionClass.php
+++ b/src/Reflection/ReflectionClass.php
@@ -1078,6 +1078,5 @@ class ReflectionClass implements Reflection, \Reflector
 
         $className = $this->getName();
         $className::${$propertyName} = $value;
-        return;
     }
 }

--- a/src/Reflection/ReflectionClass.php
+++ b/src/Reflection/ReflectionClass.php
@@ -1048,11 +1048,11 @@ class ReflectionClass implements Reflection, \Reflector
     public function getStaticPropertyValue($propertyName)
     {
         if (!class_exists($this->getName(), false)) {
-            throw new Exception\ClassDoesNotExist('Class does not exist to retrieve property');
+            throw new Exception\ClassDoesNotExist('Property cannot be retrieved as the class is not loaded');
         }
 
         if (!$this->hasProperty($propertyName) || !$this->getProperty($propertyName)->isStatic()) {
-            throw new Exception\PropertyDoesNotExist('Property does not exist or is not static');
+            throw new Exception\PropertyDoesNotExist('Property does not exist on class or is not static');
         }
 
         $className = $this->getName();
@@ -1069,11 +1069,11 @@ class ReflectionClass implements Reflection, \Reflector
     public function setStaticPropertyValue($propertyName, $value)
     {
         if (!class_exists($this->getName(), false)) {
-            throw new Exception\ClassDoesNotExist('Class does not exist to retrieve property');
+            throw new Exception\ClassDoesNotExist('Property cannot be set as the class is not loaded');
         }
 
         if (!$this->hasProperty($propertyName) || !$this->getProperty($propertyName)->isStatic()) {
-            throw new Exception\PropertyDoesNotExist('Property does not exist or is not static');
+            throw new Exception\PropertyDoesNotExist('Property does not exist on class or is not static');
         }
 
         $className = $this->getName();

--- a/src/Reflection/ReflectionObject.php
+++ b/src/Reflection/ReflectionObject.php
@@ -494,4 +494,20 @@ class ReflectionObject extends ReflectionClass
     {
         throw Exception\Uncloneable::fromClass(__CLASS__);
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setStaticPropertyValue($propertyName, $value)
+    {
+        $this->reflectionClass->setStaticPropertyValue($propertyName, $value);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getStaticPropertyValue($propertyName)
+    {
+        return $this->reflectionClass->getStaticPropertyValue($propertyName);
+    }
 }

--- a/test/unit/Fixture/StaticPropertyGetSet.php
+++ b/test/unit/Fixture/StaticPropertyGetSet.php
@@ -9,4 +9,6 @@ class Foo
 class Bar
 {
     public static $baz;
+    protected static $bat;
+    private static $qux;
 }

--- a/test/unit/Fixture/StaticPropertyGetSet.php
+++ b/test/unit/Fixture/StaticPropertyGetSet.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace BetterReflection\Fixture\StaticPropertyGetSet;
+
+class Foo
+{
+}
+
+class Bar
+{
+    public static $baz;
+}

--- a/test/unit/Reflection/ReflectionClassTest.php
+++ b/test/unit/Reflection/ReflectionClassTest.php
@@ -11,6 +11,7 @@ use BetterReflection\Reflection\Exception\NotAnObject;
 use BetterReflection\Reflection\Exception\NotAString;
 use BetterReflection\Reflection\Exception\Uncloneable;
 use BetterReflection\Reflection\Exception\PropertyDoesNotExist;
+use BetterReflection\Reflection\Exception\PropertyNotPublic;
 use BetterReflection\Reflection\ReflectionClass;
 use BetterReflection\Reflection\ReflectionMethod;
 use BetterReflection\Reflection\ReflectionProperty;
@@ -940,6 +941,30 @@ class ReflectionClassTest extends \PHPUnit_Framework_TestCase
 
         $this->setExpectedException(PropertyDoesNotExist::class);
         $classInfo->getStaticPropertyValue('foo');
+    }
+
+    public function testGetStaticPropertyValueThrowsExceptionWhenPropertyIsProtected()
+    {
+        $staticPropertyGetSetFixture = __DIR__ . '/../Fixture/StaticPropertyGetSet.php';
+        require_once($staticPropertyGetSetFixture);
+
+        $classInfo = (new ClassReflector(new SingleFileSourceLocator($staticPropertyGetSetFixture)))
+            ->reflect(StaticPropertyGetSet\Bar::class);
+
+        $this->setExpectedException(PropertyNotPublic::class);
+        $classInfo->getStaticPropertyValue('bat');
+    }
+
+    public function testGetStaticPropertyValueThrowsExceptionWhenPropertyIsPrivate()
+    {
+        $staticPropertyGetSetFixture = __DIR__ . '/../Fixture/StaticPropertyGetSet.php';
+        require_once($staticPropertyGetSetFixture);
+
+        $classInfo = (new ClassReflector(new SingleFileSourceLocator($staticPropertyGetSetFixture)))
+            ->reflect(StaticPropertyGetSet\Bar::class);
+
+        $this->setExpectedException(PropertyNotPublic::class);
+        $classInfo->getStaticPropertyValue('qux');
     }
 
     public function testGetStaticPropertyValueGetsValue()


### PR DESCRIPTION
As part of issue #14, this implements some stuff that requires the class to be loaded that we do not previously implement.

* [x] getStaticPropertyValue
* [x] setStaticPropertyValue