### PR TITLE
Add the package license for composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
     "name": "roave/better-reflection",
     "description": "Better Reflection - an improved code reflection API",
+    "license": "MIT",
     "require": {
         "php": ">= 5.6",
         "nikic/php-parser": "dev-master",


### PR DESCRIPTION
the license file is available in the repo, but the info was missing in the composer.json, marking it as an unknown license on Packagist