### PR TITLE
added getImmediateMethods

### DIFF
--- a/src/Reflection/ReflectionClass.php
+++ b/src/Reflection/ReflectionClass.php
@@ -326,6 +326,31 @@ class ReflectionClass implements Reflection, \Reflector
     }
 
     /**
+     * Get only the methods that this class implements (i.e. do not search
+     * up parent classes etc.)
+     *
+     * @return ReflectionMethod[]
+     */
+    public function getImmediateMethods()
+    {
+        /* @var $methods \ReflectionMethod[] */
+        $methods = array_map (
+            function (ClassMethod $methodNode) {
+                return ReflectionMethod::createFromNode($this->reflector, $methodNode, $this);
+            },
+            $this->node->getMethods()
+        );
+
+        $methodsByName = [];
+
+        foreach ($methods as $method) {
+            $methodsByName[$method->getName()] = $method;
+        }
+
+        return $methodsByName;
+    }
+
+    /**
      * Get a single method with the name $methodName.
      *
      * @param string $methodName

--- a/src/Reflection/ReflectionObject.php
+++ b/src/Reflection/ReflectionObject.php
@@ -192,6 +192,14 @@ class ReflectionObject extends ReflectionClass
     /**
      * {@inheritdoc}
      */
+    public function getImmediateMethods()
+    {
+        return $this->reflectionClass->getImmediateMethods();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function getMethod($methodName)
     {
         return $this->reflectionClass->getMethod($methodName);

--- a/test/unit/Reflection/ReflectionClassTest.php
+++ b/test/unit/Reflection/ReflectionClassTest.php
@@ -134,6 +134,17 @@ class ReflectionClassTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('Qux', $classInfo->getMethod('f')->getDeclaringClass()->getName());
     }
 
+    public function testGetImmediateMethods()
+    {
+        $reflector = new ClassReflector(new SingleFileSourceLocator(__DIR__ . '/../Fixture/InheritedClassMethods.php'));
+
+        $methods = $reflector->reflect('Qux')->getImmediateMethods();
+
+        $this->assertCount(1, $methods);
+        $this->assertInstanceOf(ReflectionMethod::class, $methods['f']);
+        $this->assertSame('f', $methods['f']->getName());
+    }
+
     public function testGetConstants()
     {
         $reflector = new ClassReflector($this->getComposerLocator());


### PR DESCRIPTION
* enables us to get the direkt methods (like it already exists for interfaces)
* fixed the IdentifierException to be able to get the Identifier back