### PR TITLE
Add returning AST methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ features than PHP's built-in [reflection API](http://php.net/manual/en/book.refl
 * Ability to reflect on classes directly from a string of PHP code
 * Better Reflection analyses the DocBlocks (using [phpdocumentor/type-resolver](https://github.com/phpDocumentor/TypeResolver))
 * Reflecting directly on closures
+* Ability to extract AST from methods and functions
+* Ability to return AST representation of a class or function
 * *Moar stuff coming soon!*
 
 Be sure to read more in the [feature documentation](https://github.com/Roave/BetterReflection/tree/master/docs/features.md).
@@ -51,6 +53,7 @@ $classInfo = ReflectionClass::createFromName('Foo\Bar\MyClass');
 * [Using types](https://github.com/Roave/BetterReflection/tree/master/docs/types.md)
 * [The features](https://github.com/Roave/BetterReflection/tree/master/docs/features.md)
 * [Test suite](https://github.com/Roave/BetterReflection/blob/master/test/README.md)
+* [AST extraction](https://github.com/Roave/BetterReflection/tree/master/docs/ast-extraction.md)
 
 ## Limitations
 

--- a/docs/ast-extraction.md
+++ b/docs/ast-extraction.md
@@ -1,0 +1,47 @@
+# Extracting AST from reflections
+
+## Method and Function body AST
+
+Given a `ReflectionMethod` or `ReflectionFunction`, you can extract the content
+(within curly braces) as an Abstract Syntax Tree, or as unparsed AST (i.e. as
+normal code). This allows you to easily grab the AST from a specific method with
+very few lines of code:
+
+```php
+<?php
+
+use BetterReflection\Reflector\ReflectionClass;
+
+$classInfo = ReflectionClass::createFromName('Foo\Bar\MyClass');
+
+// Retrieves the AST statements array *within* the method's curly braces
+$ast = $classInfo->getMethod('foo')->getBodyAst();
+$php = $classInfo->getMethod('foo')->getBodyCode();
+```
+
+### Note on extracting code using `getBodyCode()`
+
+The code returned by the `getBodyCode()` method is pretty-printed using the
+AST unparser in the `PhpParser` library. This means the actual code returned
+here may be laid out differently to the original function or method. See the
+code documentation for details on how to provide a custom printer to override
+the default behaviour.
+
+## Fetching AST representation of a class or function
+
+It is possible to fetch an AST representation of a class or function using the
+`getAst()` method on a `ReflectionClass` and `ReflectionFunction`.
+
+```php
+<?php
+
+use BetterReflection\Reflector\ReflectionClass;
+
+$classInfo = ReflectionClass::createFromName('Foo\Bar\MyClass');
+
+// Retrieves AST nodes for the entire class (including the class definition)
+$ast = $classInfo->getAst();
+```
+
+Note that the node returned will be the top level of the class, thus including
+the actual class definition itself.

--- a/docs/ast-extraction.md
+++ b/docs/ast-extraction.md
@@ -12,7 +12,7 @@ very few lines of code:
 
 use BetterReflection\Reflector\ReflectionClass;
 
-$classInfo = ReflectionClass::createFromName('Foo\Bar\MyClass');
+$classInfo = ReflectionClass::createFromName(\Foo\Bar\MyClass::class);
 
 // Retrieves the AST statements array *within* the method's curly braces
 $ast = $classInfo->getMethod('foo')->getBodyAst();
@@ -37,7 +37,7 @@ It is possible to fetch an AST representation of a class or function using the
 
 use BetterReflection\Reflector\ReflectionClass;
 
-$classInfo = ReflectionClass::createFromName('Foo\Bar\MyClass');
+$classInfo = ReflectionClass::createFromName(\Foo\Bar\MyClass::class);
 
 // Retrieves AST nodes for the entire class (including the class definition)
 $ast = $classInfo->getAst();

--- a/docs/features.md
+++ b/docs/features.md
@@ -17,3 +17,7 @@ See [Loading a class from a string](https://github.com/Roave/BetterReflection/tr
 ## Analysing types from DocBlocks
 
 See [types documentation](https://github.com/Roave/BetterReflection/tree/master/docs/types.md)
+
+## AST extraction from Reflections
+
+See [AST extraction documentation](https://github.com/Roave/BetterReflection/tree/master/docs/ast-extraction.md)

--- a/src/Reflection/ReflectionClass.php
+++ b/src/Reflection/ReflectionClass.php
@@ -1121,7 +1121,7 @@ class ReflectionClass implements Reflection, \Reflector
     /**
      * Retrieve the AST node for this class
      *
-     * @return ClassNode|InterfaceNode|TraitNode|ClassLikeNode
+     * @return ClassLikeNode
      */
     public function getAst()
     {

--- a/src/Reflection/ReflectionClass.php
+++ b/src/Reflection/ReflectionClass.php
@@ -1117,4 +1117,14 @@ class ReflectionClass implements Reflection, \Reflector
         $className = $this->getName();
         $className::${$propertyName} = $value;
     }
+
+    /**
+     * Retrieve the AST node for this class
+     *
+     * @return ClassNode|InterfaceNode|TraitNode|ClassLikeNode
+     */
+    public function getAst()
+    {
+        return $this->node;
+    }
 }

--- a/src/Reflection/ReflectionFunctionAbstract.php
+++ b/src/Reflection/ReflectionFunctionAbstract.php
@@ -406,4 +406,14 @@ abstract class ReflectionFunctionAbstract implements \Reflector
     {
         throw Exception\Uncloneable::fromClass(__CLASS__);
     }
+
+    /**
+     * Retrieves the body of this function as AST nodes
+     *
+     * @return array
+     */
+    public function getBodyAst()
+    {
+        return $this->node->stmts;
+    }
 }

--- a/src/Reflection/ReflectionFunctionAbstract.php
+++ b/src/Reflection/ReflectionFunctionAbstract.php
@@ -440,4 +440,14 @@ abstract class ReflectionFunctionAbstract implements \Reflector
 
         return $printer->prettyPrint($this->getBodyAst());
     }
+
+    /**
+     * Fetch the AST for this method or function.
+     *
+     * @return Node\Stmt\ClassMethod|Node\Stmt\Function_
+     */
+    public function getAst()
+    {
+        return $this->node;
+    }
 }

--- a/src/Reflection/ReflectionFunctionAbstract.php
+++ b/src/Reflection/ReflectionFunctionAbstract.php
@@ -412,7 +412,7 @@ abstract class ReflectionFunctionAbstract implements \Reflector
     /**
      * Retrieves the body of this function as AST nodes
      *
-     * @return array
+     * @return Node[]
      */
     public function getBodyAst()
     {

--- a/src/Reflection/ReflectionFunctionAbstract.php
+++ b/src/Reflection/ReflectionFunctionAbstract.php
@@ -9,6 +9,8 @@ use PhpParser\Node;
 use PhpParser\Node\Stmt\Namespace_ as NamespaceNode;
 use PhpParser\Node\Expr\Yield_ as YieldNode;
 use phpDocumentor\Reflection\Type;
+use PhpParser\PrettyPrinter\Standard as StandardPrettyPrinter;
+use PhpParser\PrettyPrinterAbstract;
 
 abstract class ReflectionFunctionAbstract implements \Reflector
 {
@@ -415,5 +417,27 @@ abstract class ReflectionFunctionAbstract implements \Reflector
     public function getBodyAst()
     {
         return $this->node->stmts;
+    }
+
+    /**
+     * Retrieves the body of this function as code.
+     *
+     * If a PrettyPrinter is provided as a paramter, it will be used, otherwise
+     * a default will be used.
+     *
+     * Note that the formatting of the code may not be the same as the original
+     * function. If specific formatting is required, you should provide your
+     * own implementation of a PrettyPrinter to unparse the AST.
+     *
+     * @param PrettyPrinterAbstract|null $printer
+     * @return string
+     */
+    public function getBodyCode(PrettyPrinterAbstract $printer = null)
+    {
+        if (null === $printer) {
+            $printer = new StandardPrettyPrinter();
+        }
+
+        return $printer->prettyPrint($this->getBodyAst());
     }
 }

--- a/src/Reflection/ReflectionObject.php
+++ b/src/Reflection/ReflectionObject.php
@@ -510,4 +510,12 @@ class ReflectionObject extends ReflectionClass
     {
         return $this->reflectionClass->getStaticPropertyValue($propertyName);
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getAst()
+    {
+        return $this->reflectionClass->getAst();
+    }
 }

--- a/test/unit/Reflection/ReflectionClassTest.php
+++ b/test/unit/Reflection/ReflectionClassTest.php
@@ -29,6 +29,7 @@ use BetterReflectionTest\Fixture\ClassForHinting;
 use BetterReflectionTest\Fixture\InvalidInheritances;
 use PhpParser\Node\Name;
 use BetterReflection\Fixture\StaticPropertyGetSet;
+use PhpParser\Node\Stmt\Class_;
 
 /**
  * @covers \BetterReflection\Reflection\ReflectionClass
@@ -1031,5 +1032,19 @@ class ReflectionClassTest extends \PHPUnit_Framework_TestCase
         $classInfo->setStaticPropertyValue('baz', 'value after');
 
         $this->assertSame('value after', StaticPropertyGetSet\Bar::$baz);
+    }
+
+    public function testGetAst()
+    {
+        $php = '<?php
+            class Foo {}
+        ';
+
+        $reflection = (new ClassReflector(new StringSourceLocator($php)))->reflect('Foo');
+
+        $ast = $reflection->getAst();
+
+        $this->assertInstanceOf(Class_::class, $ast);
+        $this->assertSame('Foo', $ast->name);
     }
 }

--- a/test/unit/Reflection/ReflectionFunctionAbstractTest.php
+++ b/test/unit/Reflection/ReflectionFunctionAbstractTest.php
@@ -365,4 +365,21 @@ class ReflectionFunctionAbstractTest extends \PHPUnit_Framework_TestCase
         $this->assertCount(1, $ast);
         $this->assertInstanceOf(Echo_::class, $ast[0]);
     }
+
+    public function testGetBodyCode()
+    {
+        $php = '<?php
+            function foo() {
+                echo "Hello world";
+            }
+        ';
+
+        $reflector = new FunctionReflector(new StringSourceLocator($php));
+        $function = $reflector->reflect('foo');
+
+        $this->assertSame(
+            "echo 'Hello world';",
+            $function->getBodyCode()
+        );
+    }
 }

--- a/test/unit/Reflection/ReflectionFunctionAbstractTest.php
+++ b/test/unit/Reflection/ReflectionFunctionAbstractTest.php
@@ -14,6 +14,7 @@ use BetterReflection\SourceLocator\Type\SingleFileSourceLocator;
 use BetterReflection\SourceLocator\Type\StringSourceLocator;
 use phpDocumentor\Reflection\Types\Boolean;
 use PhpParser\Node\Stmt\Break_;
+use PhpParser\Node\Stmt\Echo_;
 use PhpParser\Node\Stmt\Function_;
 
 /**
@@ -345,5 +346,23 @@ class ReflectionFunctionAbstractTest extends \PHPUnit_Framework_TestCase
 
         $this->setExpectedException(Uncloneable::class);
         $unused = clone $functionInfo;
+    }
+
+    public function testGetBodyAst()
+    {
+        $php = '<?php
+            function foo() {
+                echo "Hello world";
+            }
+        ';
+
+        $reflector = new FunctionReflector(new StringSourceLocator($php));
+        $function = $reflector->reflect('foo');
+
+        $ast = $function->getBodyAst();
+
+        $this->assertInternalType('array', $ast);
+        $this->assertCount(1, $ast);
+        $this->assertInstanceOf(Echo_::class, $ast[0]);
     }
 }

--- a/test/unit/Reflection/ReflectionFunctionAbstractTest.php
+++ b/test/unit/Reflection/ReflectionFunctionAbstractTest.php
@@ -382,4 +382,19 @@ class ReflectionFunctionAbstractTest extends \PHPUnit_Framework_TestCase
             $function->getBodyCode()
         );
     }
+
+    public function getAst()
+    {
+        $php = '<?php
+            function foo() {}
+        ';
+
+        $reflector = new FunctionReflector(new StringSourceLocator($php));
+        $function = $reflector->reflect('foo');
+
+        $ast = $function->getAst();
+
+        $this->assertInstanceOf(Function_::class, $ast);
+        $this->assertSame('foo', $ast->name);
+    }
 }

--- a/test/unit/Reflection/ReflectionFunctionAbstractTest.php
+++ b/test/unit/Reflection/ReflectionFunctionAbstractTest.php
@@ -383,7 +383,7 @@ class ReflectionFunctionAbstractTest extends \PHPUnit_Framework_TestCase
         );
     }
 
-    public function getAst()
+    public function testGetAst()
     {
         $php = '<?php
             function foo() {}


### PR DESCRIPTION
Would resolve #133 and #130 

This PR adds new methods:
 - `getAst` for `ReflectionClass` and `ReflectionFunctionAbstract` (#133)
 - `getBodyCode` and `getBodyAst` for `ReflectionFunctionAbstract` (#130)