### PR TITLE
Be consistent with capitalisation of DocBlock

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -14,6 +14,6 @@ not then *unload* that class - this is not currently possible in PHP.
 
 See [Loading a class from a string](https://github.com/Roave/BetterReflection/tree/master/docs/usage.md#Loading-a-class-from-a-string)
 
-## Analysing types from docblocks
+## Analysing types from DocBlocks
 
 See [types documentation](https://github.com/Roave/BetterReflection/tree/master/docs/types.md)

--- a/src/Reflection/ReflectionFunctionAbstract.php
+++ b/src/Reflection/ReflectionFunctionAbstract.php
@@ -394,7 +394,7 @@ abstract class ReflectionFunctionAbstract implements \Reflector
      *
      * @return Type[]
      */
-    public function getDocblockReturnTypes()
+    public function getDocBlockReturnTypes()
     {
         return  (new FindReturnType())->__invoke($this);
     }

--- a/src/Reflection/ReflectionObject.php
+++ b/src/Reflection/ReflectionObject.php
@@ -130,7 +130,7 @@ class ReflectionObject extends ReflectionClass
     /**
      * Create an AST PropertyNode given a reflection
      *
-     * Note that we don't copy across Docblock, protected, private or static
+     * Note that we don't copy across DocBlock, protected, private or static
      * because runtime properties can't have these attributes.
      *
      * @param \ReflectionProperty $property

--- a/src/Reflection/ReflectionParameter.php
+++ b/src/Reflection/ReflectionParameter.php
@@ -293,7 +293,7 @@ class ReflectionParameter implements \Reflector
     /**
      * Get the type hint declared for the parameter. This is the real type hint
      * for the parameter, e.g. `method(closure $someFunc)` defined by the
-     * method itself, and is separate from the docblock type hints.
+     * method itself, and is separate from the DocBlock type hints.
      *
      * @see getDocBlockTypes()
      * @return Type

--- a/test/unit/Reflection/ReflectionFunctionAbstractTest.php
+++ b/test/unit/Reflection/ReflectionFunctionAbstractTest.php
@@ -301,7 +301,7 @@ class ReflectionFunctionAbstractTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($locatedSource, $functionInfo->getLocatedSource());
     }
 
-    public function testGetDocblockReturnTypes()
+    public function testGetDocBlockReturnTypes()
     {
         $php = '<?php
             /**
@@ -312,7 +312,7 @@ class ReflectionFunctionAbstractTest extends \PHPUnit_Framework_TestCase
         $reflector = new FunctionReflector(new StringSourceLocator($php));
         $function = $reflector->reflect('foo');
 
-        $types = $function->getDocblockReturnTypes();
+        $types = $function->getDocBlockReturnTypes();
 
         $this->assertInternalType('array', $types);
         $this->assertCount(1, $types);

--- a/test/unit/Reflection/ReflectionFunctionTest.php
+++ b/test/unit/Reflection/ReflectionFunctionTest.php
@@ -109,7 +109,7 @@ class ReflectionFunctionTest extends \PHPUnit_Framework_TestCase
         $this->assertStringMatchesFormat($expectedStringValue, (string)$functionInfo);
     }
 
-    public function testGetDocblockReturnTypes()
+    public function testGetDocBlockReturnTypes()
     {
         $php = '<?php
             /**
@@ -120,7 +120,7 @@ class ReflectionFunctionTest extends \PHPUnit_Framework_TestCase
         $reflector = new FunctionReflector(new StringSourceLocator($php));
         $function = $reflector->reflect('foo');
 
-        $types = $function->getDocblockReturnTypes();
+        $types = $function->getDocBlockReturnTypes();
 
         $this->assertInternalType('array', $types);
         $this->assertCount(1, $types);

--- a/test/unit/Reflection/ReflectionMethodTest.php
+++ b/test/unit/Reflection/ReflectionMethodTest.php
@@ -145,7 +145,7 @@ class ReflectionMethodTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('someMethod', $methodInfo->getShortName());
     }
 
-    public function testGetDocblockReturnTypes()
+    public function testGetDocBlockReturnTypes()
     {
         $php = '<?php
         class Foo {
@@ -160,7 +160,7 @@ class ReflectionMethodTest extends \PHPUnit_Framework_TestCase
             ->reflect('Foo')
             ->getMethod('someMethod');
 
-        $types = $methodInfo->getDocblockReturnTypes();
+        $types = $methodInfo->getDocBlockReturnTypes();
 
         $this->assertInternalType('array', $types);
         $this->assertCount(1, $types);


### PR DESCRIPTION
This fixes the major breaking urgent security bug in #132