### PR TITLE
Method body replacement

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ features than PHP's built-in [reflection API](http://php.net/manual/en/book.refl
 * Ability to extract AST from methods and functions
 * Ability to return AST representation of a class or function
 * Fetch return type declaration and parameter type declarations in PHP 7 code (even when running PHP 5!)
+* Change the body of a function or method to do something different
 * *Moar stuff coming soon!*
 
 Be sure to read more in the [feature documentation](https://github.com/Roave/BetterReflection/tree/master/docs/features.md).
@@ -55,6 +56,7 @@ $classInfo = ReflectionClass::createFromName('Foo\Bar\MyClass');
 * [The features](https://github.com/Roave/BetterReflection/tree/master/docs/features.md)
 * [Test suite](https://github.com/Roave/BetterReflection/blob/master/test/README.md)
 * [AST extraction](https://github.com/Roave/BetterReflection/tree/master/docs/ast-extraction.md)
+* [Reflection modification](https://github.com/Roave/BetterReflection/tree/master/docs/reflection-modification.md)
 
 ## Limitations
 

--- a/demo/monkey-patching/MyClass.php
+++ b/demo/monkey-patching/MyClass.php
@@ -1,0 +1,9 @@
+<?php
+
+class MyClass
+{
+    public function foo()
+    {
+        return 5;
+    }
+}

--- a/demo/monkey-patching/index.php
+++ b/demo/monkey-patching/index.php
@@ -1,0 +1,30 @@
+<?php
+
+require_once __DIR__ . '/../../vendor/autoload.php';
+
+use BetterReflection\Reflector\ClassReflector;
+use BetterReflection\SourceLocator\AggregateSourceLocator;
+use BetterReflection\SourceLocator\SingleFileSourceLocator;
+use PhpParser\PrettyPrinter\Standard as CodePrinter;
+
+// Create the reflection first (without loading)
+$classInfo = (new ClassReflector(new AggregateSourceLocator([
+    new SingleFileSourceLocator('MyClass.php'),
+])))->reflect('MyClass');
+
+// Override the body...!
+$classInfo->getMethod('foo')->setBody(function () {
+    return 4;
+});
+
+// Load the class...!!!!
+
+$classCode = (new CodePrinter())->prettyPrint([$classInfo->getAst()]);
+
+$tmpFile = tempnam(sys_get_temp_dir(), 'br-monkey-patching');
+file_put_contents($tmpFile, '<?php ' . $classCode);
+require_once($tmpFile);
+unlink($tmpFile);
+
+$c = new MyClass();
+var_dump($c->foo()); // should be 4...!?!??

--- a/docs/reflection-modification.md
+++ b/docs/reflection-modification.md
@@ -1,0 +1,47 @@
+# Reflection Modification
+
+## Replacing a function or method body
+
+It is possible in Better Reflection to replace the body statements of a function
+in the reflection - in essence, giving the ability to monkey patch the code.
+
+Given the following class under reflection:
+
+```php
+class MyClass
+{
+    public function foo()
+    {
+        return 5;
+    }
+}
+```
+
+You can replace the body of the function like so:
+
+```php
+$classInfo = ReflectionClass::createFromName('MyClass');
+$classInfo->getMethod('foo')->setBody(function () {
+    return 4;
+});
+```
+
+This does not take immediate effect on execution - and in fact, if the class is
+already loaded, it is impossible to overwrite the in-memory class (this is a
+restriction in PHP itself). However, if you have reflected on this class in
+such a way that it is not in memory, it is possible to export the class and
+load it from a temporary location, for example:
+
+```php
+use PhpParser\PrettyPrinter\Standard;
+
+$classCode = (new Standard())->prettyPrint($classInfo->getAst());
+
+file_put_contents('/tmp/foo.php', '<?php ' . $classCode);
+require_once('/tmp/foo.php');
+
+$c = new MyClass();
+var_dump($c->foo()); // This will now be 4, not 5...
+```
+
+But, you probably shouldn't do this.

--- a/src/Reflection/Exception/ClosureAstExtractionFailure.php
+++ b/src/Reflection/Exception/ClosureAstExtractionFailure.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace BetterReflection\Reflection\Exception;
+
+class ClosureAstExtractionFailure extends \RuntimeException
+{
+}

--- a/src/Reflection/ReflectionFunctionAbstract.php
+++ b/src/Reflection/ReflectionFunctionAbstract.php
@@ -6,12 +6,16 @@ use BetterReflection\Reflector\Reflector;
 use BetterReflection\SourceLocator\Located\LocatedSource;
 use BetterReflection\TypesFinder\FindReturnType;
 use BetterReflection\TypesFinder\FindTypeFromAst;
+use Closure;
 use PhpParser\Node;
 use PhpParser\Node\Stmt\Namespace_ as NamespaceNode;
 use PhpParser\Node\Expr\Yield_ as YieldNode;
+use PhpParser\Node\Expr\Closure as ClosureNode;
 use phpDocumentor\Reflection\Type;
+use PhpParser\ParserFactory;
 use PhpParser\PrettyPrinter\Standard as StandardPrettyPrinter;
 use PhpParser\PrettyPrinterAbstract;
+use SuperClosure\Analyzer\AstAnalyzer;
 
 abstract class ReflectionFunctionAbstract implements \Reflector
 {
@@ -484,5 +488,43 @@ abstract class ReflectionFunctionAbstract implements \Reflector
     public function getAst()
     {
         return $this->node;
+    }
+
+    /**
+     * Override the method or function's body of statements with an entirely new
+     * body of statements (!) within the reflection.
+     *
+     * You may either pass a string containing statements, or a closure:
+     *
+     * @example
+     * // The following are identical...
+     * $reflectionFunction->setBody('return true');
+     * $reflectionFunction->setBody(function () { return true; });
+     *
+     * @param string|Closure $newBody
+     */
+    public function setBody($newBody)
+    {
+        if ($newBody instanceof Closure) {
+            $closureData = (new AstAnalyzer())->analyze($newBody);
+
+            if (!isset($closureData['ast']) || !($closureData['ast'] instanceof ClosureNode)) {
+                throw new Exception\ClosureAstExtractionFailure('Failed to extract AST from closure - AST data not returned by AstAnalyzer');
+            }
+
+            $functionStatements = $closureData['ast']->stmts;
+        }
+
+        if (is_string($newBody)) {
+            $functionStatements = (new ParserFactory())
+                ->create(ParserFactory::PREFER_PHP7)
+                ->parse('<?php ' . $newBody);
+        }
+
+        if (!isset($functionStatements)) {
+            throw new \InvalidArgumentException('New body for function or method must be a Closure or string with PHP statements');
+        }
+
+        $this->node->stmts = $functionStatements;
     }
 }

--- a/src/Reflection/ReflectionFunctionAbstract.php
+++ b/src/Reflection/ReflectionFunctionAbstract.php
@@ -529,4 +529,24 @@ abstract class ReflectionFunctionAbstract implements \Reflector
             ->create(ParserFactory::PREFER_PHP7)
             ->parse('<?php ' . $newBody);
     }
+
+    /**
+     * Override the method or function's body of statements with an entirely new
+     * body of statements within the reflection.
+     *
+     * @example
+     * // $ast should be an array of Nodes
+     * $reflectionFunction->setBodyFromAst($ast);
+     *
+     * @param Node[] $nodes
+     */
+    public function setBodyFromAst(array $nodes)
+    {
+        // This slightly confusing code simply type-checks the $sourceLocators
+        // array by unpacking them and splatting them in the closure.
+        $validator = function (Node ...$node) {
+            return $node;
+        };
+        $this->node->stmts = $validator(...$nodes);
+    }
 }

--- a/test/unit/Reflection/ReflectionFunctionAbstractTest.php
+++ b/test/unit/Reflection/ReflectionFunctionAbstractTest.php
@@ -445,28 +445,28 @@ class ReflectionFunctionAbstractTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('foo', $ast->name);
     }
 
-    public function testSetBodyWithClosure()
+    public function testSetBodyFromClosure()
     {
         $php = '<?php function foo() {}';
 
         $reflector = new FunctionReflector(new StringSourceLocator($php));
         $function = $reflector->reflect('foo');
 
-        $function->setBody(function () {
+        $function->setBodyFromClosure(function () {
             echo 'Hello world!';
         });
 
         $this->assertSame("echo 'Hello world!';", $function->getBodyCode());
     }
 
-    public function testSetBodyWithString()
+    public function testSetBodyFromString()
     {
         $php = '<?php function foo() {}';
 
         $reflector = new FunctionReflector(new StringSourceLocator($php));
         $function = $reflector->reflect('foo');
 
-        $function->setBody("echo 'Hello world!';");
+        $function->setBodyFromString("echo 'Hello world!';");
 
         $this->assertSame("echo 'Hello world!';", $function->getBodyCode());
     }
@@ -479,6 +479,6 @@ class ReflectionFunctionAbstractTest extends \PHPUnit_Framework_TestCase
         $function = $reflector->reflect('foo');
 
         $this->setExpectedException(\InvalidArgumentException::class);
-        $function->setBody(['foo' => 'bar']);
+        $function->setBodyFromString(['foo' => 'bar']);
     }
 }

--- a/test/unit/Reflection/ReflectionFunctionAbstractTest.php
+++ b/test/unit/Reflection/ReflectionFunctionAbstractTest.php
@@ -444,4 +444,41 @@ class ReflectionFunctionAbstractTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf(Function_::class, $ast);
         $this->assertSame('foo', $ast->name);
     }
+
+    public function testSetBodyWithClosure()
+    {
+        $php = '<?php function foo() {}';
+
+        $reflector = new FunctionReflector(new StringSourceLocator($php));
+        $function = $reflector->reflect('foo');
+
+        $function->setBody(function () {
+            echo 'Hello world!';
+        });
+
+        $this->assertSame("echo 'Hello world!';", $function->getBodyCode());
+    }
+
+    public function testSetBodyWithString()
+    {
+        $php = '<?php function foo() {}';
+
+        $reflector = new FunctionReflector(new StringSourceLocator($php));
+        $function = $reflector->reflect('foo');
+
+        $function->setBody("echo 'Hello world!';");
+
+        $this->assertSame("echo 'Hello world!';", $function->getBodyCode());
+    }
+
+    public function testSetBodyWithInvalidArgumentThrowsException()
+    {
+        $php = '<?php function foo() {}';
+
+        $reflector = new FunctionReflector(new StringSourceLocator($php));
+        $function = $reflector->reflect('foo');
+
+        $this->setExpectedException(\InvalidArgumentException::class);
+        $function->setBody(['foo' => 'bar']);
+    }
 }

--- a/test/unit/Reflection/ReflectionFunctionAbstractTest.php
+++ b/test/unit/Reflection/ReflectionFunctionAbstractTest.php
@@ -474,17 +474,16 @@ class ReflectionFunctionAbstractTest extends \PHPUnit_Framework_TestCase
 
     public function testSetBodyFromAstWithInvalidArgumentsThrowsException()
     {
+        if (version_compare(PHP_VERSION, '7.0.0') < 0) {
+            $this->markTestSkipped('Only run this test on PHP 7 and above');
+        }
+
         $php = '<?php function foo() {}';
 
         $reflector = new FunctionReflector(new StringSourceLocator($php));
         $function = $reflector->reflect('foo');
 
-        if (version_compare(PHP_VERSION, '7.0.0') >= 0) {
-            $this->setExpectedException(\TypeError::class);
-        } else {
-            $this->setExpectedException(\PHPUnit_Framework_Error::class);
-        }
-
+        $this->setExpectedException(\TypeError::class);
         $function->setBodyFromAst([1]);
     }
 


### PR DESCRIPTION
Solves part of #134  (ability to replace the statements within a function or method)

~~Note this requires PR #135 to be merged first, so do not merge please.~~

~~Also depends on jeremeamia/super_closure#70~~ (stable in 2.2.0+ now, which is used by our master now anyway)