### PR TITLE
Use branch-alias instead of dev-master

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,9 +4,9 @@
     "license": "MIT",
     "require": {
         "php": ">= 5.6",
-        "nikic/php-parser": "dev-master",
+        "nikic/php-parser": "^2.0@dev",
         "phpdocumentor/reflection-docblock": "^2.0",
-        "phpdocumentor/type-resolver": "dev-master",
+        "phpdocumentor/type-resolver": "^1.0@dev",
         "zendframework/zend-code": "^2.5@dev"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "license": "MIT",
     "require": {
         "php": ">= 5.6",
-        "nikic/php-parser": "^2.0@dev",
+        "nikic/php-parser": "^2.0-beta",
         "phpdocumentor/reflection-docblock": "^2.0",
         "phpdocumentor/type-resolver": "^1.0@dev",
         "zendframework/zend-code": "^2.5@dev"


### PR DESCRIPTION
The `dev-master` could change in every moment, instead the `branch-alias` shouldn’t change as fast as the previous.