### PR TITLE
Fix locateIdentifiersByType to correctly aggregate source

### DIFF
--- a/src/SourceLocator/Type/AggregateSourceLocator.php
+++ b/src/SourceLocator/Type/AggregateSourceLocator.php
@@ -48,7 +48,7 @@ class AggregateSourceLocator implements SourceLocator
         $located = [];
 
         foreach ($this->sourceLocators as $sourceLocator) {
-            $located += $sourceLocator->locateIdentifiersByType($reflector, $identifierType);
+            $located = array_merge($located, $sourceLocator->locateIdentifiersByType($reflector, $identifierType));
         }
 
         return $located;

--- a/test/unit/SourceLocator/Type/AggregateSourceLocatorTest.php
+++ b/test/unit/SourceLocator/Type/AggregateSourceLocatorTest.php
@@ -87,4 +87,37 @@ class AggregateSourceLocatorTest extends \PHPUnit_Framework_TestCase
 
         $this->assertSame('Foo', $reflection->getName());
     }
+
+    public function testLocateIdentifiersByTypeAggregatesSource()
+    {
+        $identifierType = new IdentifierType;
+
+        $locator1   = $this->getMock(SourceLocator::class);
+        $locator2   = $this->getMock(SourceLocator::class);
+        $locator3   = $this->getMock(SourceLocator::class);
+        $locator4   = $this->getMock(SourceLocator::class);
+
+        $source2     = $this->getMockBuilder(ReflectionClass::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $source3     = $this->getMockBuilder(ReflectionClass::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $locator1->expects($this->once())->method('locateIdentifiersByType')->willReturn([]);
+        $locator2->expects($this->once())->method('locateIdentifiersByType')->willReturn([$source2]);
+        $locator3->expects($this->once())->method('locateIdentifiersByType')->willReturn([$source3]);
+        $locator4->expects($this->once())->method('locateIdentifiersByType')->willReturn([]);
+
+        $this->assertSame(
+            [$source2, $source3],
+            (new AggregateSourceLocator([
+                $locator1,
+                $locator2,
+                $locator3,
+                $locator4,
+            ]))->locateIdentifiersByType($this->getMockReflector(), $identifierType)
+        );
+    }
 }


### PR DESCRIPTION
Hi, 

It seems the aggregate source locator was not working as `+=` ignores keys that already exist in left hand array:


> The + operator returns the right-hand array appended to the left-hand array; for keys that exist in both arrays, the elements from the left-hand array will be used, and the matching elements from the right-hand array will be ignored.

refs: http://php.net/manual/en/language.operators.array.php