### PR TITLE
Failing test for class name resolution in class constants

### DIFF
--- a/test/unit/NodeCompiler/CompileNodeToValueTest.php
+++ b/test/unit/NodeCompiler/CompileNodeToValueTest.php
@@ -251,4 +251,37 @@ class CompileNodeToValueTest extends \PHPUnit_Framework_TestCase
 
         $this->assertSame('baz', $paramInfo->getDefaultValue());
     }
+
+    public function testClassConstantClassNameResolution()
+    {
+        $phpCode = '<?php
+
+        class Foo {
+        }
+        class Bat {
+            const QUX = Foo::class;
+        }
+        ';
+
+        $reflector = new ClassReflector(new StringSourceLocator($phpCode));
+        $classInfo = $reflector->reflect('Bat');
+        $this->assertSame('Foo', $classInfo->getConstant('QUX'));
+    }
+
+    public function testClassConstantClassNameAliasResolution()
+    {
+        $phpCode = '<?php
+        namespace Bar;
+
+        class Foo {
+        }
+        class Bat {
+            const QUX = Foo::class;
+        }
+        ';
+
+        $reflector = new ClassReflector(new StringSourceLocator($phpCode));
+        $classInfo = $reflector->reflect('Bar\Bat');
+        $this->assertSame('Bar\Foo', $classInfo->getConstant('QUX'));
+    }
 }


### PR DESCRIPTION
Hi, 

Class name resolution in constants doesn't seem to work, I've provided a failing test case but I have no idea how to fix it :smile: 

If you could give some pointers I can have a pop at fixing it?