### PR TITLE
[WIP] Added CombinedReflector, a helper API

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -199,3 +199,29 @@ $functionInfo = ReflectionFunction::createFromClosure($myClosure);
 
 Note that when you reflect on a closure, in order to match the core reflection
 API, the function "short" name will be just `{closure}`.
+
+## The `CombinedReflector`
+
+Purely an ease-of-use API, the `CombinedReflector` simplifies usage when you
+need to reflect both functions and classes. The usage is similar to standalone
+`ClassReflector` or `FunctionReflector`:
+
+```php
+<?php
+
+$reflector = new CombinedReflector($sourceLocator);
+
+$class = $reflector->reflect('MyClassName'); // returns a ReflectionClass
+$function = $reflector->reflect('myFunctionName'); // returns a ReflectionFunction
+```
+
+There is also a utility method to reflect something on a specific line number:
+
+```php
+
+$reflector = new CombinedReflector(new SingleFileSourceLocator($file));
+
+// Will return a ReflectionFunction, ReflectionClass or null, depending on
+// what is on line 7 in $file
+$item = $reflector->reflectOnLine(7);
+```

--- a/src/Reflector/CombinedReflector.php
+++ b/src/Reflector/CombinedReflector.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace BetterReflection\Reflector;
+
+use BetterReflection\Identifier\Identifier;
+use BetterReflection\Identifier\IdentifierType;
+use BetterReflection\Reflection\Reflection;
+use BetterReflection\Reflection\ReflectionClass;
+use BetterReflection\Reflection\ReflectionFunction;
+use BetterReflection\SourceLocator\Type\SourceLocator;
+
+class CombinedReflector implements Reflector
+{
+    /**
+     * @var SourceLocator
+     */
+    private $sourceLocator;
+
+    public function __construct(SourceLocator $sourceLocator)
+    {
+        $this->sourceLocator = $sourceLocator;
+    }
+
+    /**
+     * @param string $itemName
+     * @return ReflectionClass|ReflectionFunction
+     */
+    public function reflect($itemName)
+    {
+        $reflectionClass = $this->sourceLocator->locateIdentifier(
+            $this,
+            new Identifier($itemName, new IdentifierType(IdentifierType::IDENTIFIER_CLASS))
+        );
+        
+        if ($reflectionClass instanceof ReflectionClass) {
+            return $reflectionClass;
+        }
+
+        $reflectionFunction = $this->sourceLocator->locateIdentifier(
+            $this,
+            new Identifier($itemName, new IdentifierType(IdentifierType::IDENTIFIER_FUNCTION))
+        );
+
+        if ($reflectionFunction instanceof ReflectionFunction) {
+            return $reflectionFunction;
+        }
+
+        return null;
+    }
+
+    /**
+     * @return Reflection[]
+     */
+    public function getAll()
+    {
+        return array_merge(
+            $this->sourceLocator->locateIdentifiersByType(
+                $this,
+                new IdentifierType(IdentifierType::IDENTIFIER_CLASS)
+            ),
+            $this->sourceLocator->locateIdentifiersByType(
+                $this,
+                new IdentifierType(IdentifierType::IDENTIFIER_FUNCTION)
+            )
+        );
+    }
+
+    /**
+     * Find a reflection on the specified line number.
+     *
+     * Returns null if no reflections found on the line.
+     *
+     * @param int $lineNumber
+     * @return ReflectionFunction|ReflectionClass|null
+     */
+    public function reflectOnLine($lineNumber)
+    {
+        $reflections = $this->getAll();
+        foreach ($reflections as $reflection) {
+            if (method_exists($reflection, 'getStartLine')
+                && $reflection->getStartLine() === $lineNumber) {
+                return $reflection;
+            }
+        }
+        return null;
+    }
+}

--- a/test/unit/Fixture/CombinedReflectorFixture.php
+++ b/test/unit/Fixture/CombinedReflectorFixture.php
@@ -1,0 +1,9 @@
+<?php
+
+function fooFunc() {
+}
+
+class SomeFooClass {
+}
+
+

--- a/test/unit/Reflector/CombinedReflectorTest.php
+++ b/test/unit/Reflector/CombinedReflectorTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace BetterReflectionTest\Reflector;
+
+use BetterReflection\Reflection\ReflectionClass;
+use BetterReflection\Reflection\ReflectionFunction;
+use BetterReflection\Reflector\CombinedReflector;
+use BetterReflection\SourceLocator\Type\SingleFileSourceLocator;
+
+/**
+ * @covers \BetterReflection\Reflector\CombinedReflector
+ */
+class CombinedReflectorTest extends \PHPUnit_Framework_TestCase
+{
+    public function testGetAll()
+    {
+        $items = (new CombinedReflector(
+            new SingleFileSourceLocator(__DIR__ . '/../Fixture/CombinedReflectorFixture.php')
+        ))->getAll();
+
+        $this->assertCount(2, $items);
+        $this->assertInstanceOf(ReflectionClass::class, $items[0]);
+        $this->assertInstanceOf(ReflectionFunction::class, $items[1]);
+    }
+
+    public function testReflectFindsClass()
+    {
+        $this->assertInstanceOf(ReflectionClass::class, (new CombinedReflector(
+            new SingleFileSourceLocator(__DIR__ . '/../Fixture/CombinedReflectorFixture.php')
+        ))->reflect('SomeFooClass'));
+    }
+
+    public function testReflectFindsFunction()
+    {
+        $this->assertInstanceOf(ReflectionFunction::class, (new CombinedReflector(
+            new SingleFileSourceLocator(__DIR__ . '/../Fixture/CombinedReflectorFixture.php')
+        ))->reflect('fooFunc'));
+    }
+
+    public function testReflectReturnsNullWhenNothingFound()
+    {
+        $this->assertNull((new CombinedReflector(
+            new SingleFileSourceLocator(__DIR__ . '/../Fixture/CombinedReflectorFixture.php')
+        ))->reflect('nothingExistsByThisName'));
+    }
+
+    public function testReflectOnLineFindsClass()
+    {
+        $this->assertInstanceOf(ReflectionClass::class, (new CombinedReflector(
+            new SingleFileSourceLocator(__DIR__ . '/../Fixture/CombinedReflectorFixture.php')
+        ))->reflectOnLine(6));
+    }
+
+    public function testReflectOnLineFindsFunction()
+    {
+        $this->assertInstanceOf(ReflectionFunction::class, (new CombinedReflector(
+            new SingleFileSourceLocator(__DIR__ . '/../Fixture/CombinedReflectorFixture.php')
+        ))->reflectOnLine(3));
+    }
+
+    public function testReflectOnLineReturnsNullWhenNothingFound()
+    {
+        $this->assertNull((new CombinedReflector(
+            new SingleFileSourceLocator(__DIR__ . '/../Fixture/CombinedReflectorFixture.php')
+        ))->reflectOnLine(-1));
+    }
+}


### PR DESCRIPTION
As per discussion in feature request #178, this introduces a new `CombinedReflector` API that allows reflecting on a specific line.

Usage would look like this:

```php
$reflector = new CombinedReflector(new SingleFileSourceLocator($file));

// Will return a ReflectionFunction, ReflectionClass or null, depending on
// what is on line 7 in $file
$item = $reflector->reflectOnLine(7);
```