### PR TITLE
Set/remove PHP 7 types

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ features than PHP's built-in [reflection API](http://php.net/manual/en/book.refl
 * Ability to extract AST from methods and functions
 * Ability to return AST representation of a class or function
 * Fetch return type declaration and parameter type declarations in PHP 7 code (even when running PHP 5!)
-* Change or remove PHP 7 return type declarations from methods and functions
+* Change or remove PHP 7 parameter type and return type declarations from methods and functions
 * Change the body of a function or method to do something different
 * *Moar stuff coming soon!*
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ features than PHP's built-in [reflection API](http://php.net/manual/en/book.refl
 * Ability to extract AST from methods and functions
 * Ability to return AST representation of a class or function
 * Fetch return type declaration and parameter type declarations in PHP 7 code (even when running PHP 5!)
+* Change or remove PHP 7 return type declarations from methods and functions
 * Change the body of a function or method to do something different
 * *Moar stuff coming soon!*
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -33,3 +33,23 @@ by using the `getTypeObject()` method:
 $reflectionType = $parameterInfo->getType();
 $phpDocumentorReflectionType = $reflectionType->getTypeObject();
 ```
+
+However, Better Reflection also gives the ability to change, and remove type
+declarations. Removing these types might be useful if you want to make code
+written for PHP 7 work in PHP 5 for example, and setting new types might
+do the opposite. For instance, you might want to set the PHP 7 return type
+declaration to that defined in the PHP DocBlock.
+
+```
+// Change a function to ensure it returns an integer
+$functionInfo->setReturnType(new \phpDocumentor\Reflection\Types\Integer());
+
+// If there is only one type defined in the DocBlock, set it as the return type
+$returnTypes = $functionInfo->getDocBlockReturnTypes();
+if (count($returnTypes) === 1) {
+    $functionInfo->setReturnType($returnTypes[0]);
+}
+
+// Remove the return type declaration
+$functionInfo->removeReturnType();
+```

--- a/docs/features.md
+++ b/docs/features.md
@@ -53,3 +53,10 @@ if (count($returnTypes) === 1) {
 // Remove the return type declaration
 $functionInfo->removeReturnType();
 ```
+
+You can do similar things with parameter types also:
+
+```
+$parameterInfo->setType(new \phpDocumentor\Reflection\Types\Integer());
+$parameterInfo->removeType();
+```

--- a/src/Reflection/ReflectionFunctionAbstract.php
+++ b/src/Reflection/ReflectionFunctionAbstract.php
@@ -441,6 +441,26 @@ abstract class ReflectionFunctionAbstract implements \Reflector
     }
 
     /**
+     * Set the return type declaration.
+     *
+     * You must use the phpDocumentor reflection type classes as the parameter.
+     *
+     * @param Type $newReturnType
+     */
+    public function setReturnType(Type $newReturnType)
+    {
+        $this->node->returnType = new Node\Name((string)$newReturnType);
+    }
+
+    /**
+     * Remove the return type declaration completely.
+     */
+    public function removeReturnType()
+    {
+        $this->node->returnType = null;
+    }
+
+    /**
      * @throws Exception\Uncloneable
      */
     public function __clone()

--- a/src/Reflection/ReflectionParameter.php
+++ b/src/Reflection/ReflectionParameter.php
@@ -406,6 +406,26 @@ class ReflectionParameter implements \Reflector
     }
 
     /**
+     * Set the parameter type declaration.
+     *
+     * You must use the phpDocumentor reflection type classes as the parameter.
+     *
+     * @param Type $newParameterType
+     */
+    public function setType(Type $newParameterType)
+    {
+        $this->node->type = new Node\Name((string)$newParameterType);
+    }
+
+    /**
+     * Remove the parameter type declaration completely.
+     */
+    public function removeType()
+    {
+        $this->node->type = null;
+    }
+
+    /**
      * Is this parameter an array?
      *
      * @return bool

--- a/test/unit/Reflection/ReflectionFunctionAbstractTest.php
+++ b/test/unit/Reflection/ReflectionFunctionAbstractTest.php
@@ -14,10 +14,12 @@ use BetterReflection\SourceLocator\Type\ClosureSourceLocator;
 use BetterReflection\SourceLocator\Type\SingleFileSourceLocator;
 use BetterReflection\SourceLocator\Type\StringSourceLocator;
 use phpDocumentor\Reflection\Types\Boolean;
+use phpDocumentor\Reflection\Types\Integer;
 use PhpParser\Node\Scalar\String_;
 use PhpParser\Node\Stmt\Break_;
 use PhpParser\Node\Stmt\Echo_;
 use PhpParser\Node\Stmt\Function_;
+use PhpParser\PrettyPrinter\Standard as StandardPrettyPrinter;
 
 /**
  * @covers \BetterReflection\Reflection\ReflectionFunctionAbstract
@@ -384,6 +386,28 @@ class ReflectionFunctionAbstractTest extends \PHPUnit_Framework_TestCase
         $reflector = new FunctionReflector(new SingleFileSourceLocator(__DIR__ . '/../Fixture/Php7ReturnTypeDeclarations.php'));
         $functionInfo = $reflector->reflect('returnsNothing');
         $this->assertFalse($functionInfo->hasReturnType());
+    }
+
+    public function testSetReturnType()
+    {
+        $reflector = new FunctionReflector(new SingleFileSourceLocator(__DIR__ . '/../Fixture/Php7ReturnTypeDeclarations.php'));
+        $functionInfo = $reflector->reflect('returnsString');
+
+        $functionInfo->setReturnType(new Integer());
+
+        $this->assertSame('int', (string)$functionInfo->getReturnType());
+        $this->assertStringStartsWith('function returnsString() : int', (new StandardPrettyPrinter())->prettyPrint([$functionInfo->getAst()]));
+    }
+
+    public function testRemoveReturnType()
+    {
+        $reflector = new FunctionReflector(new SingleFileSourceLocator(__DIR__ . '/../Fixture/Php7ReturnTypeDeclarations.php'));
+        $functionInfo = $reflector->reflect('returnsString');
+
+        $functionInfo->removeReturnType();
+
+        $this->assertNull($functionInfo->getReturnType());
+        $this->assertNotContains(': string', (new StandardPrettyPrinter())->prettyPrint([$functionInfo->getAst()]));
     }
 
     public function testCannotClone()

--- a/test/unit/Reflection/ReflectionParameterTest.php
+++ b/test/unit/Reflection/ReflectionParameterTest.php
@@ -13,6 +13,7 @@ use BetterReflectionTest\Fixture\Php7ParameterTypeDeclarations;
 use phpDocumentor\Reflection\Types;
 use BetterReflection\SourceLocator\Type\ComposerSourceLocator;
 use BetterReflection\SourceLocator\Type\StringSourceLocator;
+use PhpParser\PrettyPrinter\Standard as StandardPrettyPrinter;
 
 /**
  * @covers \BetterReflection\Reflection\ReflectionParameter
@@ -296,6 +297,36 @@ class ReflectionParameterTest extends \PHPUnit_Framework_TestCase
         $method = $classInfo->getMethod('foo');
 
         $this->assertFalse($method->getParameter('noTypeParam')->hasType());
+    }
+
+    public function testSetType()
+    {
+        $classInfo = $this->reflector->reflect(Php7ParameterTypeDeclarations::class);
+        $methodInfo = $classInfo->getMethod('foo');
+        $parameterInfo = $methodInfo->getParameter('intParam');
+
+        $parameterInfo->setType(new Types\String_());
+
+        $this->assertSame('string', (string)$parameterInfo->getType());
+        $this->assertStringStartsWith(
+            'public function foo(string $intParam',
+            (new StandardPrettyPrinter())->prettyPrint([$methodInfo->getAst()])
+        );
+    }
+
+    public function testRemoveType()
+    {
+        $classInfo = $this->reflector->reflect(Php7ParameterTypeDeclarations::class);
+        $methodInfo = $classInfo->getMethod('foo');
+        $parameterInfo = $methodInfo->getParameter('intParam');
+
+        $parameterInfo->removeType();
+
+        $this->assertNull($parameterInfo->getType());
+        $this->assertStringStartsWith(
+            'public function foo($intParam',
+            (new StandardPrettyPrinter())->prettyPrint([$methodInfo->getAst()])
+        );
     }
 
     public function testIsCallable()


### PR DESCRIPTION
For feature request in issue #162, this adds feature and documentation for setting/removing PHP 7 type declarations, for both parameters and return types.