### PR TITLE
Throw exceptions when ClassReflector cannot locate identifiers

### DIFF
--- a/src/Reflector/ClassReflector.php
+++ b/src/Reflector/ClassReflector.php
@@ -45,10 +45,15 @@ class ClassReflector implements Reflector
      */
     public function reflect($className)
     {
-        return $this->sourceLocator->locateIdentifier(
-            $this,
-            new Identifier($className, new IdentifierType(IdentifierType::IDENTIFIER_CLASS))
-        );
+        $identifier = new Identifier($className, new IdentifierType(IdentifierType::IDENTIFIER_CLASS));
+
+        $classInfo = $this->sourceLocator->locateIdentifier($this, $identifier);
+
+        if (null === $classInfo) {
+            throw Exception\IdentifierNotFound::fromIdentifier($identifier);
+        }
+
+        return $classInfo;
     }
 
     /**

--- a/test/unit/Reflector/ClassReflectorTest.php
+++ b/test/unit/Reflector/ClassReflectorTest.php
@@ -4,6 +4,7 @@ namespace BetterReflectionTest\Reflector;
 
 use BetterReflection\Reflection\ReflectionClass;
 use BetterReflection\Reflector\ClassReflector;
+use BetterReflection\Reflector\Exception\IdentifierNotFound;
 use BetterReflection\SourceLocator\Type\AggregateSourceLocator;
 use BetterReflection\SourceLocator\Type\SingleFileSourceLocator;
 use BetterReflection\SourceLocator\Type\StringSourceLocator;
@@ -47,5 +48,14 @@ class ClassReflectorTest extends \PHPUnit_Framework_TestCase
 
         $sourceLocator = $this->getObjectAttribute($defaultReflector, 'sourceLocator');
         $this->assertInstanceOf(AggregateSourceLocator::class, $sourceLocator);
+    }
+
+    public function testThrowsExceptionWhenIdentifierNotFound()
+    {
+        $defaultReflector = ClassReflector::buildDefaultReflector();
+
+        $this->expectException(IdentifierNotFound::class);
+
+        $defaultReflector->reflect('Something\That\Should\Not\Exist');
     }
 }

--- a/test/unit/SourceLocator/Type/AutoloadSourceLocatorTest.php
+++ b/test/unit/SourceLocator/Type/AutoloadSourceLocatorTest.php
@@ -159,9 +159,12 @@ class AutoloadSourceLocatorTest extends \PHPUnit_Framework_TestCase
 
     public function testReturnsNullWhenUnableToAutoload()
     {
-        $reflector = new ClassReflector(new AutoloadSourceLocator());
+        $sourceLocator = new AutoloadSourceLocator();
 
-        $this->assertNull($reflector->reflect('Some\Class\That\Cannot\Exist'));
+        $this->assertNull($sourceLocator->locateIdentifier(
+            new ClassReflector($sourceLocator),
+            new Identifier('Some\Class\That\Cannot\Exist', new IdentifierType(IdentifierType::IDENTIFIER_CLASS))
+        ));
     }
 
     public function testShouldNotConsiderEvaledSources()


### PR DESCRIPTION
As reported in #189, we are creating calls on `null` objects when identifiers are not found. This is expected behaviour, but not clearly reported on. This change introduces the `IdentifierNotFound` exception, but at the `ClassReflector` level (thus allowing exception to bubble up, rather than simply returning `null`).