### PR TITLE
Fix unit test broken by PhpParser 2.1.0 change

### DIFF
--- a/test/unit/Reflection/ReflectionFunctionAbstractTest.php
+++ b/test/unit/Reflection/ReflectionFunctionAbstractTest.php
@@ -440,11 +440,11 @@ class ReflectionFunctionAbstractTest extends \PHPUnit_Framework_TestCase
 
     public function testGetBodyCode()
     {
-        $php = '<?php
+        $php = "<?php
             function foo() {
-                echo "Hello world";
+                echo 'Hello world';
             }
-        ';
+        ";
 
         $reflector = new FunctionReflector(new StringSourceLocator($php));
         $function = $reflector->reflect('foo');


### PR DESCRIPTION
Referring to https://github.com/nikic/PHP-Parser/releases/tag/v2.1.0 a change was introduced that distinguishes between "- and '-enclosed strings, therefore proved this test was flaky (the conversion from " to ' was assumped implicit).