### PR TITLE
Added ReflectionFunctionAbstract::getReturnStatementsAst() method

### DIFF
--- a/src/Reflection/ReflectionFunctionAbstract.php
+++ b/src/Reflection/ReflectionFunctionAbstract.php
@@ -603,6 +603,9 @@ abstract class ReflectionFunctionAbstract implements \Reflector
     /**
      * Fetch an array of all return statements found within this function.
      *
+     * Note that return statements within smaller scopes contained (e.g. anonymous classes, closures) are not returned
+     * here as they are not within the immediate scope.
+     *
      * @return Node\Stmt\Return_[]
      */
     public function getReturnStatementsAst()

--- a/src/Reflection/ReflectionFunctionAbstract.php
+++ b/src/Reflection/ReflectionFunctionAbstract.php
@@ -6,6 +6,7 @@ use BetterReflection\Reflector\Reflector;
 use BetterReflection\SourceLocator\Located\LocatedSource;
 use BetterReflection\TypesFinder\FindReturnType;
 use BetterReflection\TypesFinder\FindTypeFromAst;
+use BetterReflection\Util\Visitor\ReturnNodeVisitor;
 use Closure;
 use PhpParser\Node;
 use PhpParser\Node\Stmt\Namespace_ as NamespaceNode;
@@ -13,6 +14,7 @@ use PhpParser\Node\Expr\Yield_ as YieldNode;
 use PhpParser\Node\Expr\Closure as ClosureNode;
 use PhpParser\Node\Param as ParamNode;
 use phpDocumentor\Reflection\Type;
+use PhpParser\NodeTraverser;
 use PhpParser\ParserFactory;
 use PhpParser\PrettyPrinter\Standard as StandardPrettyPrinter;
 use PhpParser\PrettyPrinterAbstract;
@@ -596,5 +598,22 @@ abstract class ReflectionFunctionAbstract implements \Reflector
                 unset($this->node->params[$key]);
             }
         }
+    }
+
+    /**
+     * Fetch an array of all return statements found within this function.
+     *
+     * @return Node\Stmt\Return_[]
+     */
+    public function getReturnStatementsAst()
+    {
+        $visitor = new ReturnNodeVisitor();
+
+        $traverser = new NodeTraverser();
+        $traverser->addVisitor($visitor);
+
+        $traverser->traverse($this->node->getStmts());
+
+        return $visitor->getReturnNodes();
     }
 }

--- a/src/Util/Visitor/ReturnNodeVisitor.php
+++ b/src/Util/Visitor/ReturnNodeVisitor.php
@@ -2,6 +2,7 @@
 
 namespace BetterReflection\Util\Visitor;
 
+use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitorAbstract;
 use PhpParser\Node;
 
@@ -12,16 +13,10 @@ class ReturnNodeVisitor extends NodeVisitorAbstract
      */
     private $returnNodes = [];
 
-    private $scopeDepth = 1;
-
     public function enterNode(Node $node)
     {
         if ($this->isScopeChangingNode($node)) {
-            $this->scopeDepth++;
-        }
-
-        if ($this->scopeDepth !== 1) {
-            return;
+            return NodeTraverser::DONT_TRAVERSE_CHILDREN;
         }
 
         if ($node instanceof Node\Stmt\Return_) {
@@ -29,16 +24,9 @@ class ReturnNodeVisitor extends NodeVisitorAbstract
         }
     }
 
-    public function leaveNode(Node $node)
-    {
-        if ($this->isScopeChangingNode($node)) {
-            $this->scopeDepth--;
-        }
-    }
-
     private function isScopeChangingNode(Node $node)
     {
-        return $node instanceof Node\Expr\Closure || $node instanceof Node\Stmt\Class_;
+        return $node instanceof Node\FunctionLike || $node instanceof Node\Stmt\Class_;
     }
 
     /**

--- a/src/Util/Visitor/ReturnNodeVisitor.php
+++ b/src/Util/Visitor/ReturnNodeVisitor.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace BetterReflection\Util\Visitor;
+
+use PhpParser\NodeVisitorAbstract;
+use PhpParser\Node;
+
+class ReturnNodeVisitor extends NodeVisitorAbstract
+{
+    /**
+     * @var Node\Stmt\Return_[]
+     */
+    private $returnNodes = [];
+
+    public function enterNode(Node $node)
+    {
+        if ($node instanceof Node\Stmt\Return_) {
+            array_push($this->returnNodes, $node);
+        }
+    }
+
+    /**
+     * @return Node\Stmt\Return_[]
+     */
+    public function getReturnNodes()
+    {
+        return $this->returnNodes;
+    }
+}

--- a/src/Util/Visitor/ReturnNodeVisitor.php
+++ b/src/Util/Visitor/ReturnNodeVisitor.php
@@ -12,11 +12,33 @@ class ReturnNodeVisitor extends NodeVisitorAbstract
      */
     private $returnNodes = [];
 
+    private $scopeDepth = 1;
+
     public function enterNode(Node $node)
     {
+        if ($this->isScopeChangingNode($node)) {
+            $this->scopeDepth++;
+        }
+
+        if ($this->scopeDepth !== 1) {
+            return;
+        }
+
         if ($node instanceof Node\Stmt\Return_) {
             array_push($this->returnNodes, $node);
         }
+    }
+
+    public function leaveNode(Node $node)
+    {
+        if ($this->isScopeChangingNode($node)) {
+            $this->scopeDepth--;
+        }
+    }
+
+    private function isScopeChangingNode(Node $node)
+    {
+        return $node instanceof Node\Expr\Closure || $node instanceof Node\Stmt\Class_;
     }
 
     /**

--- a/test/unit/Util/Visitor/ReturnNodeVisitorTest.php
+++ b/test/unit/Util/Visitor/ReturnNodeVisitorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace BetterReflectionTest\Util\Visitor;
+
+use BetterReflection\Util\Visitor\ReturnNodeVisitor;
+use PhpParser\Node;
+
+/**
+ * @covers \BetterReflection\Util\Visitor\ReturnNodeVisitor
+ */
+class ReturnNodeVisitorTest extends \PHPUnit_Framework_TestCase
+{
+    public function testOnlyReturnNodesAreAdded()
+    {
+        $visitor = new ReturnNodeVisitor();
+
+        $this->assertCount(0, $visitor->getReturnNodes());
+
+        $visitor->enterNode(new Node\Scalar\MagicConst\File());
+
+        $this->assertCount(0, $visitor->getReturnNodes());
+
+        $visitor->enterNode(new Node\Stmt\Return_());
+
+        $this->assertCount(1, $visitor->getReturnNodes());
+        $this->assertContainsOnlyInstancesOf(Node\Stmt\Return_::class, $visitor->getReturnNodes());
+    }
+}

--- a/test/unit/Util/Visitor/ReturnNodeVisitorTest.php
+++ b/test/unit/Util/Visitor/ReturnNodeVisitorTest.php
@@ -25,4 +25,34 @@ class ReturnNodeVisitorTest extends \PHPUnit_Framework_TestCase
         $this->assertCount(1, $visitor->getReturnNodes());
         $this->assertContainsOnlyInstancesOf(Node\Stmt\Return_::class, $visitor->getReturnNodes());
     }
+
+    public function outOfScopeNodeTypeProvider()
+    {
+        return [
+            'closure' => [new Node\Expr\Closure()],
+            'anonymousClass' => [new Node\Stmt\Class_('')],
+        ];
+    }
+
+    /**
+     * @param Node $nodeType
+     * @dataProvider outOfScopeNodeTypeProvider
+     */
+    public function testReturnNodesWithinNodeTypesAreNotAdded(Node $nodeType)
+    {
+        $visitor = new ReturnNodeVisitor();
+
+        $this->assertCount(0, $visitor->getReturnNodes());
+
+        $visitor->enterNode($nodeType);
+        $visitor->enterNode(new Node\Stmt\Return_());
+
+        $this->assertCount(0, $visitor->getReturnNodes());
+
+        $visitor->leaveNode($nodeType);
+
+        $visitor->enterNode(new Node\Stmt\Return_());
+
+        $this->assertCount(1, $visitor->getReturnNodes());
+    }
 }


### PR DESCRIPTION
Fixes #198 

Adds ability to fetch all `return` statement node trees from a reflection of a function/method.