### PR TITLE
Replaced fabpot/php-cs-fixer with friendsofphp/php-cs-fixer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         "jeremeamia/superclosure": "^2.2"
     },
     "require-dev": {
-        "fabpot/php-cs-fixer": "^1.11",
+        "friendsofphp/php-cs-fixer": "^1.11",
         "phpunit/phpunit": "^5.2"
     },
     "autoload": {


### PR DESCRIPTION
Because `fabpot/php-cs-fixer` is moved to new package name.