### PR TITLE
Added test for `void` return type for PHP 7.1

### DIFF
--- a/test/unit/Fixture/Php7ReturnTypeDeclarations.php
+++ b/test/unit/Fixture/Php7ReturnTypeDeclarations.php
@@ -19,3 +19,7 @@ function returnsNull(): null
 function returnsNothing()
 {
 }
+
+function returnsVoid(): void
+{
+}

--- a/test/unit/Reflection/ReflectionFunctionAbstractTest.php
+++ b/test/unit/Reflection/ReflectionFunctionAbstractTest.php
@@ -349,6 +349,7 @@ class ReflectionFunctionAbstractTest extends \PHPUnit_Framework_TestCase
             ['returnsString', 'string'],
             ['returnsNull', 'null'],
             ['returnsObject', '\stdClass'],
+            ['returnsVoid', 'void'],
         ];
     }
 
@@ -523,7 +524,7 @@ class ReflectionFunctionAbstractTest extends \PHPUnit_Framework_TestCase
                 new String_('Hello world!')
             ]),
         ]);
-        
+
         $this->assertSame("echo 'Hello world!';", $function->getBodyCode());
     }
 


### PR DESCRIPTION
Fixes #203 - `void` is already supported, so just needed to add test to ensure.