### PR TITLE
Updated deprecated phpunit API calls in test suite

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,13 +6,13 @@
         "php": "^5.6|^7.0",
         "nikic/php-parser": "^2.0",
         "phpdocumentor/reflection-docblock": "^2.0",
-        "phpdocumentor/type-resolver": "^0.1.6",
+        "phpdocumentor/type-resolver": "^0.2",
         "zendframework/zend-code": "^3.0",
         "jeremeamia/superclosure": "^2.2"
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "^1.11",
-        "phpunit/phpunit": "^5.2"
+        "friendsofphp/php-cs-fixer": "^1.12",
+        "phpunit/phpunit": "^5.4"
     },
     "autoload": {
         "psr-4": {

--- a/test/unit/Identifier/IdentifierTypeTest.php
+++ b/test/unit/Identifier/IdentifierTypeTest.php
@@ -34,18 +34,14 @@ class IdentifierTypeTest extends \PHPUnit_Framework_TestCase
 
     public function testThrowsAnExceptionWhenInvalidTypeGiven()
     {
-        $this->setExpectedException(
-            InvalidArgumentException::class,
-            'foo is not a valid identifier type'
-        );
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('foo is not a valid identifier type');
         new IdentifierType('foo');
     }
 
     public function testIsMatchingReflectorClass()
     {
-        $reflectionClass = $this->getMockBuilder(ReflectionClass::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $reflectionClass = $this->createMock(ReflectionClass::class);
 
         $type = new IdentifierType(IdentifierType::IDENTIFIER_CLASS);
 
@@ -54,9 +50,7 @@ class IdentifierTypeTest extends \PHPUnit_Framework_TestCase
 
     public function testIsMatchingReflectorFunction()
     {
-        $reflectionFunction = $this->getMockBuilder(ReflectionFunction::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $reflectionFunction = $this->createMock(ReflectionFunction::class);
 
         $type = new IdentifierType(IdentifierType::IDENTIFIER_FUNCTION);
 
@@ -74,9 +68,7 @@ class IdentifierTypeTest extends \PHPUnit_Framework_TestCase
         $prop->setAccessible(true);
         $prop->setValue($classType, 'nonsense');
 
-        $reflectionClass = $this->getMockBuilder(ReflectionClass::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $reflectionClass = $this->createMock(ReflectionClass::class);
 
         $this->assertFalse($classType->isMatchingReflector($reflectionClass));
     }

--- a/test/unit/NodeCompiler/CompileNodeToValueTest.php
+++ b/test/unit/NodeCompiler/CompileNodeToValueTest.php
@@ -150,43 +150,35 @@ class CompileNodeToValueTest extends \PHPUnit_Framework_TestCase
 
     public function testExceptionThrownWhenInvalidNodeGiven()
     {
-        $this->setExpectedException(
-            UnableToCompileNode::class,
-            'Unable to compile expression: ' . Yield_::class
-        );
+        $this->expectException(UnableToCompileNode::class);
+        $this->expectExceptionMessage('Unable to compile expression: ' . Yield_::class);
         (new CompileNodeToValue())->__invoke(new Yield_(), $this->getDummyContext());
     }
 
     public function testExceptionThrownWhenCoalesceOperatorUsed()
     {
-        $this->setExpectedException(
-            UnableToCompileNode::class,
-            'Unable to compile binary operator'
-        );
+        $this->expectException(UnableToCompileNode::class);
+        $this->expectExceptionMessage('Unable to compile binary operator');
         (new CompileNodeToValue())->__invoke(new Coalesce(new LNumber(5), new LNumber(3)), $this->getDummyContext());
     }
 
     public function testExceptionThrownWhenSpaceshipOperatorUsed()
     {
-        $this->setExpectedException(
-            UnableToCompileNode::class,
-            'Unable to compile binary operator'
-        );
+        $this->expectException(UnableToCompileNode::class);
+        $this->expectExceptionMessage('Unable to compile binary operator');
         (new CompileNodeToValue())->__invoke(new Spaceship(new LNumber(5), new LNumber(3)), $this->getDummyContext());
     }
 
     public function testExceptionThrownWhenUndefinedConstUsed()
     {
-        $this->setExpectedException(
-            UnableToCompileNode::class,
-            'Constant "FOO" has not been defined'
-        );
+        $this->expectException(UnableToCompileNode::class);
+        $this->expectExceptionMessage('Constant "FOO" has not been defined');
         (new CompileNodeToValue())->__invoke(new ConstFetch(new Name('FOO')), $this->getDummyContext());
     }
 
     public function testConstantValueCompiled()
     {
-        $constName = uniqid('BETTER_REFLECTION_TEST_CONST_');
+        $constName = uniqid('BETTER_REFLECTION_TEST_CONST_', true);
         define($constName, 123);
 
         $this->assertSame(

--- a/test/unit/NodeCompiler/CompilerContextTest.php
+++ b/test/unit/NodeCompiler/CompilerContextTest.php
@@ -19,10 +19,8 @@ class CompilerContextTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($context->hasSelf());
         $this->assertSame($reflector, $context->getReflector());
 
-        $this->setExpectedException(
-            \RuntimeException::class,
-            'The current context does not have a class for self'
-        );
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('The current context does not have a class for self');
         $context->getSelf();
     }
 

--- a/test/unit/Reflection/Adapter/ReflectionClassTest.php
+++ b/test/unit/Reflection/Adapter/ReflectionClassTest.php
@@ -32,17 +32,11 @@ class ReflectionClassTest extends \PHPUnit_Framework_TestCase
 
     public function methodExpectationProvider()
     {
-        $mockMethod = $this->getMockBuilder(BetterReflectionMethod::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $mockMethod = $this->createMock(BetterReflectionMethod::class);
 
-        $mockProperty = $this->getMockBuilder(BetterReflectionProperty::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $mockProperty = $this->createMock(BetterReflectionProperty::class);
 
-        $mockClassLike = $this->getMockBuilder(BetterReflectionClass::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $mockClassLike = $this->createMock(BetterReflectionClass::class);
 
         return [
             ['__toString', null, '', []],
@@ -105,9 +99,7 @@ class ReflectionClassTest extends \PHPUnit_Framework_TestCase
     public function testAdapterMethods($methodName, $expectedException, $returnValue, array $args)
     {
         /* @var BetterReflectionClass|\PHPUnit_Framework_MockObject_MockObject $reflectionStub */
-        $reflectionStub = $this->getMockBuilder(BetterReflectionClass::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $reflectionStub = $this->createMock(BetterReflectionClass::class);
 
         if (null === $expectedException) {
             $reflectionStub->expects($this->once())
@@ -117,7 +109,7 @@ class ReflectionClassTest extends \PHPUnit_Framework_TestCase
         }
 
         if (null !== $expectedException) {
-            $this->setExpectedException($expectedException);
+            $this->expectException($expectedException);
         }
 
         $adapter = new ReflectionClassAdapter($reflectionStub);

--- a/test/unit/Reflection/Adapter/ReflectionFunctionTest.php
+++ b/test/unit/Reflection/Adapter/ReflectionFunctionTest.php
@@ -32,9 +32,7 @@ class ReflectionFunctionTest extends \PHPUnit_Framework_TestCase
 
     public function methodExpectationProvider()
     {
-        $mockParameter = $this->getMockBuilder(BetterReflectionParameter::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $mockParameter = $this->createMock(BetterReflectionParameter::class);
 
         return [
             // Inherited
@@ -81,9 +79,7 @@ class ReflectionFunctionTest extends \PHPUnit_Framework_TestCase
     public function testAdapterMethods($methodName, $expectedException, $returnValue, array $args)
     {
         /* @var BetterReflectionFunction|\PHPUnit_Framework_MockObject_MockObject $reflectionStub */
-        $reflectionStub = $this->getMockBuilder(BetterReflectionFunction::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $reflectionStub = $this->createMock(BetterReflectionFunction::class);
 
         if (null === $expectedException) {
             $reflectionStub->expects($this->once())
@@ -93,7 +89,7 @@ class ReflectionFunctionTest extends \PHPUnit_Framework_TestCase
         }
 
         if (null !== $expectedException) {
-            $this->setExpectedException($expectedException);
+            $this->expectException($expectedException);
         }
 
         $adapter = new ReflectionFunctionAdapter($reflectionStub);
@@ -102,7 +98,8 @@ class ReflectionFunctionTest extends \PHPUnit_Framework_TestCase
 
     public function testExport()
     {
-        $this->setExpectedException(\Exception::class, 'Unable to export statically');
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Unable to export statically');
         ReflectionFunctionAdapter::export('str_replace');
     }
 }

--- a/test/unit/Reflection/Adapter/ReflectionMethodTest.php
+++ b/test/unit/Reflection/Adapter/ReflectionMethodTest.php
@@ -33,17 +33,11 @@ class ReflectionMethodTest extends \PHPUnit_Framework_TestCase
 
     public function methodExpectationProvider()
     {
-        $mockParameter = $this->getMockBuilder(BetterReflectionParameter::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $mockParameter = $this->createMock(BetterReflectionParameter::class);
 
-        $mockClassLike = $this->getMockBuilder(BetterReflectionClass::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $mockClassLike = $this->createMock(BetterReflectionClass::class);
 
-        $mockMethod = $this->getMockBuilder(BetterReflectionMethod::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $mockMethod = $this->createMock(BetterReflectionMethod::class);
 
         return [
             // Inherited
@@ -101,9 +95,7 @@ class ReflectionMethodTest extends \PHPUnit_Framework_TestCase
     public function testAdapterMethods($methodName, $expectedException, $returnValue, array $args)
     {
         /* @var BetterReflectionMethod|\PHPUnit_Framework_MockObject_MockObject $reflectionStub */
-        $reflectionStub = $this->getMockBuilder(BetterReflectionMethod::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $reflectionStub = $this->createMock(BetterReflectionMethod::class);
 
         if (null === $expectedException) {
             $reflectionStub->expects($this->once())
@@ -113,7 +105,7 @@ class ReflectionMethodTest extends \PHPUnit_Framework_TestCase
         }
 
         if (null !== $expectedException) {
-            $this->setExpectedException($expectedException);
+            $this->expectException($expectedException);
         }
 
         $adapter = new ReflectionMethodAdapter($reflectionStub);
@@ -122,7 +114,8 @@ class ReflectionMethodTest extends \PHPUnit_Framework_TestCase
 
     public function testExport()
     {
-        $this->setExpectedException(\Exception::class, 'Unable to export statically');
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Unable to export statically');
         ReflectionMethodAdapter::export('\stdClass', 'foo');
     }
 }

--- a/test/unit/Reflection/Adapter/ReflectionObjectTest.php
+++ b/test/unit/Reflection/Adapter/ReflectionObjectTest.php
@@ -34,17 +34,11 @@ class ReflectionObjectTest extends \PHPUnit_Framework_TestCase
 
     public function methodExpectationProvider()
     {
-        $mockMethod = $this->getMockBuilder(BetterReflectionMethod::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $mockMethod = $this->createMock(BetterReflectionMethod::class);
 
-        $mockProperty = $this->getMockBuilder(BetterReflectionProperty::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $mockProperty = $this->createMock(BetterReflectionProperty::class);
 
-        $mockClassLike = $this->getMockBuilder(BetterReflectionClass::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $mockClassLike = $this->createMock(BetterReflectionClass::class);
 
         return [
             ['__toString', null, '', []],
@@ -107,9 +101,7 @@ class ReflectionObjectTest extends \PHPUnit_Framework_TestCase
     public function testAdapterMethods($methodName, $expectedException, $returnValue, array $args)
     {
         /* @var BetterReflectionObject|\PHPUnit_Framework_MockObject_MockObject $reflectionStub */
-        $reflectionStub = $this->getMockBuilder(BetterReflectionObject::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $reflectionStub = $this->createMock(BetterReflectionObject::class);
 
         if (null === $expectedException) {
             $reflectionStub->expects($this->once())
@@ -119,7 +111,7 @@ class ReflectionObjectTest extends \PHPUnit_Framework_TestCase
         }
 
         if (null !== $expectedException) {
-            $this->setExpectedException($expectedException);
+            $this->expectException($expectedException);
         }
 
         $adapter = new ReflectionObjectAdapter($reflectionStub);

--- a/test/unit/Reflection/Adapter/ReflectionParameterTest.php
+++ b/test/unit/Reflection/Adapter/ReflectionParameterTest.php
@@ -33,17 +33,11 @@ class ReflectionParameterTest extends \PHPUnit_Framework_TestCase
 
     public function methodExpectationProvider()
     {
-        $mockFunction = $this->getMockBuilder(BetterReflectionFunction::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $mockFunction = $this->createMock(BetterReflectionFunction::class);
 
-        $mockMethod = $this->getMockBuilder(BetterReflectionMethod::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $mockMethod = $this->createMock(BetterReflectionMethod::class);
 
-        $mockClassLike = $this->getMockBuilder(BetterReflectionClass::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $mockClassLike = $this->createMock(BetterReflectionClass::class);
 
         return [
             ['__toString', null, '', []],
@@ -78,9 +72,7 @@ class ReflectionParameterTest extends \PHPUnit_Framework_TestCase
     public function testAdapterMethods($methodName, $expectedException, $returnValue, array $args)
     {
         /* @var BetterReflectionParameter|\PHPUnit_Framework_MockObject_MockObject $reflectionStub */
-        $reflectionStub = $this->getMockBuilder(BetterReflectionParameter::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $reflectionStub = $this->createMock(BetterReflectionParameter::class);
 
         if (null === $expectedException) {
             $reflectionStub->expects($this->once())
@@ -90,7 +82,7 @@ class ReflectionParameterTest extends \PHPUnit_Framework_TestCase
         }
 
         if (null !== $expectedException) {
-            $this->setExpectedException($expectedException);
+            $this->expectException($expectedException);
         }
 
         $adapter = new ReflectionParameterAdapter($reflectionStub);
@@ -99,7 +91,8 @@ class ReflectionParameterTest extends \PHPUnit_Framework_TestCase
 
     public function testExport()
     {
-        $this->setExpectedException(\Exception::class, 'Unable to export statically');
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Unable to export statically');
         ReflectionParameterAdapter::export('foo', 0);
     }
 }

--- a/test/unit/Reflection/Adapter/ReflectionPropertyTest.php
+++ b/test/unit/Reflection/Adapter/ReflectionPropertyTest.php
@@ -32,9 +32,7 @@ class ReflectionPropertyTest extends \PHPUnit_Framework_TestCase
 
     public function methodExpectationProvider()
     {
-        $mockClassLike = $this->getMockBuilder(BetterReflectionClass::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $mockClassLike = $this->createMock(BetterReflectionClass::class);
 
         return [
             ['__toString', null, '', []],
@@ -63,9 +61,7 @@ class ReflectionPropertyTest extends \PHPUnit_Framework_TestCase
     public function testAdapterMethods($methodName, $expectedException, $returnValue, array $args)
     {
         /* @var BetterReflectionProperty|\PHPUnit_Framework_MockObject_MockObject $reflectionStub */
-        $reflectionStub = $this->getMockBuilder(BetterReflectionProperty::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $reflectionStub = $this->createMock(BetterReflectionProperty::class);
 
         if (null === $expectedException) {
             $reflectionStub->expects($this->once())
@@ -75,7 +71,7 @@ class ReflectionPropertyTest extends \PHPUnit_Framework_TestCase
         }
 
         if (null !== $expectedException) {
-            $this->setExpectedException($expectedException);
+            $this->expectException($expectedException);
         }
 
         $adapter = new ReflectionPropertyAdapter($reflectionStub);
@@ -84,7 +80,8 @@ class ReflectionPropertyTest extends \PHPUnit_Framework_TestCase
 
     public function testExport()
     {
-        $this->setExpectedException(\Exception::class, 'Unable to export statically');
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Unable to export statically');
         ReflectionPropertyAdapter::export('foo', 0);
     }
 }

--- a/test/unit/Reflection/ReflectionClassTest.php
+++ b/test/unit/Reflection/ReflectionClassTest.php
@@ -55,16 +55,14 @@ class ReflectionClassTest extends \PHPUnit_Framework_TestCase
 
     public function testCreateFromInstanceThrowsExceptionWhenInvalidArgumentProvided()
     {
-        $this->setExpectedException(
-            \InvalidArgumentException::class,
-            'Instance must be an instance of an object'
-        );
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Instance must be an instance of an object');
         ReflectionClass::createFromInstance('invalid argument');
     }
 
     public function testCanReflectEvaledClassWithDefaultLocator()
     {
-        $className = uniqid('foo');
+        $className = uniqid('foo', false);
 
         eval('class ' . $className . '{}');
 
@@ -629,7 +627,7 @@ class ReflectionClassTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($class->isInstance($this));
         $this->assertTrue($class->isInstance(new ClassForHinting()));
 
-        $this->setExpectedException(NotAnObject::class);
+        $this->expectException(NotAnObject::class);
 
         $class->isInstance('foo');
     }
@@ -661,7 +659,7 @@ class ReflectionClassTest extends \PHPUnit_Framework_TestCase
             'A subclass of a parent class (considering eventual backslashes upfront)'
         );
 
-        $this->setExpectedException(NotAString::class);
+        $this->expectException(NotAString::class);
 
         $subExampleClass->isSubclassOf($this);
     }
@@ -680,7 +678,7 @@ class ReflectionClassTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($subExampleClass->implementsInterface(\E::class));
         $this->assertFalse($subExampleClass->implementsInterface(\Iterator::class));
 
-        $this->setExpectedException(NotAString::class);
+        $this->expectException(NotAString::class);
 
         $subExampleClass->implementsInterface($this);
     }
@@ -751,7 +749,7 @@ class ReflectionClassTest extends \PHPUnit_Framework_TestCase
 
         $class = $reflector->reflect(InvalidInheritances\ClassExtendingInterface::class);
 
-        $this->setExpectedException(NotAClassReflection::class);
+        $this->expectException(NotAClassReflection::class);
 
         $class->getParentClass();
     }
@@ -763,7 +761,7 @@ class ReflectionClassTest extends \PHPUnit_Framework_TestCase
 
         $class = $reflector->reflect(InvalidInheritances\ClassExtendingTrait::class);
 
-        $this->setExpectedException(NotAClassReflection::class);
+        $this->expectException(NotAClassReflection::class);
 
         $class->getParentClass();
     }
@@ -775,7 +773,7 @@ class ReflectionClassTest extends \PHPUnit_Framework_TestCase
 
         $class = $reflector->reflect(InvalidInheritances\InterfaceExtendingClass::class);
 
-        $this->setExpectedException(NotAnInterfaceReflection::class);
+        $this->expectException(NotAnInterfaceReflection::class);
 
         $class->getInterfaces();
     }
@@ -787,7 +785,7 @@ class ReflectionClassTest extends \PHPUnit_Framework_TestCase
 
         $class = $reflector->reflect(InvalidInheritances\InterfaceExtendingTrait::class);
 
-        $this->setExpectedException(NotAnInterfaceReflection::class);
+        $this->expectException(NotAnInterfaceReflection::class);
 
         $class->getInterfaces();
     }
@@ -849,7 +847,8 @@ class ReflectionClassTest extends \PHPUnit_Framework_TestCase
 
         $nameNode = new Name(['int']);
 
-        $this->setExpectedException(\Exception::class, 'Unable to determine FQSEN for named node');
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Unable to determine FQSEN for named node');
         $reflectionClassMethodReflection->invoke($reflection, $nameNode);
     }
 
@@ -882,7 +881,7 @@ class ReflectionClassTest extends \PHPUnit_Framework_TestCase
 
     public function testExportWithNoClassName()
     {
-        $this->setExpectedException(\InvalidArgumentException::class);
+        $this->expectException(\InvalidArgumentException::class);
         ReflectionClass::export();
     }
 
@@ -932,7 +931,7 @@ class ReflectionClassTest extends \PHPUnit_Framework_TestCase
         $reflector = new ClassReflector($this->getComposerLocator());
         $classInfo = $reflector->reflect('\BetterReflectionTest\Fixture\ExampleClass');
 
-        $this->setExpectedException(Uncloneable::class);
+        $this->expectException(Uncloneable::class);
         $unused = clone $classInfo;
     }
 
@@ -943,7 +942,7 @@ class ReflectionClassTest extends \PHPUnit_Framework_TestCase
         ';
 
         $classInfo = (new ClassReflector(new StringSourceLocator($php)))->reflect('Foo');
-        $this->setExpectedException(ClassDoesNotExist::class);
+        $this->expectException(ClassDoesNotExist::class);
         $classInfo->getStaticPropertyValue('foo');
     }
 
@@ -955,7 +954,7 @@ class ReflectionClassTest extends \PHPUnit_Framework_TestCase
         $classInfo = (new ClassReflector(new SingleFileSourceLocator($staticPropertyGetSetFixture)))
             ->reflect(StaticPropertyGetSet\Foo::class);
 
-        $this->setExpectedException(PropertyDoesNotExist::class);
+        $this->expectException(PropertyDoesNotExist::class);
         $classInfo->getStaticPropertyValue('foo');
     }
 
@@ -967,7 +966,7 @@ class ReflectionClassTest extends \PHPUnit_Framework_TestCase
         $classInfo = (new ClassReflector(new SingleFileSourceLocator($staticPropertyGetSetFixture)))
             ->reflect(StaticPropertyGetSet\Bar::class);
 
-        $this->setExpectedException(PropertyNotPublic::class);
+        $this->expectException(PropertyNotPublic::class);
         $classInfo->getStaticPropertyValue('bat');
     }
 
@@ -979,7 +978,7 @@ class ReflectionClassTest extends \PHPUnit_Framework_TestCase
         $classInfo = (new ClassReflector(new SingleFileSourceLocator($staticPropertyGetSetFixture)))
             ->reflect(StaticPropertyGetSet\Bar::class);
 
-        $this->setExpectedException(PropertyNotPublic::class);
+        $this->expectException(PropertyNotPublic::class);
         $classInfo->getStaticPropertyValue('qux');
     }
 
@@ -1003,7 +1002,7 @@ class ReflectionClassTest extends \PHPUnit_Framework_TestCase
         ';
 
         $classInfo = (new ClassReflector(new StringSourceLocator($php)))->reflect('Foo');
-        $this->setExpectedException(ClassDoesNotExist::class);
+        $this->expectException(ClassDoesNotExist::class);
         $classInfo->setStaticPropertyValue('foo', 'bar');
     }
 
@@ -1015,7 +1014,7 @@ class ReflectionClassTest extends \PHPUnit_Framework_TestCase
         $classInfo = (new ClassReflector(new SingleFileSourceLocator($staticPropertyGetSetFixture)))
             ->reflect(StaticPropertyGetSet\Foo::class);
 
-        $this->setExpectedException(PropertyDoesNotExist::class);
+        $this->expectException(PropertyDoesNotExist::class);
         $classInfo->setStaticPropertyValue('foo', 'bar');
     }
 

--- a/test/unit/Reflection/ReflectionFunctionAbstractTest.php
+++ b/test/unit/Reflection/ReflectionFunctionAbstractTest.php
@@ -32,7 +32,7 @@ class ReflectionFunctionAbstractTest extends \PHPUnit_Framework_TestCase
 {
     public function testExportThrowsException()
     {
-        $this->setExpectedException(\Exception::class);
+        $this->expectException(\Exception::class);
         ReflectionFunctionAbstract::export();
     }
 
@@ -51,7 +51,7 @@ class ReflectionFunctionAbstractTest extends \PHPUnit_Framework_TestCase
         $populateMethodReflection = new \ReflectionMethod(ReflectionFunctionAbstract::class, 'populateFunctionAbstract');
         $populateMethodReflection->setAccessible(true);
 
-        $this->setExpectedException(InvalidAbstractFunctionNodeType::class);
+        $this->expectException(InvalidAbstractFunctionNodeType::class);
         $populateMethodReflection->invoke($abstract, $reflector, $breakNode, $locatedSource, null);
     }
 
@@ -421,7 +421,7 @@ class ReflectionFunctionAbstractTest extends \PHPUnit_Framework_TestCase
 
         $functionInfo = (new FunctionReflector(new StringSourceLocator($php)))->reflect('foo');
 
-        $this->setExpectedException(Uncloneable::class);
+        $this->expectException(Uncloneable::class);
         $unused = clone $functionInfo;
     }
 
@@ -512,7 +512,7 @@ class ReflectionFunctionAbstractTest extends \PHPUnit_Framework_TestCase
         $reflector = new FunctionReflector(new StringSourceLocator($php));
         $function = $reflector->reflect('foo');
 
-        $this->setExpectedException(\TypeError::class);
+        $this->expectException(\TypeError::class);
         $function->setBodyFromAst([1]);
     }
 
@@ -539,7 +539,7 @@ class ReflectionFunctionAbstractTest extends \PHPUnit_Framework_TestCase
         $reflector = new FunctionReflector(new StringSourceLocator($php));
         $function = $reflector->reflect('foo');
 
-        $this->setExpectedException(\InvalidArgumentException::class);
+        $this->expectException(\InvalidArgumentException::class);
         $function->setBodyFromString(['foo' => 'bar']);
     }
 

--- a/test/unit/Reflection/ReflectionMethodTest.php
+++ b/test/unit/Reflection/ReflectionMethodTest.php
@@ -237,7 +237,7 @@ class ReflectionMethodTest extends \PHPUnit_Framework_TestCase
         $reflector = new ClassReflector(new SingleFileSourceLocator($fixture));
 
         if (null === $expectedPrototype) {
-            $this->setExpectedException(MethodPrototypeNotFound::class);
+            $this->expectException(MethodPrototypeNotFound::class);
         }
 
         $b = $reflector->reflect($class)->getMethod($method)->getPrototype();
@@ -255,7 +255,8 @@ class ReflectionMethodTest extends \PHPUnit_Framework_TestCase
         $methodNodeProp->setAccessible(true);
         $methodNodeProp->setValue($method, new Function_('foo'));
 
-        $this->setExpectedException(\RuntimeException::class, 'Expected a ClassMethod node');
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Expected a ClassMethod node');
         $method->isPublic();
     }
 

--- a/test/unit/Reflection/ReflectionObjectTest.php
+++ b/test/unit/Reflection/ReflectionObjectTest.php
@@ -36,7 +36,7 @@ class ReflectionObjectTest extends \PHPUnit_Framework_TestCase
 
     public function testExceptionThrownWhenNonObjectGiven()
     {
-        $this->setExpectedException(\InvalidArgumentException::class);
+        $this->expectException(\InvalidArgumentException::class);
         ReflectionObject::createFromInstance(123);
     }
 
@@ -80,9 +80,7 @@ class ReflectionObjectTest extends \PHPUnit_Framework_TestCase
 
         $classInfo = ReflectionObject::createFromInstance($foo);
 
-        $mockClass = $this->getMockBuilder(ReflectionClass::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $mockClass = $this->createMock(ReflectionClass::class);
 
         $reflectionObjectReflection = new \ReflectionObject($classInfo);
 
@@ -94,7 +92,7 @@ class ReflectionObjectTest extends \PHPUnit_Framework_TestCase
         $reflectionObjectReflectionClassReflection->setAccessible(true);
         $reflectionObjectReflectionClassReflection->setValue($classInfo, $mockClass);
 
-        $this->setExpectedException(\InvalidArgumentException::class);
+        $this->expectException(\InvalidArgumentException::class);
         $classInfo->getProperties();
     }
 
@@ -185,27 +183,21 @@ class ReflectionObjectTest extends \PHPUnit_Framework_TestCase
     public function testCreateFromNodeThrowsException()
     {
         /** @var Reflector|\PHPUnit_Framework_MockObject_MockObject $mReflector */
-        $mReflector = $this->getMockBuilder(Reflector::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $mReflector = $this->createMock(Reflector::class);
 
         /** @var ClassLike|\PHPUnit_Framework_MockObject_MockObject $mClassNode */
-        $mClassNode = $this->getMockBuilder(ClassLike::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $mClassNode = $this->createMock(ClassLike::class);
 
         /** @var LocatedSource|\PHPUnit_Framework_MockObject_MockObject $mLocatedSource */
-        $mLocatedSource = $this->getMockBuilder(LocatedSource::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $mLocatedSource = $this->createMock(LocatedSource::class);
 
-        $this->setExpectedException(\LogicException::class);
+        $this->expectException(\LogicException::class);
         ReflectionObject::createFromNode($mReflector, $mClassNode, $mLocatedSource);
     }
 
     public function testCreateFromNameThrowsException()
     {
-        $this->setExpectedException(\LogicException::class);
+        $this->expectException(\LogicException::class);
         ReflectionObject::createFromName('foo');
     }
 
@@ -248,7 +240,7 @@ BLAH;
     {
         $classInfo = ReflectionObject::createFromInstance(new \stdClass());
 
-        $this->setExpectedException(Uncloneable::class);
+        $this->expectException(Uncloneable::class);
         $unused = clone $classInfo;
     }
 }

--- a/test/unit/Reflection/ReflectionParameterTest.php
+++ b/test/unit/Reflection/ReflectionParameterTest.php
@@ -75,13 +75,15 @@ class ReflectionParameterTest extends \PHPUnit_Framework_TestCase
 
     public function testCreateFromSpecWithClosure()
     {
-        $this->setExpectedException(\Exception::class, 'Creating by closure is not supported yet');
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Creating by closure is not supported yet');
         ReflectionParameter::createFromSpec(function ($a) {}, 'a');
     }
 
     public function testCreateFromSpecWithInvalidArgumentThrowsException()
     {
-        $this->setExpectedException(\InvalidArgumentException::class, 'Could not create reflection from the spec given');
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Could not create reflection from the spec given');
         ReflectionParameter::createFromSpec(123, 'a');
     }
 
@@ -96,7 +98,7 @@ class ReflectionParameterTest extends \PHPUnit_Framework_TestCase
 
     public function testExportThrowsException()
     {
-        $this->setExpectedException(\Exception::class);
+        $this->expectException(\Exception::class);
         ReflectionParameter::export();
     }
 
@@ -143,7 +145,8 @@ class ReflectionParameterTest extends \PHPUnit_Framework_TestCase
         $methodInfo = $classInfo->getMethod('myMethod');
         $paramInfo = $methodInfo->getParameter('var');
 
-        $this->setExpectedException(\LogicException::class, 'This parameter does not have a default value available');
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('This parameter does not have a default value available');
         $paramInfo->getDefaultValue();
     }
 
@@ -446,7 +449,8 @@ class ReflectionParameterTest extends \PHPUnit_Framework_TestCase
         $intDefault = $method->getParameter('intDefault');
         $this->assertFalse($intDefault->isDefaultValueConstant());
 
-        $this->setExpectedException(\LogicException::class, 'This parameter is not a constant default value, so cannot have a constant name');
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('This parameter is not a constant default value, so cannot have a constant name');
         $intDefault->getDefaultValueConstantName();
     }
 
@@ -539,7 +543,7 @@ class ReflectionParameterTest extends \PHPUnit_Framework_TestCase
         $methodInfo = $classInfo->getMethod('methodWithParameters');
         $paramInfo = $methodInfo->getParameter('parameter1');
 
-        $this->setExpectedException(Uncloneable::class);
+        $this->expectException(Uncloneable::class);
         $unused = clone $paramInfo;
     }
 }

--- a/test/unit/Reflection/ReflectionPropertyTest.php
+++ b/test/unit/Reflection/ReflectionPropertyTest.php
@@ -154,7 +154,7 @@ class ReflectionPropertyTest extends \PHPUnit_Framework_TestCase
 
     public function testExportThrowsException()
     {
-        $this->setExpectedException(\Exception::class);
+        $this->expectException(\Exception::class);
         ReflectionProperty::export();
     }
 
@@ -241,7 +241,7 @@ class ReflectionPropertyTest extends \PHPUnit_Framework_TestCase
         $classInfo = $this->reflector->reflect('\BetterReflectionTest\Fixture\ExampleClass');
         $publicProp = $classInfo->getProperty('publicProperty');
 
-        $this->setExpectedException(Uncloneable::class);
+        $this->expectException(Uncloneable::class);
         $unused = clone $publicProp;
     }
 

--- a/test/unit/Reflection/ReflectionTypeTest.php
+++ b/test/unit/Reflection/ReflectionTypeTest.php
@@ -50,7 +50,7 @@ class ReflectionTypeTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('callable', (string)ReflectionType::createFromType(new Types\Callable_(), false));
         $this->assertSame('bool', (string)ReflectionType::createFromType(new Types\Boolean(), false));
         $this->assertSame('float', (string)ReflectionType::createFromType(new Types\Float_(), false));
-        $this->assertSame('void', (string)ReflectionType::createFromType(new Types\Void(), false));
+        $this->assertSame('void', (string)ReflectionType::createFromType(new Types\Void_(), false));
 
         $this->assertSame('\Foo\Bar\Baz', (string)ReflectionType::createFromType(
             new Types\Object_(new Fqsen('\Foo\Bar\Baz')),

--- a/test/unit/SourceLocator/Ast/FindReflectionsInTreeTest.php
+++ b/test/unit/SourceLocator/Ast/FindReflectionsInTreeTest.php
@@ -28,16 +28,13 @@ class FindReflectionsInTreeTest extends \PHPUnit_Framework_TestCase
     public function testInvokeDoesNotCallReflectNodesWhenNoNodesFoundInEmptyAst()
     {
         /** @var NodeToReflection|\PHPUnit_Framework_MockObject_MockObject $strategy */
-        $strategy = $this->getMockBuilder(NodeToReflection::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['__invoke'])
-            ->getMock();
+        $strategy = $this->createMock(NodeToReflection::class);
 
         $strategy->expects($this->never())
             ->method('__invoke');
 
         /** @var Reflector|\PHPUnit_Framework_MockObject_MockObject $reflector */
-        $reflector = $this->getMock(Reflector::class);
+        $reflector = $this->createMock(Reflector::class);
         $locatedSource = new LocatedSource('<?php', null);
 
         $this->assertSame(
@@ -54,16 +51,13 @@ class FindReflectionsInTreeTest extends \PHPUnit_Framework_TestCase
     public function testInvokeDoesNotCallReflectNodesWhenNoNodesFoundInPopulatedAst()
     {
         /** @var NodeToReflection|\PHPUnit_Framework_MockObject_MockObject $strategy */
-        $strategy = $this->getMockBuilder(NodeToReflection::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['__invoke'])
-            ->getMock();
+        $strategy = $this->createMock(NodeToReflection::class);
 
         $strategy->expects($this->never())
             ->method('__invoke');
 
         /** @var Reflector|\PHPUnit_Framework_MockObject_MockObject $reflector */
-        $reflector = $this->getMock(Reflector::class);
+        $reflector = $this->createMock(Reflector::class);
         $locatedSource = new LocatedSource('<?php echo "Hello world";', null);
 
         $this->assertSame(
@@ -80,21 +74,16 @@ class FindReflectionsInTreeTest extends \PHPUnit_Framework_TestCase
     public function testInvokeCallsReflectNodesForClassWithoutNamespace()
     {
         /** @var NodeToReflection|\PHPUnit_Framework_MockObject_MockObject $strategy */
-        $strategy = $this->getMockBuilder(NodeToReflection::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['__invoke'])
-            ->getMock();
+        $strategy = $this->createMock(NodeToReflection::class);
 
-        $mockReflection = $this->getMockBuilder(ReflectionClass::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $mockReflection = $this->createMock(ReflectionClass::class);
 
         $strategy->expects($this->once())
             ->method('__invoke')
             ->will($this->returnValue($mockReflection));
 
         /** @var Reflector|\PHPUnit_Framework_MockObject_MockObject $reflector */
-        $reflector = $this->getMock(Reflector::class);
+        $reflector = $this->createMock(Reflector::class);
         $locatedSource = new LocatedSource('<?php class Foo {}', null);
 
         $this->assertSame(
@@ -113,21 +102,16 @@ class FindReflectionsInTreeTest extends \PHPUnit_Framework_TestCase
     public function testInvokeCallsReflectNodesForNamespacedClass()
     {
         /** @var NodeToReflection|\PHPUnit_Framework_MockObject_MockObject $strategy */
-        $strategy = $this->getMockBuilder(NodeToReflection::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['__invoke'])
-            ->getMock();
+        $strategy = $this->createMock(NodeToReflection::class);
 
-        $mockReflection = $this->getMockBuilder(ReflectionClass::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $mockReflection = $this->createMock(ReflectionClass::class);
 
         $strategy->expects($this->once())
             ->method('__invoke')
             ->will($this->returnValue($mockReflection));
 
         /** @var Reflector|\PHPUnit_Framework_MockObject_MockObject $reflector */
-        $reflector = $this->getMock(Reflector::class);
+        $reflector = $this->createMock(Reflector::class);
         $locatedSource = new LocatedSource('<?php namespace Foo { class Bar {} }', null);
 
         $this->assertSame(
@@ -146,21 +130,16 @@ class FindReflectionsInTreeTest extends \PHPUnit_Framework_TestCase
     public function testInvokeCallsReflectNodesForFunction()
     {
         /** @var NodeToReflection|\PHPUnit_Framework_MockObject_MockObject $strategy */
-        $strategy = $this->getMockBuilder(NodeToReflection::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['__invoke'])
-            ->getMock();
+        $strategy = $this->createMock(NodeToReflection::class);
 
-        $mockReflection = $this->getMockBuilder(ReflectionFunction::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $mockReflection = $this->createMock(ReflectionFunction::class);
 
         $strategy->expects($this->once())
             ->method('__invoke')
             ->will($this->returnValue($mockReflection));
 
         /** @var Reflector|\PHPUnit_Framework_MockObject_MockObject $reflector */
-        $reflector = $this->getMock(Reflector::class);
+        $reflector = $this->createMock(Reflector::class);
         $locatedSource = new LocatedSource('<?php function foo() {}', null);
 
         $this->assertSame(

--- a/test/unit/SourceLocator/Ast/LocatorTest.php
+++ b/test/unit/SourceLocator/Ast/LocatorTest.php
@@ -74,7 +74,7 @@ class LocatorTest extends \PHPUnit_Framework_TestCase
     {
         $php = '<?php';
 
-        $this->setExpectedException(IdentifierNotFound::class);
+        $this->expectException(IdentifierNotFound::class);
         (new Locator())->findReflection(
             new ClassReflector(new StringSourceLocator($php)),
             new LocatedSource($php, null),
@@ -89,7 +89,7 @@ class LocatorTest extends \PHPUnit_Framework_TestCase
         echo 'Hello world';
         ";
 
-        $this->setExpectedException(IdentifierNotFound::class);
+        $this->expectException(IdentifierNotFound::class);
         (new Locator())->findReflection(
             new ClassReflector(new StringSourceLocator($php)),
             new LocatedSource($php, null),

--- a/test/unit/SourceLocator/Ast/Strategy/NodeToReflectionTest.php
+++ b/test/unit/SourceLocator/Ast/Strategy/NodeToReflectionTest.php
@@ -26,7 +26,7 @@ class NodeToReflectionTest extends \PHPUnit_Framework_TestCase
     public function testReturnsReflectionForClassNode()
     {
         /** @var Reflector|\PHPUnit_Framework_MockObject_MockObject $reflector */
-        $reflector = $this->getMock(Reflector::class);
+        $reflector = $this->createMock(Reflector::class);
 
         $locatedSource = new LocatedSource('<?php class Foo {}', null);
 
@@ -44,7 +44,7 @@ class NodeToReflectionTest extends \PHPUnit_Framework_TestCase
     public function testReturnsReflectionForTraitNode()
     {
         /** @var Reflector|\PHPUnit_Framework_MockObject_MockObject $reflector */
-        $reflector = $this->getMock(Reflector::class);
+        $reflector = $this->createMock(Reflector::class);
 
         $locatedSource = new LocatedSource('<?php trait Foo {}', null);
 
@@ -63,7 +63,7 @@ class NodeToReflectionTest extends \PHPUnit_Framework_TestCase
     public function testReturnsReflectionForInterfaceNode()
     {
         /** @var Reflector|\PHPUnit_Framework_MockObject_MockObject $reflector */
-        $reflector = $this->getMock(Reflector::class);
+        $reflector = $this->createMock(Reflector::class);
 
         $locatedSource = new LocatedSource('<?php interface Foo {}', null);
 
@@ -82,7 +82,7 @@ class NodeToReflectionTest extends \PHPUnit_Framework_TestCase
     public function testReturnsReflectionForFunctionNode()
     {
         /** @var Reflector|\PHPUnit_Framework_MockObject_MockObject $reflector */
-        $reflector = $this->getMock(Reflector::class);
+        $reflector = $this->createMock(Reflector::class);
 
         $locatedSource = new LocatedSource('<?php function foo(){}', null);
 
@@ -100,7 +100,7 @@ class NodeToReflectionTest extends \PHPUnit_Framework_TestCase
     public function testReturnsNullWhenIncompatibleNodeFound()
     {
         /** @var Reflector|\PHPUnit_Framework_MockObject_MockObject $reflector */
-        $reflector = $this->getMock(Reflector::class);
+        $reflector = $this->createMock(Reflector::class);
 
         $locatedSource = new LocatedSource('<?php echo "Hello world";', null);
 

--- a/test/unit/SourceLocator/Located/LocatedSourceTest.php
+++ b/test/unit/SourceLocator/Located/LocatedSourceTest.php
@@ -56,25 +56,29 @@ class LocatedSourceTest extends \PHPUnit_Framework_TestCase
      */
     public function testThrowsExceptionWhenInvalidValuesGiven($source, $file, $expectedException, $expectedMessage)
     {
-        $this->setExpectedException($expectedException, $expectedMessage);
+        $this->expectException($expectedException);
+        $this->expectExceptionMessage($expectedMessage);
         new LocatedSource($source, $file);
     }
 
     public function testConstructorThrowsExceptionIfEmptyFileGiven()
     {
-        $this->setExpectedException(InvalidFileLocation::class, 'Filename was empty');
+        $this->expectException(InvalidFileLocation::class);
+        $this->expectExceptionMessage('Filename was empty');
         new LocatedSource('<?php', '');
     }
 
     public function testConstructorThrowsExceptionIfFileDoesNotExist()
     {
-        $this->setExpectedException(InvalidFileLocation::class, 'File does not exist');
+        $this->expectException(InvalidFileLocation::class);
+        $this->expectExceptionMessage('File does not exist');
         new LocatedSource('<?php', 'sdklfjdfslsdfhlkjsdglkjsdflgkj');
     }
 
     public function testConstructorThrowsExceptionIfFileIsNotAFile()
     {
-        $this->setExpectedException(InvalidFileLocation::class, 'Is not a file');
+        $this->expectException(InvalidFileLocation::class);
+        $this->expectExceptionMessage('Is not a file');
         new LocatedSource('<?php', __DIR__);
     }
 
@@ -85,7 +89,8 @@ class LocatedSourceTest extends \PHPUnit_Framework_TestCase
         $originalPermission = fileperms($file);
         chmod($file, 0000);
 
-        $this->setExpectedException(InvalidFileLocation::class, 'File is not readable');
+        $this->expectException(InvalidFileLocation::class);
+        $this->expectExceptionMessage('File is not readable');
 
         try {
             new LocatedSource('<?php', $file);

--- a/test/unit/SourceLocator/Type/AbstractSourceLocatorTest.php
+++ b/test/unit/SourceLocator/Type/AbstractSourceLocatorTest.php
@@ -19,20 +19,16 @@ class AbstractSourceLocatorTest extends \PHPUnit_Framework_TestCase
     public function testLocateIdentifierCallsFindReflection()
     {
         /** @var Reflector|\PHPUnit_Framework_MockObject_MockObject $mockReflector */
-        $mockReflector = $this->getMock(Reflector::class);
+        $mockReflector = $this->createMock(Reflector::class);
 
         $locatedSource = new LocatedSource('<?php class Foo{}', null);
 
         $identifier = new Identifier('Foo', new IdentifierType(IdentifierType::IDENTIFIER_CLASS));
 
-        $mockReflection = $this->getMockBuilder(ReflectionClass::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $mockReflection = $this->createMock(ReflectionClass::class);
 
         /** @var AstLocator|\PHPUnit_Framework_MockObject_MockObject $astLocator */
-        $astLocator = $this->getMockBuilder(AstLocator::class)
-            ->setMethods(['findReflection'])
-            ->getMock();
+        $astLocator = $this->createMock(AstLocator::class);
 
         $astLocator->expects($this->once())
             ->method('findReflection')
@@ -56,14 +52,12 @@ class AbstractSourceLocatorTest extends \PHPUnit_Framework_TestCase
     public function testLocateIdentifierReturnsNullWithoutTryingToFindReflectionWhenUnableToLocateSource()
     {
         /** @var Reflector|\PHPUnit_Framework_MockObject_MockObject $mockReflector */
-        $mockReflector = $this->getMock(Reflector::class);
+        $mockReflector = $this->createMock(Reflector::class);
 
         $identifier = new Identifier('Foo', new IdentifierType(IdentifierType::IDENTIFIER_CLASS));
 
         /** @var AstLocator|\PHPUnit_Framework_MockObject_MockObject $astLocator */
-        $astLocator = $this->getMockBuilder(AstLocator::class)
-            ->setMethods(['findReflection'])
-            ->getMock();
+        $astLocator = $this->createMock(AstLocator::class);
 
         $astLocator->expects($this->never())
             ->method('findReflection');
@@ -85,16 +79,14 @@ class AbstractSourceLocatorTest extends \PHPUnit_Framework_TestCase
     public function testLocateIdentifierReturnsNullWhenFindLocatorThrowsException()
     {
         /** @var Reflector|\PHPUnit_Framework_MockObject_MockObject $mockReflector */
-        $mockReflector = $this->getMock(Reflector::class);
+        $mockReflector = $this->createMock(Reflector::class);
 
         $locatedSource = new LocatedSource('<?php class Foo{}', null);
 
         $identifier = new Identifier('Foo', new IdentifierType(IdentifierType::IDENTIFIER_CLASS));
 
         /** @var AstLocator|\PHPUnit_Framework_MockObject_MockObject $astLocator */
-        $astLocator = $this->getMockBuilder(AstLocator::class)
-            ->setMethods(['findReflection'])
-            ->getMock();
+        $astLocator = $this->createMock(AstLocator::class);
 
         $astLocator->expects($this->once())
             ->method('findReflection')
@@ -118,20 +110,16 @@ class AbstractSourceLocatorTest extends \PHPUnit_Framework_TestCase
     public function testLocateIdentifiersByTypeCallsFindReflectionsOfType()
     {
         /** @var Reflector|\PHPUnit_Framework_MockObject_MockObject $mockReflector */
-        $mockReflector = $this->getMock(Reflector::class);
+        $mockReflector = $this->createMock(Reflector::class);
 
         $locatedSource = new LocatedSource('<?php class Foo{}', null);
 
         $identifierType = new IdentifierType(IdentifierType::IDENTIFIER_CLASS);
 
-        $mockReflection = $this->getMockBuilder(ReflectionClass::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $mockReflection = $this->createMock(ReflectionClass::class);
 
         /** @var AstLocator|\PHPUnit_Framework_MockObject_MockObject $astLocator */
-        $astLocator = $this->getMockBuilder(AstLocator::class)
-            ->setMethods(['findReflectionsOfType'])
-            ->getMock();
+        $astLocator = $this->createMock(AstLocator::class);
 
         $astLocator->expects($this->once())
             ->method('findReflectionsOfType')
@@ -153,20 +141,12 @@ class AbstractSourceLocatorTest extends \PHPUnit_Framework_TestCase
     public function testLocateIdentifiersByTypeReturnsEmptyArrayWithoutTryingToFindReflectionsWhenUnableToLocateSource()
     {
         /** @var Reflector|\PHPUnit_Framework_MockObject_MockObject $mockReflector */
-        $mockReflector = $this->getMock(Reflector::class);
-
-        $locatedSource = new LocatedSource('<?php class Foo{}', null);
+        $mockReflector = $this->createMock(Reflector::class);
 
         $identifierType = new IdentifierType(IdentifierType::IDENTIFIER_CLASS);
 
-        $mockReflection = $this->getMockBuilder(ReflectionClass::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
         /** @var AstLocator|\PHPUnit_Framework_MockObject_MockObject $astLocator */
-        $astLocator = $this->getMockBuilder(AstLocator::class)
-            ->setMethods(['findReflectionsOfType'])
-            ->getMock();
+        $astLocator = $this->createMock(AstLocator::class);
 
         $astLocator->expects($this->never())
             ->method('findReflectionsOfType');

--- a/test/unit/SourceLocator/Type/AggregateSourceLocatorTest.php
+++ b/test/unit/SourceLocator/Type/AggregateSourceLocatorTest.php
@@ -20,13 +20,13 @@ class AggregateSourceLocatorTest extends \PHPUnit_Framework_TestCase
      */
     private function getMockReflector()
     {
-        return $this->getMock(Reflector::class);
+        return $this->createMock(Reflector::class);
     }
 
     public function testInvokeWillTraverseAllGivenLocatorsAndFailToResolve()
     {
-        $locator1   = $this->getMock(SourceLocator::class);
-        $locator2   = $this->getMock(SourceLocator::class);
+        $locator1   = $this->createMock(SourceLocator::class);
+        $locator2   = $this->createMock(SourceLocator::class);
         $identifier = new Identifier('Foo', new IdentifierType(IdentifierType::IDENTIFIER_CLASS));
 
         $locator1->expects($this->once())->method('locateIdentifier');
@@ -39,14 +39,12 @@ class AggregateSourceLocatorTest extends \PHPUnit_Framework_TestCase
     {
         $identifier = new Identifier('Foo', new IdentifierType(IdentifierType::IDENTIFIER_CLASS));
 
-        $locator1   = $this->getMock(SourceLocator::class);
-        $locator2   = $this->getMock(SourceLocator::class);
-        $locator3   = $this->getMock(SourceLocator::class);
-        $locator4   = $this->getMock(SourceLocator::class);
+        $locator1   = $this->createMock(SourceLocator::class);
+        $locator2   = $this->createMock(SourceLocator::class);
+        $locator3   = $this->createMock(SourceLocator::class);
+        $locator4   = $this->createMock(SourceLocator::class);
 
-        $source3     = $this->getMockBuilder(ReflectionClass::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $source3     = $this->createMock(ReflectionClass::class);
 
         $locator1->expects($this->once())->method('locateIdentifier');
         $locator2->expects($this->once())->method('locateIdentifier');
@@ -92,18 +90,14 @@ class AggregateSourceLocatorTest extends \PHPUnit_Framework_TestCase
     {
         $identifierType = new IdentifierType;
 
-        $locator1   = $this->getMock(SourceLocator::class);
-        $locator2   = $this->getMock(SourceLocator::class);
-        $locator3   = $this->getMock(SourceLocator::class);
-        $locator4   = $this->getMock(SourceLocator::class);
+        $locator1 = $this->createMock(SourceLocator::class);
+        $locator2 = $this->createMock(SourceLocator::class);
+        $locator3 = $this->createMock(SourceLocator::class);
+        $locator4 = $this->createMock(SourceLocator::class);
 
-        $source2     = $this->getMockBuilder(ReflectionClass::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $source2 = $this->createMock(ReflectionClass::class);
 
-        $source3     = $this->getMockBuilder(ReflectionClass::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $source3 = $this->createMock(ReflectionClass::class);
 
         $locator1->expects($this->once())->method('locateIdentifiersByType')->willReturn([]);
         $locator2->expects($this->once())->method('locateIdentifiersByType')->willReturn([$source2]);

--- a/test/unit/SourceLocator/Type/AutoloadSourceLocatorTest.php
+++ b/test/unit/SourceLocator/Type/AutoloadSourceLocatorTest.php
@@ -24,7 +24,7 @@ class AutoloadSourceLocatorTest extends \PHPUnit_Framework_TestCase
      */
     private function getMockReflector()
     {
-        return $this->getMock(Reflector::class);
+        return $this->createMock(Reflector::class);
     }
 
     public function testClassLoads()
@@ -139,7 +139,7 @@ class AutoloadSourceLocatorTest extends \PHPUnit_Framework_TestCase
     {
         $reflector = new FunctionReflector(new AutoloadSourceLocator());
 
-        $this->setExpectedException(FunctionUndefined::class);
+        $this->expectException(FunctionUndefined::class);
         $reflector->reflect('this function does not exist, hopefully');
     }
 

--- a/test/unit/SourceLocator/Type/ClosureSourceLocatorTest.php
+++ b/test/unit/SourceLocator/Type/ClosureSourceLocatorTest.php
@@ -19,7 +19,7 @@ class ClosureSourceLocatorTest extends \PHPUnit_Framework_TestCase
      */
     private function getMockReflector()
     {
-        return $this->getMock(Reflector::class);
+        return $this->createMock(Reflector::class);
     }
 
     public function testClosureSourceLocator()
@@ -51,7 +51,8 @@ class ClosureSourceLocatorTest extends \PHPUnit_Framework_TestCase
 
         $locator = new ClosureSourceLocator($closure);
 
-        $this->setExpectedException(\LogicException::class, 'Not implemented');
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('Not implemented');
         $locator->locateIdentifiersByType(
             $this->getMockReflector(),
             new IdentifierType(IdentifierType::IDENTIFIER_FUNCTION)
@@ -64,7 +65,7 @@ class ClosureSourceLocatorTest extends \PHPUnit_Framework_TestCase
 
         $locator = new ClosureSourceLocator($closure1);
 
-        $this->setExpectedException(TwoClosuresOneLine::class);
+        $this->expectException(TwoClosuresOneLine::class);
 
         $locator->locateIdentifier(
             $this->getMockReflector(),

--- a/test/unit/SourceLocator/Type/ComposerSourceLocatorTest.php
+++ b/test/unit/SourceLocator/Type/ComposerSourceLocatorTest.php
@@ -19,7 +19,7 @@ class ComposerSourceLocatorTest extends \PHPUnit_Framework_TestCase
      */
     private function getMockReflector()
     {
-        return $this->getMock(Reflector::class);
+        return $this->createMock(Reflector::class);
     }
 
     public function testInvokableLoadsSource()
@@ -27,9 +27,7 @@ class ComposerSourceLocatorTest extends \PHPUnit_Framework_TestCase
         $className = 'ClassWithNoNamespace';
         $fileName = __DIR__ . '/../../Fixture/NoNamespace.php';
 
-        $loader = $this->getMockBuilder(ClassLoader::class)
-            ->setMethods(['findFile'])
-            ->getMock();
+        $loader = $this->createMock(ClassLoader::class);
 
         $loader
             ->expects($this->once())
@@ -52,9 +50,7 @@ class ComposerSourceLocatorTest extends \PHPUnit_Framework_TestCase
     {
         $className = ClassWithNoNamespace::class;
 
-        $loader = $this->getMockBuilder(ClassLoader::class)
-            ->setMethods(['findFile'])
-            ->getMock();
+        $loader = $this->createMock(ClassLoader::class);
 
         $loader
             ->expects($this->once())
@@ -73,7 +69,7 @@ class ComposerSourceLocatorTest extends \PHPUnit_Framework_TestCase
 
     public function testInvokeThrowsExceptionWhenTryingToLocateFunction()
     {
-        $loader = $this->getMock(ClassLoader::class);
+        $loader = $this->createMock(ClassLoader::class);
 
         /** @var ClassLoader $loader */
         $locator = new ComposerSourceLocator($loader);

--- a/test/unit/SourceLocator/Type/EvaledCodeSourceLocatorTest.php
+++ b/test/unit/SourceLocator/Type/EvaledCodeSourceLocatorTest.php
@@ -20,7 +20,7 @@ class EvaledCodeSourceLocatorTest extends \PHPUnit_Framework_TestCase
      */
     private function getMockReflector()
     {
-        return $this->getMock(Reflector::class);
+        return $this->createMock(Reflector::class);
     }
 
     public function testCanReflectEvaledClass()

--- a/test/unit/SourceLocator/Type/PhpInternalSourceLocatorTest.php
+++ b/test/unit/SourceLocator/Type/PhpInternalSourceLocatorTest.php
@@ -23,7 +23,7 @@ class PhpInternalSourceLocatorTest extends \PHPUnit_Framework_TestCase
      */
     private function getMockReflector()
     {
-        return $this->getMock(Reflector::class);
+        return $this->createMock(Reflector::class);
     }
 
     /**

--- a/test/unit/SourceLocator/Type/SingleFileSourceLocatorTest.php
+++ b/test/unit/SourceLocator/Type/SingleFileSourceLocatorTest.php
@@ -18,7 +18,7 @@ class SingleFileSourceLocatorTest extends \PHPUnit_Framework_TestCase
      */
     private function getMockReflector()
     {
-        return $this->getMock(Reflector::class);
+        return $this->createMock(Reflector::class);
     }
 
     public function testReturnsNullWhenSourceDoesNotContainClass()
@@ -55,19 +55,22 @@ class SingleFileSourceLocatorTest extends \PHPUnit_Framework_TestCase
 
     public function testConstructorThrowsExceptionIfEmptyFileGiven()
     {
-        $this->setExpectedException(InvalidFileLocation::class, 'Filename was empty');
+        $this->expectException(InvalidFileLocation::class);
+        $this->expectExceptionMessage('Filename was empty');
         new SingleFileSourceLocator('');
     }
 
     public function testConstructorThrowsExceptionIfFileDoesNotExist()
     {
-        $this->setExpectedException(InvalidFileLocation::class, 'File does not exist');
+        $this->expectException(InvalidFileLocation::class);
+        $this->expectExceptionMessage('File does not exist');
         new SingleFileSourceLocator('sdklfjdfslsdfhlkjsdglkjsdflgkj');
     }
 
     public function testConstructorThrowsExceptionIfFileIsNotAFile()
     {
-        $this->setExpectedException(InvalidFileLocation::class, 'Is not a file');
+        $this->expectException(InvalidFileLocation::class);
+        $this->expectExceptionMessage('Is not a file');
         new SingleFileSourceLocator(__DIR__);
     }
 }

--- a/test/unit/SourceLocator/Type/StringSourceLocatorTest.php
+++ b/test/unit/SourceLocator/Type/StringSourceLocatorTest.php
@@ -18,7 +18,7 @@ class StringSourceLocatorTest extends \PHPUnit_Framework_TestCase
      */
     private function getMockReflector()
     {
-        return $this->getMock(Reflector::class);
+        return $this->createMock(Reflector::class);
     }
 
     public function testReturnsNullWhenSourceDoesNotContainClass()
@@ -55,7 +55,7 @@ class StringSourceLocatorTest extends \PHPUnit_Framework_TestCase
 
     public function testConstructorThrowsExceptionIfEmptyStringGiven()
     {
-        $this->setExpectedException(EmptyPhpSourceCode::class);
+        $this->expectException(EmptyPhpSourceCode::class);
         new StringSourceLocator('');
     }
 }

--- a/test/unit/TypesFinder/FindParameterTypeTest.php
+++ b/test/unit/TypesFinder/FindParameterTypeTest.php
@@ -66,10 +66,7 @@ class FindParameterTypeTest extends \PHPUnit_Framework_TestCase
         $node = new ParamNode($nodeName);
         $docBlock = "/**\n * $docBlock\n */";
 
-        $function = $this->getMockBuilder(ReflectionFunction::class)
-            ->setMethods(['getDocComment', 'getLocatedSource'])
-            ->disableOriginalConstructor()
-            ->getMock();
+        $function = $this->createMock(ReflectionFunction::class);
 
         $function
             ->expects($this->once())
@@ -102,20 +99,14 @@ class FindParameterTypeTest extends \PHPUnit_Framework_TestCase
         $node = new ParamNode($nodeName);
         $docBlock = "/**\n * $docBlock\n */";
 
-        $class = $this->getMockBuilder(ReflectionClass::class)
-            ->setMethods(['getLocatedSource'])
-            ->disableOriginalConstructor()
-            ->getMock();
+        $class = $this->createMock(ReflectionClass::class);
 
         $class
             ->expects($this->once())
             ->method('getLocatedSource')
             ->will($this->returnValue(new LocatedSource('<?php', null)));
 
-        $method = $this->getMockBuilder(ReflectionMethod::class)
-            ->setMethods(['getDocComment', 'getDeclaringClass'])
-            ->disableOriginalConstructor()
-            ->getMock();
+        $method = $this->createMock(ReflectionMethod::class);
 
         $method
             ->expects($this->once())

--- a/test/unit/TypesFinder/FindPropertyTypeTest.php
+++ b/test/unit/TypesFinder/FindPropertyTypeTest.php
@@ -36,10 +36,7 @@ class FindPropertyTypeTest extends \PHPUnit_Framework_TestCase
      */
     public function testFindPropertyType($docBlock, $expectedInstances)
     {
-        $class = $this->getMockBuilder(ReflectionClass::class)
-            ->setMethods(['getNamespaceName', 'getLocatedSource'])
-            ->disableOriginalConstructor()
-            ->getMock();
+        $class = $this->createMock(ReflectionClass::class);
 
         $class->expects($this->any())->method('getNamespaceName')
             ->will($this->returnValue(''));
@@ -47,10 +44,7 @@ class FindPropertyTypeTest extends \PHPUnit_Framework_TestCase
         $class->expects($this->any())->method('getLocatedSource')
             ->will($this->returnValue(new LocatedSource('<?php', null)));
 
-        $property = $this->getMockBuilder(ReflectionProperty::class)
-            ->setMethods(['getDeclaringClass', 'getDocComment'])
-            ->disableOriginalConstructor()
-            ->getMock();
+        $property = $this->createMock(ReflectionProperty::class);
 
         $property->expects($this->any())->method('getDeclaringClass')
             ->will($this->returnValue($class));
@@ -93,10 +87,7 @@ class FindPropertyTypeTest extends \PHPUnit_Framework_TestCase
 
     public function testFindPropertyTypeReturnsEmptyArrayWhenNoCommentsNodesFound()
     {
-        $class = $this->getMockBuilder(ReflectionClass::class)
-            ->setMethods(['getNamespaceName', 'getLocatedSource'])
-            ->disableOriginalConstructor()
-            ->getMock();
+        $class = $this->createMock(ReflectionClass::class);
 
         $class->expects($this->any())->method('getNamespaceName')
             ->will($this->returnValue(''));
@@ -104,10 +95,7 @@ class FindPropertyTypeTest extends \PHPUnit_Framework_TestCase
         $class->expects($this->any())->method('getLocatedSource')
             ->will($this->returnValue(new LocatedSource('<?php', null)));
 
-        $property = $this->getMockBuilder(ReflectionProperty::class)
-            ->setMethods(['getDeclaringClass', 'getDocComment'])
-            ->disableOriginalConstructor()
-            ->getMock();
+        $property = $this->createMock(ReflectionProperty::class);
 
         $property->expects($this->any())->method('getDeclaringClass')
             ->will($this->returnValue($class));

--- a/test/unit/TypesFinder/FindReturnTypeTest.php
+++ b/test/unit/TypesFinder/FindReturnTypeTest.php
@@ -38,10 +38,7 @@ class FindReturnTypeTest extends \PHPUnit_Framework_TestCase
     {
         $docBlock = "/**\n * $docBlock\n */";
 
-        $function = $this->getMockBuilder(ReflectionFunction::class)
-            ->setMethods(['getDocComment', 'getLocatedSource'])
-            ->disableOriginalConstructor()
-            ->getMock();
+        $function = $this->createMock(ReflectionFunction::class);
 
         $function
             ->expects($this->once())
@@ -72,20 +69,14 @@ class FindReturnTypeTest extends \PHPUnit_Framework_TestCase
     {
         $docBlock = "/**\n * $docBlock\n */";
 
-        $class = $this->getMockBuilder(ReflectionClass::class)
-            ->setMethods(['getLocatedSource'])
-            ->disableOriginalConstructor()
-            ->getMock();
+        $class = $this->createMock(ReflectionClass::class);
 
         $class
             ->expects($this->once())
             ->method('getLocatedSource')
             ->will($this->returnValue(new LocatedSource('<?php', null)));
 
-        $method = $this->getMockBuilder(ReflectionMethod::class)
-            ->setMethods(['getDocComment', 'getDeclaringClass'])
-            ->disableOriginalConstructor()
-            ->getMock();
+        $method = $this->createMock(ReflectionMethod::class);
 
         $method
             ->expects($this->once())


### PR DESCRIPTION
Fixes #170 and also replaces uses of `getMock` with `createMock`