### PR TITLE
[WIP] Variable collector

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: php
 
 php:
-  - 5.6
+    #  - 5.6
   - 7.0
   - hhvm
 

--- a/src/Reflection/ReflectionFunctionAbstract.php
+++ b/src/Reflection/ReflectionFunctionAbstract.php
@@ -20,6 +20,7 @@ use PhpParser\PrettyPrinter\Standard as StandardPrettyPrinter;
 use PhpParser\PrettyPrinterAbstract;
 use SuperClosure\Analyzer\AstAnalyzer;
 use BetterReflection\Util\Visitor\VariableCollectionVisitor;
+use BetterReflection\NodeCompiler\CompilerContext;
 
 abstract class ReflectionFunctionAbstract implements \Reflector
 {
@@ -624,7 +625,8 @@ abstract class ReflectionFunctionAbstract implements \Reflector
     public function getVariables()
     {
         $nodeTraverser = new NodeTraverser();
-        $nodeTraverser->addVisitor($visitor = new VariableCollectionVisitor($this->getDeclaringClass(), $this->reflector));
+        $context = new CompilerContext($this->reflector, $this->getDeclaringClass());
+        $nodeTraverser->addVisitor($visitor = new VariableCollectionVisitor($context));
         $nodeTraverser->traverse([$this->getNode()]);
 
         return $visitor->getVariables();

--- a/src/Reflection/ReflectionFunctionAbstract.php
+++ b/src/Reflection/ReflectionFunctionAbstract.php
@@ -19,6 +19,7 @@ use PhpParser\ParserFactory;
 use PhpParser\PrettyPrinter\Standard as StandardPrettyPrinter;
 use PhpParser\PrettyPrinterAbstract;
 use SuperClosure\Analyzer\AstAnalyzer;
+use BetterReflection\Util\Visitor\VariableCollectionVisitor;
 
 abstract class ReflectionFunctionAbstract implements \Reflector
 {
@@ -618,5 +619,14 @@ abstract class ReflectionFunctionAbstract implements \Reflector
         $traverser->traverse($this->node->getStmts());
 
         return $visitor->getReturnNodes();
+    }
+
+    public function getVariables()
+    {
+        $nodeTraverser = new NodeTraverser();
+        $nodeTraverser->addVisitor($visitor = new VariableCollectionVisitor($this->getDeclaringClass(), $this->reflector));
+        $nodeTraverser->traverse([$this->getNode()]);
+
+        return $visitor->getVariables();
     }
 }

--- a/src/Reflection/ReflectionMethod.php
+++ b/src/Reflection/ReflectionMethod.php
@@ -4,6 +4,8 @@ namespace BetterReflection\Reflection;
 
 use BetterReflection\Reflector\Reflector;
 use PhpParser\Node\Stmt\ClassMethod as MethodNode;
+use PhpParser\NodeTraverser;
+use BetterReflection\Util\Visitor\VariableCollectionVisitor;
 
 class ReflectionMethod extends ReflectionFunctionAbstract
 {

--- a/src/Reflection/ReflectionVariable.php
+++ b/src/Reflection/ReflectionVariable.php
@@ -9,6 +9,7 @@ use PhpParser\Node\Param;
 use PhpParser\Node\Expr\Variable;
 use BetterReflection\Reflection\ReflectionType;
 use BetterReflection\Reflection\ReflectionVariable;
+use BetterReflection\Reflection\ReflectionFunctionAbstract;
 
 class ReflectionVariable
 {
@@ -32,14 +33,27 @@ class ReflectionVariable
      */
     private $type;
 
-    public static function createFromParamAndType(Param $param, ReflectionType $type): ReflectionVariable
+    /**
+     * @var ReflectionFunctionAbstract
+     */
+    private $scopeReflection;
+
+    public static function createFromParamAndType(
+        Param $param,
+        ReflectionType $type,
+        ReflectionFunctionAbstract $scopeReflection = null
+    ): ReflectionVariable
     {
         return self::createFromNodeAndType($param, $type);
     }
 
-    public static function createFromVariableAndType(Variable $variable, ReflectionType $type): ReflectionVariable
+    public static function createFromVariableAndType(
+        Variable $variable,
+        ReflectionType $type,
+        ReflectionFunctionAbstract $scopeReflection = null
+    ): ReflectionVariable
     {
-        return self::createFromNodeAndType($variable, $type);
+        return self::createFromNodeAndType($variable, $type, $scopeReflection);
     }
 
     public function getName(): string
@@ -71,6 +85,12 @@ class ReflectionVariable
         return $this->endPos;
     }
 
+    public function getScopeReflection(): ReflectionFunctionAbstract
+    {
+        return $this->scopeReflection;
+    }
+    
+
     /**
      * Create a new reflection variable, 
      *
@@ -81,13 +101,18 @@ class ReflectionVariable
      *       the node, which means that the Lexer should be configured to provide
      *       them.
      */
-    private static function createFromNodeAndType(NodeAbstract $node, ReflectionType $type): ReflectionVariable
+    private static function createFromNodeAndType(
+        NodeAbstract $node,
+        ReflectionType $type,
+        ReflectionFunctionAbstract $scopeReflection = null
+    ): ReflectionVariable
     {
         $reflectionVariable = new self();
         $reflectionVariable->name = $node->name;
         $reflectionVariable->type = $type;
         $reflectionVariable->startPos = $node->getAttribute('startFilePos');
         $reflectionVariable->endPos = $node->getAttribute('endFilePos');
+        $reflectionVariable->scopeReflection = $scopeReflection;
 
         return $reflectionVariable;
     }

--- a/src/Reflection/ReflectionVariable.php
+++ b/src/Reflection/ReflectionVariable.php
@@ -4,6 +4,9 @@ namespace BetterReflection\Reflection;
 
 use phpDocumentor\Reflection\Type;
 use phpDocumentor\Reflection\Types;
+use PhpParser\NodeAbstract;
+use PhpParser\Node\Param;
+use PhpParser\Node\Expr\Variable;
 
 class ReflectionVariable
 {
@@ -15,26 +18,37 @@ class ReflectionVariable
     /**
      * @var int
      */
-    private $declaredAt;
+    private $startPos;
+
+    /**
+     * @var int
+     */
+    private $endPos;
 
     /**
      * @var $type
      */
     private $type;
 
-    /**
-     * @param string $name
-     * @param int $declaredAt
-     * @param string $type
-     * @return ReflectionType
-     */
-    public static function createFromName($name, ReflectionType $type = null, $declaredAt)
+    public static function createFromParamAndType(Param $param, ReflectionType $type)
     {
-        $reflectionType = new self();
-        $reflectionType->name = $name;
-        $reflectionType->declaredAt = $declaredAt;
-        $reflectionType->type = $type;
-        return $reflectionType;
+        return self::createFromNodeAndType($param, $type);
+    }
+
+    public static function createFromVariableAndType(Variable $variable, ReflectionType $type)
+    {
+        return self::createFromNodeAndType($variable, $type);
+    }
+
+    private static function createFromNodeAndType(NodeAbstract $node, ReflectionType $type)
+    {
+        $reflectionVariable = new self();
+        $reflectionVariable->name = $node->name;
+        $reflectionVariable->type = $type;
+        $reflectionVariable->startPos = $node->getAttribute('startPos');
+        $reflectionVariable->endPos = $node->getAttribute('endPos');
+
+        return $reflectionVariable;
     }
 
     public function getName() 

--- a/src/Reflection/ReflectionVariable.php
+++ b/src/Reflection/ReflectionVariable.php
@@ -7,6 +7,8 @@ use phpDocumentor\Reflection\Types;
 use PhpParser\NodeAbstract;
 use PhpParser\Node\Param;
 use PhpParser\Node\Expr\Variable;
+use BetterReflection\Reflection\ReflectionType;
+use BetterReflection\Reflection\ReflectionVariable;
 
 class ReflectionVariable
 {
@@ -26,70 +28,68 @@ class ReflectionVariable
     private $endPos;
 
     /**
-     * @var $type
+     * @var ReflectionType $type
      */
     private $type;
 
-    public static function createFromParamAndType(Param $param, ReflectionType $type)
+    public static function createFromParamAndType(Param $param, ReflectionType $type): ReflectionVariable
     {
         return self::createFromNodeAndType($param, $type);
     }
 
-    public static function createFromVariableAndType(Variable $variable, ReflectionType $type)
+    public static function createFromVariableAndType(Variable $variable, ReflectionType $type): ReflectionVariable
     {
         return self::createFromNodeAndType($variable, $type);
     }
 
-    private static function createFromNodeAndType(NodeAbstract $node, ReflectionType $type)
-    {
-        $reflectionVariable = new self();
-        $reflectionVariable->name = $node->name;
-        $reflectionVariable->type = $type;
-        $reflectionVariable->startPos = $node->getAttribute('startPos');
-        $reflectionVariable->endPos = $node->getAttribute('endPos');
-
-        return $reflectionVariable;
-    }
-
-    public function getName() 
+    public function getName(): string
     {
         return $this->name;
     }
-
-    public function getDeclaredAt() 
-    {
-        return $this->declaredAt;
-    }
-
+    
     /**
-     * Get a PhpDocumentor type object for this type
-     *
-     * @return Type
+     * Return the reflection type for this variable.
      */
-    public function getTypeObject()
+    public function getType(): ReflectionType
     {
         return $this->type;
     }
 
     /**
-     * Checks if it is a built-in type (i.e., it's not an object...)
-     *
-     * @see http://php.net/manual/en/reflectiontype.isbuiltin.php
-     * @return bool
+     * Returns the offset into the code string of the first character that is part of the node.
      */
-    public function isBuiltin()
+    public function getStartPos(): int
     {
-        return (!$this->type instanceof Types\Object_);
+        return $this->startPos;
     }
 
     /**
-     * Convert this string type to a string
-     *
-     * @see https://github.com/php/php-src/blob/master/ext/reflection/php_reflection.c#L2993
-     * @return string
+     * Returns the offset into the code string of the last character that is part of the node.
      */
-    public function __toString()
+    public function getEndPos(): int
     {
-        return sprintf('@var $%s (%s): %s', $this->name, $this->type, $this->declaredAt);
+        return $this->endPos;
     }
+
+    /**
+     * Create a new reflection variable, 
+     *
+     * NOTE: This method is private as both `Variables` and
+     *       `Params` have the same properties but do not extend a common type.
+     *
+     * NOTE: The startFilePos and endFilePos attributes should be available on
+     *       the node, which means that the Lexer should be configured to provide
+     *       them.
+     */
+    private static function createFromNodeAndType(NodeAbstract $node, ReflectionType $type): ReflectionVariable
+    {
+        $reflectionVariable = new self();
+        $reflectionVariable->name = $node->name;
+        $reflectionVariable->type = $type;
+        $reflectionVariable->startPos = $node->getAttribute('startFilePos');
+        $reflectionVariable->endPos = $node->getAttribute('endFilePos');
+
+        return $reflectionVariable;
+    }
+
 }

--- a/src/Reflection/ReflectionVariable.php
+++ b/src/Reflection/ReflectionVariable.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace BetterReflection\Reflection;
+
+use phpDocumentor\Reflection\Type;
+use phpDocumentor\Reflection\Types;
+
+class ReflectionVariable
+{
+    /**
+     * @var string
+     */
+    private $name;
+
+    /**
+     * @var int
+     */
+    private $declaredAt;
+
+    /**
+     * @var $type
+     */
+    private $type;
+
+    /**
+     * @param string $name
+     * @param int $declaredAt
+     * @param string $type
+     * @return ReflectionType
+     */
+    public static function createFromName($name, ReflectionType $type = null, $declaredAt)
+    {
+        $reflectionType = new self();
+        $reflectionType->name = $name;
+        $reflectionType->declaredAt = $declaredAt;
+        $reflectionType->type = $type;
+        return $reflectionType;
+    }
+
+    public function getName() 
+    {
+        return $this->name;
+    }
+
+    public function getDeclaredAt() 
+    {
+        return $this->declaredAt;
+    }
+
+    /**
+     * Get a PhpDocumentor type object for this type
+     *
+     * @return Type
+     */
+    public function getTypeObject()
+    {
+        return $this->type;
+    }
+
+    /**
+     * Checks if it is a built-in type (i.e., it's not an object...)
+     *
+     * @see http://php.net/manual/en/reflectiontype.isbuiltin.php
+     * @return bool
+     */
+    public function isBuiltin()
+    {
+        return (!$this->type instanceof Types\Object_);
+    }
+
+    /**
+     * Convert this string type to a string
+     *
+     * @see https://github.com/php/php-src/blob/master/ext/reflection/php_reflection.c#L2993
+     * @return string
+     */
+    public function __toString()
+    {
+        return sprintf('@var $%s (%s): %s', $this->name, $this->type, $this->declaredAt);
+    }
+}

--- a/src/Reflection/ReflectionVariable.php
+++ b/src/Reflection/ReflectionVariable.php
@@ -40,7 +40,7 @@ class ReflectionVariable
 
     public static function createFromParamAndType(
         Param $param,
-        ReflectionType $type,
+        ReflectionType $type = null,
         ReflectionFunctionAbstract $scopeReflection = null
     ): ReflectionVariable
     {
@@ -49,7 +49,7 @@ class ReflectionVariable
 
     public static function createFromVariableAndType(
         Variable $variable,
-        ReflectionType $type,
+        ReflectionType $type = null,
         ReflectionFunctionAbstract $scopeReflection = null
     ): ReflectionVariable
     {
@@ -64,7 +64,7 @@ class ReflectionVariable
     /**
      * Return the reflection type for this variable.
      */
-    public function getType(): ReflectionType
+    public function getType()
     {
         return $this->type;
     }
@@ -103,7 +103,7 @@ class ReflectionVariable
      */
     private static function createFromNodeAndType(
         NodeAbstract $node,
-        ReflectionType $type,
+        ReflectionType $type = null,
         ReflectionFunctionAbstract $scopeReflection = null
     ): ReflectionVariable
     {

--- a/src/SourceLocator/Ast/Locator.php
+++ b/src/SourceLocator/Ast/Locator.php
@@ -11,6 +11,7 @@ use BetterReflection\Reflector\Exception\IdentifierNotFound;
 use BetterReflection\SourceLocator\Located\LocatedSource;
 use PhpParser\Parser;
 use PhpParser\ParserFactory;
+use PhpParser\Lexer;
 
 /**
  * @internal
@@ -31,7 +32,8 @@ class Locator
     {
         $this->findReflectionsInTree = new FindReflectionsInTree(new NodeToReflection());
 
-        $this->parser = (new ParserFactory())->create(ParserFactory::PREFER_PHP7);
+        $lexer = new Lexer([ 'usedAttributes' => [ 'comments', 'startFilePos', 'endFilePos', 'startLine', 'endLine' ] ]);
+        $this->parser = (new ParserFactory())->create(ParserFactory::PREFER_PHP7, $lexer);
     }
 
     /**

--- a/src/TypesFinder/FindPropertyType.php
+++ b/src/TypesFinder/FindPropertyType.php
@@ -19,6 +19,7 @@ class FindPropertyType
     public function __invoke(ReflectionProperty $reflectionProperty)
     {
         $contextFactory = new ContextFactory();
+
         $context = $contextFactory->createForNamespace(
             $reflectionProperty->getDeclaringClass()->getNamespaceName(),
             $reflectionProperty->getDeclaringClass()->getLocatedSource()->getSource()

--- a/src/Util/Visitor/VariableCollectionVisitor.php
+++ b/src/Util/Visitor/VariableCollectionVisitor.php
@@ -46,10 +46,6 @@ class VariableCollectionVisitor extends NodeVisitorAbstract
      */
     private $methodParamTypes = [];
 
-    /**
-     * Construct with the reflection class for the AST that we are traversing
-     * and a reflector instance to resolve types from other classes.
-     */
     public function __construct(CompilerContext $context, TypeResolver $typeResolver = null)
     {
         $this->context = $context;
@@ -173,7 +169,7 @@ class VariableCollectionVisitor extends NodeVisitorAbstract
         if ($expr instanceof Expr\MethodCall) {
             $type = $this->typeFromNode($expr->var);
 
-            if ($type->getTypeObject() instanceof DocType\Object_) {
+            if (false === $type->isBuiltin()) {
                 $reflection = $this->context->getReflector()->reflect($type);
                 $method = $reflection->getMethod($expr->name);
 

--- a/src/Util/Visitor/VariableCollectionVisitor.php
+++ b/src/Util/Visitor/VariableCollectionVisitor.php
@@ -1,0 +1,273 @@
+<?php
+
+namespace BetterReflection\Util\Visitor;
+
+use PhpParser\NodeVisitorAbstract;
+use BetterReflection\Reflection\ReflectionVariable;
+use BetterReflection\TypesFinder\FindTypeFromAst;
+use BetterReflection\Reflection\ReflectionType;
+use BetterReflection\Reflection\ReflectionClass;
+use PhpParser\Node;
+use PhpParser\Node\Expr;
+use BetterReflection\Reflector\Reflector;
+use phpDocumentor\Reflection\Types\Object_;
+use phpDocumentor\Reflection\Fqsen;
+use phpDocumentor\Reflection\Types as DocType;
+
+class VariableCollectionVisitor extends NodeVisitorAbstract
+{
+    /**
+     * @var ReflectionClass
+     */
+    private $reflection;
+
+    /**
+     * @var Reflector
+     */
+    private $reflector;
+
+    /**
+     * @var array
+     */
+    private $variables = [];
+
+    /**
+     * @var array
+     */
+    private $methodParamTypes = [];
+
+    /**
+     * Construct with the reflection class for the AST that we are traversing
+     * and a reflector instance to resolve types from other classes.
+     */
+    public function __construct(ReflectionClass $reflection, Reflector $reflector)
+    {
+        $this->reflector = $reflector;
+        $this->reflection = $reflection;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * Just in case this visitor is invoked again, reset the
+     * variables before traversal starts.
+     */
+    public function beforeTraverse(array $nodes)
+    {
+        $this->variables = [];
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * Currently we care about two types of variables:
+     *
+     * 1. Parameters that are passed to class methods.
+     * 2. Newly declared variables.
+     */
+    public function enterNode(Node $node)
+    {
+        if ($node instanceof Node\Stmt\ClassMethod) {
+            $this->processClassMethod($node);
+            return;
+        }
+
+        if ($node instanceof Expr\Assign) {
+            $this->processAssignation($node);
+            return;
+        }
+    }
+
+    /**
+     * Return all the variables which were discovered in the AST.
+     *
+     * @return ReflectionVariable[]
+     */
+    public function getVariables()
+    {
+        return $this->variables;
+    }
+
+    private function processClassMethod(Node\Stmt\ClassMethod $node)
+    {
+        // reset when we enter the class method scope
+        $this->methodParamTypes = [];
+
+        foreach ($node->params as $param) {
+            $reflParam = $this->reflection->getMethod($node->name)->getParameter($param->name);
+            $type = $reflParam->getType();
+
+            // if the type is null, then try and guess the type from the docblock, if
+            // multiple types are available, then return the first.
+            if (null === $type) {
+                $types = $reflParam->getDocBlockTypes();
+                $type = count($types) ? ReflectionType::createFromType(reset($types), false) : null;
+            }
+
+            $this->methodParamTypes[$param->name] = $type;
+            $this->variables[] = ReflectionVariable::createFromName($param->name, $type, $param->getAttribute('startLine'));
+        }
+    }
+
+    private function processAssignation(Expr\Assign $node)
+    {
+        // assignment is not directly to a vaiable, so just ignore it
+        // rather than trying to recreate state.
+        if (false === $node->var instanceof Expr\Variable) {
+            return;
+        }
+
+        $type = $this->typeFromExpression($node->expr);
+        $this->variables[] = ReflectionVariable::createFromName($node->var->name, $type, $node->getAttribute('startLine'));
+    }
+
+    private function typeFromExpression(Node $expr)
+    {
+        $type = null;
+
+        // new object, just get the type and we are good.
+        if ($expr instanceof Expr\New_) {
+            return $this->createType($expr->class);
+        }
+
+        // if this is a property fetch we must resolve the call
+        // chain to determine the type.
+        if ($expr instanceof Expr\PropertyFetch) {
+            $exprs = $this->flattenFetchChain($expr);
+
+            return $this->resolvePropertyFetchChain($exprs);
+        }
+
+        // if it is a method call then we recurse to resolve the type.
+        if ($expr instanceof Expr\MethodCall) {
+            $type = $this->typeFromExpression($expr->var);
+            $reflection = $this->reflector->reflect($type);
+            $method = $reflection->getMethod($expr->name);
+
+            return $method->getReturnType();
+        }
+
+        if ($expr instanceof Expr\Variable) {
+            if ($expr->name === 'this') {
+                $type = ReflectionType::createFromType(new Object_(new Fqsen('\\'.$this->reflection->getName())), false);
+
+                return $type;
+            }
+
+            if (isset($this->methodParamTypes[$expr->name])) {
+                return $this->methodParamTypes[$expr->name];
+            }
+        }
+
+        // if this is a function call, try and instantiate the runtime native
+        // \ReflectionFunction, if it is not internal then ignore it as we
+        // cannot guarantee that we are running in the same process as the code
+        // we are analyzing.
+        //
+        // TODO: This is no positive test case for this ... which PHP internal functions
+        //       actually have a return type??
+        if ($expr instanceof Expr\FuncCall) {
+            $func = (string) $expr->name;
+            $reflection = new \ReflectionFunction($func);
+
+            // do not try and find out return type for non-internal functions
+            if (false === $reflection->isInternal()) {
+                return;
+            }
+
+            // in the case that no return type was provided, just return
+            // "mixed".
+            return $reflection->getReturnType() ?: ReflectionType::createFromType(new DocType\Mixed(), false);
+        }
+
+        if ($expr instanceof Expr\ArrayDimFetch) {
+            return ReflectionType::createFromType(new DocType\Mixed(), false);
+        }
+
+        if ($expr instanceof Expr\Array_) {
+            return ReflectionType::createFromType(new DocType\Array_(), false);
+        }
+
+        if ($expr instanceof Node\Scalar) {
+            switch (get_class($expr)) {
+                case Node\Scalar\DNumber::class:
+                    return ReflectionType::createFromType(new DocType\Float_(), false);
+
+                case Node\Scalar\LNumber::class:
+                    return ReflectionType::createFromType(new DocType\Integer(), false);
+
+                case Node\Scalar\String_::class:
+                    return ReflectionType::createFromType(new DocType\String_(), false);
+
+                case Node\Scalar\Encapsed::class:
+                case Node\Scalar\MagicConst::class:
+                case Node\Scalar\EncapsedStringPart::class:
+                    // TODO: ???
+                    return;
+                default:
+                    throw new \RuntimeException(sprintf(
+                        'Do not know scalar type "%s"', get_class($expr)
+                    ));
+            }
+        }
+
+        throw new \RuntimeException(sprintf(
+            'Could not determine type from expression for node of type "%s"',
+            get_class($expr)
+        ));
+    }
+
+    private function resolvePropertyFetchChain(array $exprs)
+    {
+        $reflection = $this->reflection;
+
+        foreach ($exprs as $expr) {
+            // TODO: This seems very wrong ...
+            if (false === $expr instanceof Expr\PropertyFetch) {
+                continue;
+            }
+
+            // resolve the type of the property from its docblock
+            $prop = $reflection->getProperty($expr->name);
+            $types = $prop->getDocBlockTypes();
+            $type = reset($types);
+
+            // set the new reflection to the type of the property
+            $reflection = $this->reflector->reflect($type->getFqsen());
+        }
+
+        return $reflection->getName();
+    }
+
+    private function flattenFetchChain(Expr\PropertyFetch $node)
+    {
+        $exprs = [];
+
+        // if this the child of this node is also a property fetch node then
+        // recurse, otherwise just add the child to the chain and return.
+        if ($node->var instanceof Expr\PropertyFetch) {
+            $exprs = array_merge($exprs, $this->flattenFetchChain($node->var));
+        } else {
+            $exprs[] = $node->var;
+        }
+
+        $exprs[] = $node;
+
+        return $exprs;
+    }
+
+    private function createType($type)
+    {
+        $typeHint = (new FindTypeFromAst())->__invoke(
+            $type,
+            $this->reflection->getLocatedSource(),
+            $this->reflection->getNamespaceName()
+        );
+
+        if (null === $typeHint) {
+            return;
+        }
+
+        return ReflectionType::createFromType($typeHint, false);
+    }
+}

--- a/src/Util/Visitor/VariableCollectionVisitor.php
+++ b/src/Util/Visitor/VariableCollectionVisitor.php
@@ -140,7 +140,7 @@ class VariableCollectionVisitor extends NodeVisitorAbstract
         $this->variables[] = ReflectionVariable::createFromVariableAndType($node->var, $type, $this->getCurrentScope());
     }
 
-    private function typeFromNode(Node $expr): ReflectionType
+    private function typeFromNode(Node $expr)
     {
         if ($expr instanceof Expr\New_) {
             return $this->reflectionTypeFromNameNode($expr->class);
@@ -218,7 +218,7 @@ class VariableCollectionVisitor extends NodeVisitorAbstract
         return $reflectionType ?: $this->reflectionTypeForUnknown();
     }
 
-    private function reflectionTypeFromPropertyFetch(Expr\PropertyFetch $expr): ReflectionType
+    private function reflectionTypeFromPropertyFetch(Expr\PropertyFetch $expr)
     {
         $type = $this->typeFromNode($expr->var);
 
@@ -238,7 +238,7 @@ class VariableCollectionVisitor extends NodeVisitorAbstract
         return $this->reflectionTypeForUnknown();
     }
 
-    private function reflectionTypeFromMethodCall(Expr\MethodCall $expr): ReflectionType
+    private function reflectionTypeFromMethodCall(Expr\MethodCall $expr)
     {
         $type = $this->typeFromNode($expr->var);
 
@@ -252,7 +252,7 @@ class VariableCollectionVisitor extends NodeVisitorAbstract
         return $this->reflectionTypeForUnknown();
     }
 
-    private function reflectionTypeFromVariable(Expr\Variable $expr): ReflectionType
+    private function reflectionTypeFromVariable(Expr\Variable $expr)
     {
         if ($this->context->hasSelf() && $expr->name === 'this') {
             $type = $this->reflectionTypeFromString($this->context->getSelf()->getName());
@@ -263,6 +263,21 @@ class VariableCollectionVisitor extends NodeVisitorAbstract
         if (isset($this->methodParamTypes[$expr->name])) {
             return $this->methodParamTypes[$expr->name];
         }
+
+        // TODO: Test me
+        $reflectionType = null;
+        foreach ($this->variables as $variable) {
+
+            // assuming all the record variables came before this one, so we
+            // want the last declared variable in the case that a variable name
+            // was repeated.
+            if ($variable->getName() === $expr->name) {
+                $reflectionType = $variable->getType();
+            }
+
+        }
+
+        return $reflectionType;
     }
 
     /**
@@ -274,7 +289,7 @@ class VariableCollectionVisitor extends NodeVisitorAbstract
      * TODO: This is no positive test case for this ... which PHP internal functions
      *       actually have a return type??
      */
-    private function reflectionTypeFromFunctionCall(Expr\FuncCall $expr): ReflectionType
+    private function reflectionTypeFromFunctionCall(Expr\FuncCall $expr)
     {
         $func = (string) $expr->name;
         $reflection = new \ReflectionFunction($func);
@@ -313,7 +328,7 @@ class VariableCollectionVisitor extends NodeVisitorAbstract
         );
     }
 
-    private function reflectionTypeFromDocType(Type $type): ReflectionType
+    private function reflectionTypeFromDocType(Type $type)
     {
         return ReflectionType::createFromType($type, false);
     }

--- a/test/unit/Fixture/MethodVariables.php
+++ b/test/unit/Fixture/MethodVariables.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace BetterReflectionTest\Fixture;
+
+define('SOME_DEFINED_VALUE', 1);
+
+class MethodVariables
+{
+    public function methodOne(int $arg1)
+    {
+        $foobar = $arg1;
+    }
+}

--- a/test/unit/Reflection/ReflectionMethodTest.php
+++ b/test/unit/Reflection/ReflectionMethodTest.php
@@ -12,6 +12,7 @@ use BetterReflection\SourceLocator\Type\SingleFileSourceLocator;
 use BetterReflection\SourceLocator\Type\StringSourceLocator;
 use phpDocumentor\Reflection\Types\Integer;
 use PhpParser\Node\Stmt\Function_;
+use BetterReflection\Reflection\ReflectionVariable;
 
 /**
  * @covers \BetterReflection\Reflection\ReflectionMethod
@@ -303,5 +304,13 @@ class ReflectionMethodTest extends \PHPUnit_Framework_TestCase
         $method = $classInfo->getMethod($methodName);
 
         $this->assertStringMatchesFormat($expectedStringValue, (string)$method);
+    }
+
+    public function testGetVariables()
+    {
+        $classInfo = $this->reflector->reflect('\BetterReflectionTest\Fixture\MethodVariables');
+        $variables = $classInfo->getMethod('methodOne')->getVariables();
+        $this->assertCount(2, $variables);
+        $this->assertContainsOnlyInstancesOf(ReflectionVariable::class, $variables);
     }
 }

--- a/test/unit/Reflection/ReflectionVariableTest.php
+++ b/test/unit/Reflection/ReflectionVariableTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BetterReflectionTest\Reflection;
+
+use phpDocumentor\Reflection\Fqsen;
+use phpDocumentor\Reflection\Types;
+use BetterReflection\Reflection\ReflectionVariable;
+use BetterReflection\Reflection\ReflectionType;
+use PhpParser\Node\Param;
+use PhpParser\Node\Expr\Variable;
+
+/**
+ * @covers \BetterReflection\Reflection\ReflectionVariable
+ */
+class ReflectionVariableTest extends \PHPUnit_Framework_TestCase
+{
+    private $reflectionType;
+
+    public function setUp()
+    {
+        $this->reflectionType = $this->prophesize(ReflectionType::class);
+    }
+
+    public function testCreateFromParamAndType()
+    {
+        $this->reflectionType->__toString()->willReturn('string');
+
+        $variable = ReflectionVariable::createFromParamAndType(
+            $this->createParam('foobar'),
+            $this->reflectionType->reveal()
+        );
+        $this->assertInstanceOf(ReflectionVariable::class, $variable);
+        $this->assertEquals('foobar', $variable->getName());
+        $this->assertSame($this->reflectionType->reveal(), $variable->getType());
+        $this->assertEquals(10, $variable->getStartPos());
+        $this->assertEquals(20, $variable->getEndPos());
+    }
+
+    public function testCreateFromVariableAndType()
+    {
+        $this->reflectionType->__toString()->willReturn('string');
+
+        $variable = ReflectionVariable::createFromVariableAndType(
+            $this->createVariable('foobar'),
+            $this->reflectionType->reveal()
+        );
+        $this->assertInstanceOf(ReflectionVariable::class, $variable);
+        $this->assertEquals('foobar', $variable->getName());
+        $this->assertSame($this->reflectionType->reveal(), $variable->getType());
+        $this->assertEquals(10, $variable->getStartPos());
+        $this->assertEquals(20, $variable->getEndPos());
+    }
+
+    /**
+     * NOTE: It should be better to use the Builder here as the constructor
+     *       could change with later versions of PHP, however the builder does not
+     *       allow the setting of attributes.
+     */
+    public function createParam($name): Param
+    {
+        return new Param(
+            $name, null, null, false, false, [
+                'startFilePos' => 10,
+                'endFilePos' => 20,
+            ]
+        );
+    }
+
+    public function createVariable($name): Variable
+    {
+        return new Variable(
+            $name, [
+                'startFilePos' => 10,
+                'endFilePos' => 20,
+            ]
+        );
+    }
+}

--- a/test/unit/Util/Visitor/Fixtures/ClassOne.php
+++ b/test/unit/Util/Visitor/Fixtures/ClassOne.php
@@ -4,7 +4,16 @@ namespace BetterReflectionTest\Util\Visitor\Fixtures;
 
 class ClassOne
 {
+    /**
+     * @var ClassTwo
+     */
+    public $classTwo;
+
     public function getClassThree(int $number, ClassTwo $object): ClassThree
+    {
+    }
+
+    public function getClassTwo(): ClassTwo
     {
     }
 }

--- a/test/unit/Util/Visitor/Fixtures/ClassOne.php
+++ b/test/unit/Util/Visitor/Fixtures/ClassOne.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace BetterReflectionTest\Util\Visitor\Fixtures;
+
+class ClassOne
+{
+    public function getClassThree(int $number, ClassTwo $object): ClassThree
+    {
+    }
+}

--- a/test/unit/Util/Visitor/Fixtures/ClassThree.php
+++ b/test/unit/Util/Visitor/Fixtures/ClassThree.php
@@ -4,7 +4,16 @@ namespace BetterReflectionTest\Util\Visitor\Fixtures;
 
 class ClassThree
 {
-    public function methodThree(int $number, ClassThree $object): ClassThree
+    /**
+     * @var ClassOne
+     */
+    public $classOne;
+
+    public function getClassThree(int $number, ClassThree $object): ClassThree
+    {
+    }
+
+    public function getClassOne(): ClassOne
     {
     }
 }

--- a/test/unit/Util/Visitor/Fixtures/ClassThree.php
+++ b/test/unit/Util/Visitor/Fixtures/ClassThree.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace BetterReflectionTest\Util\Visitor\Fixtures;
+
+class ClassThree
+{
+    public function methodThree(int $number, ClassThree $object): ClassThree
+    {
+    }
+}

--- a/test/unit/Util/Visitor/Fixtures/ClassTwo.php
+++ b/test/unit/Util/Visitor/Fixtures/ClassTwo.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace BetterReflectionTest\Util\Visitor\Fixtures;
+
+class ClassTwo
+{
+    public function methodTwo(int $number, ClassTwo $object): ClassThree
+    {
+    }
+}

--- a/test/unit/Util/Visitor/Fixtures/ClassTwo.php
+++ b/test/unit/Util/Visitor/Fixtures/ClassTwo.php
@@ -4,7 +4,12 @@ namespace BetterReflectionTest\Util\Visitor\Fixtures;
 
 class ClassTwo
 {
-    public function methodTwo(int $number, ClassTwo $object): ClassThree
+    /**
+     * @var ClassThree
+     */
+    public $classThree;
+
+    public function getClassThree(int $number, ClassTwo $object): ClassThree
     {
     }
 }

--- a/test/unit/Util/Visitor/VariableCollectionVisitorTest.php
+++ b/test/unit/Util/Visitor/VariableCollectionVisitorTest.php
@@ -1,0 +1,216 @@
+<?php
+
+namespace BetterReflectionTest\Util\Visitor;
+
+use BetterReflection\Util\Visitor\ReturnNodeVisitor;
+use PhpParser\Node;
+use PhpParser\NodeTraverser;
+use PhpParser\ParserFactory;
+use BetterReflection\Util\Visitor\VariableCollectionVisitor;
+use BetterReflection\Reflection\ReflectionClass;
+use BetterReflectionTest\Util\Visitor\source;
+use BetterReflection\Reflector\ClassReflector;
+use phpDocumentor\Reflection\TypeResolver;
+use BetterReflection\Reflection\ReflectionVariable;
+use BetterReflection\SourceLocator\Type\StringSourceLocator;
+use BetterReflection\SourceLocator\Type\PhpInternalSourceLocator;
+use BetterReflection\SourceLocator\Type\AggregateSourceLocator;
+use BetterReflection\SourceLocator\Type\AutoloadSourceLocator;
+use BetterReflection\SourceLocator\Type\EvaledCodeSourceLocator;
+use BetterReflectionTest\Util\Visitor\Fixtures\Params;
+
+/**
+ * @covers \BetterReflection\Util\Visitor\VariableCollectionVisitor
+ */
+class VariableCollectionVisitorTest extends \PHPUnit_Framework_TestCase
+{
+    public function variableCollectionProvider()
+    {
+        return [
+            'shouldInterpretArrayAccessesAsMixed' => [
+                <<<'EOT'
+public function foobar()
+{
+    $bar = [ 'foobar' => 'barfoo' ];
+    $access = $bar['foobar'];
+}
+EOT
+                , [
+                    [ 'bar', 'array' ],
+                    [ 'access', 'mixed' ],
+                ],
+            ],
+            'shouldCollectScalarAssignations' => [
+                <<<'EOT'
+public function foobar()
+{
+    $float = 12.12;
+    $integer = 1234;
+    $string = '1234';
+}
+EOT
+                , [
+                    [ 'float', 'float' ],
+                    [ 'integer', 'int' ],
+                    [ 'string', 'string' ],
+                ],
+            ],
+            'shouldCollectReassignedVariables' => [
+                <<<'EOT'
+public function foobar()
+{
+    $foo = 12;
+    $foo = 'string';
+}
+EOT
+                , [
+                    [ 'foo', 'int' ],
+                    [ 'foo', 'string' ],
+                ],
+            ],
+            'shouldResolveCallsOnParameters' => [
+                <<<'EOT'
+public function foobar(ClassOne $params)
+{
+    $foo = $params->getClassThree();
+}
+EOT
+                , [
+                    [ 'params', '\\' . Fixtures\ClassOne::class ],
+                    [ 'foo', '\\' . Fixtures\ClassThree::class ],
+                ],
+            ],
+            'shouldResolveFunctionReturnTypes' => [
+                <<<'EOT'
+public function foobar()
+{
+    $name = trim('foobar');
+}
+EOT
+                , [
+                    [ 'name', 'mixed' ],
+                ],
+            ],
+            'shouldResolveMethodChain' => [
+                <<<'EOT'
+public function methodOne()
+{
+    $date = $this->me()->getClassOne();
+}
+
+public function getClassOne(): ClassOne
+{
+}
+
+public function me(): Foobar
+{
+}
+EOT
+                , [
+                    [ 'date', '\\' . Fixtures\ClassOne::class ],
+                ],
+            ],
+            'shouldResolvePropertyChain' => [
+                <<<'EOT'
+/**
+ * @var ClassOne
+ */
+private $object;
+
+public function getClassThree()
+{
+    $date = $this->object->getClassThree();
+}
+EOT
+
+                , [
+                    [ 'date', '\\' . Fixtures\ClassThree::class ],
+                ]
+            ],
+            'shouldResolveParams' => [
+                <<<'EOT'
+public function getClassThree(int $number, ClassOne $object)
+{
+}
+EOT
+                , [
+                    [ 'number', 'int' ],
+                    [ 'object', '\\' . Fixtures\ClassOne::class ],
+                ]
+            ],
+            'shouldResolveParamsWithDocblock' => [
+                <<<'EOT'
+/**
+ * @param int $number
+ * @param ClassTwo $object
+ */
+public function getClassThree($number, $object)
+{
+}
+EOT
+                , [
+                    [ 'number', 'int' ],
+                    [ 'object', '\\' . Fixtures\ClassTwo::class ],
+                ]
+            ],
+            'shouldResolveThis' => [
+            <<<'EOT'
+public function getClassThree()
+{
+    $foo = $this;
+}
+EOT
+                , [
+                    [ 'foo', '\\' . __NAMESPACE__ . '\\Fixtures\\Foobar' ]
+                ]
+            ],
+        ];
+    }
+
+    /**
+     * @param Node[] $statements
+     * @param int $expectedReturns
+     *
+     * @dataProvider variableCollectionProvider
+     */
+    public function testVariableCollectionProvider($source, $expectedVariables)
+    {
+        $source = str_replace(':content:', $source, <<<'EOT'
+<?php
+
+namespace BetterReflectionTest\Util\Visitor\Fixtures;
+
+class Foobar
+{
+    :content:
+}
+EOT
+        );
+
+        $sourceLocator = new AggregateSourceLocator([
+            new StringSourceLocator($source),
+            new AutoloadSourceLocator(),
+        ]);
+
+        $reflector = new ClassReflector($sourceLocator);
+        $reflection = $reflector->reflect('BetterReflectionTest\Util\Visitor\Fixtures\Foobar');
+
+        $visitor = new VariableCollectionVisitor($reflection, $reflector);
+
+        $traverser = new NodeTraverser();
+        $traverser->addVisitor($visitor);
+        $traverser->traverse([ $reflection->getAst() ]);
+
+        $variables = $visitor->getVariables();
+
+        foreach ($expectedVariables as $index => $expectedVariable) {
+            list($expectedName, $expectedType) = $expectedVariable;
+            $this->assertArrayHasKey($index, $variables);
+            $actual = $variables[$index];
+            $this->assertInstanceOf(ReflectionVariable::class, $actual);
+            $this->assertEquals($expectedName, $actual->getName());
+            $this->assertEquals($expectedType, (string) $actual->getTypeObject());
+        }
+    }
+}
+

--- a/test/unit/Util/Visitor/VariableCollectionVisitorTest.php
+++ b/test/unit/Util/Visitor/VariableCollectionVisitorTest.php
@@ -17,6 +17,7 @@ use BetterReflection\SourceLocator\Type\PhpInternalSourceLocator;
 use BetterReflection\SourceLocator\Type\AggregateSourceLocator;
 use BetterReflection\SourceLocator\Type\AutoloadSourceLocator;
 use BetterReflection\SourceLocator\Type\EvaledCodeSourceLocator;
+use BetterReflection\NodeCompiler\CompilerContext;
 
 /**
  * @covers \BetterReflection\Util\Visitor\VariableCollectionVisitor
@@ -315,8 +316,9 @@ EOT
 
         $reflector = new ClassReflector($sourceLocator);
         $reflection = $reflector->reflect('BetterReflectionTest\Util\Visitor\Fixtures\Foobar');
+        $context = new CompilerContext($reflector, $reflection);
 
-        $visitor = new VariableCollectionVisitor($reflection, $reflector);
+        $visitor = new VariableCollectionVisitor($context);
 
         $traverser = new NodeTraverser();
         $traverser->addVisitor($visitor);

--- a/test/unit/Util/Visitor/VariableCollectionVisitorTest.php
+++ b/test/unit/Util/Visitor/VariableCollectionVisitorTest.php
@@ -332,7 +332,7 @@ EOT
             $actual = $variables[$index];
             $this->assertInstanceOf(ReflectionVariable::class, $actual);
             $this->assertEquals($expectedName, $actual->getName());
-            $this->assertEquals($expectedType, (string) $actual->getTypeObject());
+            $this->assertEquals($expectedType, (string) $actual->getType());
         }
     }
 }

--- a/test/unit/Util/Visitor/VariableCollectionVisitorTest.php
+++ b/test/unit/Util/Visitor/VariableCollectionVisitorTest.php
@@ -304,7 +304,7 @@ namespace BetterReflectionTest\Util\Visitor\Fixtures;
 
 class Foobar
 {
-    :content:
+:content:
 }
 EOT
         );


### PR DESCRIPTION
This is an initial attempt at a variable collector (#222), which can be used by the `ReflectionMethod` to determine the variables that are used. The bulk of this code is concerned with resolving types so that:

```php
/**
 * @var Foobar
 */
public function something()
{
     $bar = $this->foobar->getSomeClass()->getFoo();
}
```

If the `getSomeClass` method has the return type `SomeClass` class and `SomeClass` a method `getFoo` that returns type `int`, then `$bar` will be resolved to `int`.


```php
$reflection = $reflector->reflect(SomeClass::class);
$vars = $reflection->getMethod('something')->getVariables();

echo $vars[0]->getName(); // bar
echo $vars[0]->getType(); // int
echo $vars[0]->getDeclaredAt(); // 6
```

The variable collector visitor can return locally assigned and parameter variables available in the AST it is traversing (regardless of scope).  In the case of getting the variables in a method it would suffice to traverse only the method AST.

This is really rough WIP atm and contains an unknown number of bugs, so before reviewing do you agree with the general approach?

TODO:

- [ ] Types from static methods/properties.
- [ ] ... 