### PR TITLE
Change instances of Iterateable to Iterable

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -41,7 +41,7 @@
 | isInstantiable | :heavy_check_mark: Yes  |
 | isInterface | :heavy_check_mark: Yes |
 | isInternal | :heavy_check_mark: Yes |
-| isIterateable | :heavy_check_mark: Yes  |
+| isIterable | :heavy_check_mark: Yes  |
 | isSubclassOf | :heavy_check_mark: Yes  |
 | isTrait | :heavy_check_mark: Yes |
 | isUserDefined | :heavy_check_mark: Yes |

--- a/src/Reflection/Adapter/ReflectionClass.php
+++ b/src/Reflection/Adapter/ReflectionClass.php
@@ -378,9 +378,9 @@ class ReflectionClass extends CoreReflectionClass
     /**
      * {@inheritDoc}
      */
-    public function isIterateable()
+    public function isIterable()
     {
-        return $this->betterReflectionClass->isIterateable();
+        return $this->betterReflectionClass->isIterable();
     }
 
     /**

--- a/src/Reflection/Adapter/ReflectionObject.php
+++ b/src/Reflection/Adapter/ReflectionObject.php
@@ -372,9 +372,9 @@ class ReflectionObject extends CoreReflectionObject
     /**
      * {@inheritDoc}
      */
-    public function isIterateable()
+    public function isIterable()
     {
-        return $this->betterReflectionObject->isIterateable();
+        return $this->betterReflectionObject->isIterable();
     }
 
     /**

--- a/src/Reflection/ReflectionClass.php
+++ b/src/Reflection/ReflectionClass.php
@@ -976,13 +976,13 @@ class ReflectionClass implements Reflection, \Reflector
     }
 
     /**
-     * Checks if iterateable
+     * Checks if Iterable
      *
-     * @link http://php.net/manual/en/reflectionclass.isiterateable.php
+     * @link http://php.net/manual/en/reflectionclass.isIterable.php
      *
      * @return bool
      */
-    public function isIterateable()
+    public function isIterable()
     {
         return $this->isInstantiable() && $this->implementsInterface(\Traversable::class);
     }

--- a/src/Reflection/ReflectionObject.php
+++ b/src/Reflection/ReflectionObject.php
@@ -482,9 +482,9 @@ class ReflectionObject extends ReflectionClass
     /**
      * {@inheritdoc}
      */
-    public function isIterateable()
+    public function isIterable()
     {
-        return $this->reflectionClass->isIterateable();
+        return $this->reflectionClass->isIterable();
     }
 
     /**

--- a/stub/ReflectionClass.stub
+++ b/stub/ReflectionClass.stub
@@ -185,7 +185,7 @@ class ReflectionClass implements Reflector
     {
     }
 
-    public function isIterateable()
+    public function isIterable()
     {
     }
 

--- a/test/core/001.phpt
+++ b/test/core/001.phpt
@@ -51,7 +51,7 @@ $exp = array (
   'UMLClass::isSubclassOf',
   'UMLClass::getStaticProperties',
   'UMLClass::getDefaultProperties',
-  'UMLClass::isIterateable',
+  'UMLClass::isIterable',
   'UMLClass::implementsInterface',
   'UMLClass::getExtension',
   'UMLClass::getExtensionName');

--- a/test/core/ReflectionClass_isIterable_001.phpt
+++ b/test/core/ReflectionClass_isIterable_001.phpt
@@ -1,5 +1,5 @@
 --TEST--
-ReflectionClass::isIterateable()
+ReflectionClass::isIterable()
 --CREDITS--
 Robin Fernandes <robinf@php.net>
 Steve Seear <stevseea@php.net>
@@ -32,21 +32,21 @@ $classes = array('Traversable', 'Iterator', 'IteratorAggregate', 'ExtendsIterato
 foreach($classes as $class) {
 	$rc = new ReflectionClass($class);
 	echo "Is $class iterable? ";
-	var_dump($rc->isIterateable());
+	var_dump($rc->isIterable());
 }
 
 echo "\nTest invalid params:\n";
 $rc = new ReflectionClass('IteratorImpl');
-var_dump($rc->isIterateable(null));
-var_dump($rc->isIterateable(null, null));
-var_dump($rc->isIterateable(1));
-var_dump($rc->isIterateable(1.5));
-var_dump($rc->isIterateable(true));
-var_dump($rc->isIterateable('X'));
-var_dump($rc->isIterateable(null));
+var_dump($rc->isIterable(null));
+var_dump($rc->isIterable(null, null));
+var_dump($rc->isIterable(1));
+var_dump($rc->isIterable(1.5));
+var_dump($rc->isIterable(true));
+var_dump($rc->isIterable('X'));
+var_dump($rc->isIterable(null));
 
 echo "\nTest static invocation:\n";
-ReflectionClass::isIterateable();
+ReflectionClass::isIterable();
 
 ?>
 --EXPECTF--
@@ -63,30 +63,30 @@ Is A iterable? bool(false)
 
 Test invalid params:
 
-Warning: ReflectionClass::isIterateable() expects exactly 0 parameters, 1 given in %s on line 34
+Warning: ReflectionClass::isIterable() expects exactly 0 parameters, 1 given in %s on line 34
 NULL
 
-Warning: ReflectionClass::isIterateable() expects exactly 0 parameters, 2 given in %s on line 35
+Warning: ReflectionClass::isIterable() expects exactly 0 parameters, 2 given in %s on line 35
 NULL
 
-Warning: ReflectionClass::isIterateable() expects exactly 0 parameters, 1 given in %s on line 36
+Warning: ReflectionClass::isIterable() expects exactly 0 parameters, 1 given in %s on line 36
 NULL
 
-Warning: ReflectionClass::isIterateable() expects exactly 0 parameters, 1 given in %s on line 37
+Warning: ReflectionClass::isIterable() expects exactly 0 parameters, 1 given in %s on line 37
 NULL
 
-Warning: ReflectionClass::isIterateable() expects exactly 0 parameters, 1 given in %s on line 38
+Warning: ReflectionClass::isIterable() expects exactly 0 parameters, 1 given in %s on line 38
 NULL
 
-Warning: ReflectionClass::isIterateable() expects exactly 0 parameters, 1 given in %s on line 39
+Warning: ReflectionClass::isIterable() expects exactly 0 parameters, 1 given in %s on line 39
 NULL
 
-Warning: ReflectionClass::isIterateable() expects exactly 0 parameters, 1 given in %s on line 40
+Warning: ReflectionClass::isIterable() expects exactly 0 parameters, 1 given in %s on line 40
 NULL
 
 Test static invocation:
 
-Fatal error: Uncaught Error: Non-static method ReflectionClass::isIterateable() cannot be called statically in %s:43
+Fatal error: Uncaught Error: Non-static method ReflectionClass::isIterable() cannot be called statically in %s:43
 Stack trace:
 #0 {main}
   thrown in %s on line 43

--- a/test/core/ReflectionClass_isIterable_basic.phpt
+++ b/test/core/ReflectionClass_isIterable_basic.phpt
@@ -1,5 +1,5 @@
 --TEST--
-ReflectionClass::isIterateable() basic
+ReflectionClass::isIterable() basic
 --CREDITS--
 Felix De Vliegher <felix.devliegher@gmail.com>, Marc Veldman <marc@ibuildings.nl>
 --FILE--
@@ -16,19 +16,19 @@ class IteratorClass implements Iterator {
 class DerivedClass extends IteratorClass {}
 class NonIterator {}
 
-function dump_iterateable($class) {
+function dump_Iterable($class) {
 	$reflection = new ReflectionClass($class);
-	var_dump($reflection->isIterateable());
+	var_dump($reflection->isIterable());
 }
 
 $classes = array("ArrayObject", "IteratorClass", "DerivedClass", "NonIterator");
 foreach ($classes as $class) {
-	echo "Is $class iterateable? ";
-	dump_iterateable($class);
+	echo "Is $class Iterable? ";
+	dump_Iterable($class);
 }
 ?>
 --EXPECT--
-Is ArrayObject iterateable? bool(true)
-Is IteratorClass iterateable? bool(true)
-Is DerivedClass iterateable? bool(true)
-Is NonIterator iterateable? bool(false)
+Is ArrayObject Iterable? bool(true)
+Is IteratorClass Iterable? bool(true)
+Is DerivedClass Iterable? bool(true)
+Is NonIterator Iterable? bool(false)

--- a/test/core/ReflectionClass_isIterable_variation1.phpt
+++ b/test/core/ReflectionClass_isIterable_variation1.phpt
@@ -1,5 +1,5 @@
 --TEST--
-ReflectionClass::isIterateable() variations
+ReflectionClass::isIterable() variations
 --CREDITS--
 Felix De Vliegher <felix.devliegher@gmail.com>
 --FILE--
@@ -7,17 +7,17 @@ Felix De Vliegher <felix.devliegher@gmail.com>
 
 class BasicClass {}
 
-function dump_iterateable($obj)
+function dump_Iterable($obj)
 {
 	$reflection = new ReflectionClass($obj);
-	var_dump($reflection->isIterateable());
+	var_dump($reflection->isIterable());
 }
 
 $basicClass = new BasicClass();
 $stdClass = new StdClass();
 
-dump_iterateable($basicClass);
-dump_iterateable($stdClass);
+dump_Iterable($basicClass);
+dump_Iterable($stdClass);
 
 ?>
 --EXPECT--

--- a/test/core/ReflectionClass_toString_001.phpt
+++ b/test/core/ReflectionClass_toString_001.phpt
@@ -310,7 +310,7 @@ Class [ <internal:Reflection> class ReflectionClass implements Reflector ] {
       }
     }
 
-    Method [ <internal:Reflection> public method isIterateable ] {
+    Method [ <internal:Reflection> public method isIterable ] {
 
       - Parameters [0] {
       }

--- a/test/unit/Reflection/Adapter/ReflectionClassTest.php
+++ b/test/unit/Reflection/Adapter/ReflectionClassTest.php
@@ -79,7 +79,7 @@ class ReflectionClassTest extends \PHPUnit_Framework_TestCase
             ['getStaticPropertyValue', NotImplemented::class, null, ['foo']],
             ['setStaticPropertyValue', NotImplemented::class, null, ['foo', 'bar']],
             ['getDefaultProperties', null, ['foo' => 'bar'], []],
-            ['isIterateable', null, true, []],
+            ['isIterable', null, true, []],
             ['implementsInterface', null, true, ['\Traversable']],
             ['getExtension', NotImplemented::class, null, []],
             ['getExtensionName', NotImplemented::class, null, []],

--- a/test/unit/Reflection/Adapter/ReflectionObjectTest.php
+++ b/test/unit/Reflection/Adapter/ReflectionObjectTest.php
@@ -81,7 +81,7 @@ class ReflectionObjectTest extends \PHPUnit_Framework_TestCase
             ['getStaticPropertyValue', NotImplemented::class, null, ['foo']],
             ['setStaticPropertyValue', NotImplemented::class, null, ['foo', 'bar']],
             ['getDefaultProperties', null, ['foo' => 'bar'], []],
-            ['isIterateable', null, true, []],
+            ['isIterable', null, true, []],
             ['implementsInterface', null, true, ['\Traversable']],
             ['getExtension', NotImplemented::class, null, []],
             ['getExtensionName', NotImplemented::class, null, []],

--- a/test/unit/Reflection/ReflectionClassTest.php
+++ b/test/unit/Reflection/ReflectionClassTest.php
@@ -715,7 +715,7 @@ class ReflectionClassTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($reflector->reflect(ClassesWithCloneMethod\WithPrivateClone::class)->isCloneable());
     }
 
-    public function testIsIterateable()
+    public function testIsIterable()
     {
         $sourceLocator = new SingleFileSourceLocator(__DIR__ . '/../Fixture/ClassesImplementingIterators.php');
         $reflector     = new ClassReflector($sourceLocator);
@@ -723,22 +723,22 @@ class ReflectionClassTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue(
             $reflector
                 ->reflect(ClassesImplementingIterators\TraversableImplementation::class)
-                ->isIterateable()
+                ->isIterable()
         );
         $this->assertFalse(
             $reflector
                 ->reflect(ClassesImplementingIterators\NonTraversableImplementation::class)
-                ->isIterateable()
+                ->isIterable()
         );
         $this->assertFalse(
             $reflector
                 ->reflect(ClassesImplementingIterators\AbstractTraversableImplementation::class)
-                ->isIterateable()
+                ->isIterable()
         );
         $this->assertFalse(
             $reflector
                 ->reflect(ClassesImplementingIterators\TraversableExtension::class)
-                ->isIterateable()
+                ->isIterable()
         );
     }
 


### PR DESCRIPTION
This PR "fixes" the assumed incorrect spelling of Iterable by replacing
the usage of Iterateable with Iterable.

Great library, thanks for all the hard work.

Anthony.