### PR TITLE
[RFC] Allow the Parser to be injected into the AST Locator

### DIFF
--- a/src/SourceLocator/Ast/Locator.php
+++ b/src/SourceLocator/Ast/Locator.php
@@ -27,11 +27,11 @@ class Locator
      */
     private $parser;
 
-    public function __construct()
+    public function __construct(Parser $parser = null)
     {
         $this->findReflectionsInTree = new FindReflectionsInTree(new NodeToReflection());
 
-        $this->parser = (new ParserFactory())->create(ParserFactory::PREFER_PHP7);
+        $this->parser = $parser ?: (new ParserFactory())->create(ParserFactory::PREFER_PHP7);
     }
 
     /**

--- a/src/SourceLocator/Type/AbstractSourceLocator.php
+++ b/src/SourceLocator/Type/AbstractSourceLocator.php
@@ -31,7 +31,7 @@ abstract class AbstractSourceLocator implements SourceLocator
 
     public function __construct(AstLocator $astLocator = null)
     {
-        $this->astLocator = (null !== $astLocator) ? $astLocator : new AstLocator();
+        $this->astLocator = $astLocator ?: new AstLocator();
     }
 
     /**

--- a/src/SourceLocator/Type/ComposerSourceLocator.php
+++ b/src/SourceLocator/Type/ComposerSourceLocator.php
@@ -21,9 +21,9 @@ class ComposerSourceLocator extends AbstractSourceLocator
      */
     private $classLoader;
 
-    public function __construct(ClassLoader $classLoader)
+    public function __construct(ClassLoader $classLoader, Locator $locator = null)
     {
-        parent::__construct();
+        parent::__construct($locator);
         $this->classLoader = $classLoader;
     }
 

--- a/src/SourceLocator/Type/EvaledCodeSourceLocator.php
+++ b/src/SourceLocator/Type/EvaledCodeSourceLocator.php
@@ -6,6 +6,7 @@ use Roave\BetterReflection\Identifier\Identifier;
 use Roave\BetterReflection\SourceLocator\Located\EvaledLocatedSource;
 use Roave\BetterReflection\SourceLocator\Reflection\SourceStubber;
 use Zend\Code\Reflection\ClassReflection;
+use BetterReflection\SourceLocator\Ast\Locator;
 
 final class EvaledCodeSourceLocator extends AbstractSourceLocator
 {
@@ -14,9 +15,9 @@ final class EvaledCodeSourceLocator extends AbstractSourceLocator
      */
     private $stubber;
 
-    public function __construct()
+    public function __construct(Locator $locator = null)
     {
-        parent::__construct();
+        parent::__construct($locator);
         $this->stubber = new SourceStubber();
     }
 

--- a/src/SourceLocator/Type/PhpInternalSourceLocator.php
+++ b/src/SourceLocator/Type/PhpInternalSourceLocator.php
@@ -14,9 +14,9 @@ final class PhpInternalSourceLocator extends AbstractSourceLocator
      */
     private $stubber;
 
-    public function __construct()
+    public function __construct(Locator $locator = null)
     {
-        parent::__construct();
+        parent::__construct($locator);
         $this->stubber = new SourceStubber();
     }
 

--- a/src/SourceLocator/Type/SingleFileSourceLocator.php
+++ b/src/SourceLocator/Type/SingleFileSourceLocator.php
@@ -24,9 +24,9 @@ class SingleFileSourceLocator extends AbstractSourceLocator
     /**
      * @param string $filename
      */
-    public function __construct($filename)
+    public function __construct($filename, Locator $locator = null)
     {
-        parent::__construct();
+        parent::__construct($locator);
         $this->filename = (string)$filename;
 
         if (empty($this->filename)) {

--- a/src/SourceLocator/Type/StringSourceLocator.php
+++ b/src/SourceLocator/Type/StringSourceLocator.php
@@ -23,9 +23,9 @@ class StringSourceLocator extends AbstractSourceLocator
     /**
      * @param string $source
      */
-    public function __construct($source)
+    public function __construct($source, Locator $locator = null)
     {
-        parent::__construct();
+        parent::__construct($locator);
         $this->source = (string)$source;
 
         if (empty($this->source)) {

--- a/test/unit/SourceLocator/Type/AbstractSourceLocatorTest.php
+++ b/test/unit/SourceLocator/Type/AbstractSourceLocatorTest.php
@@ -138,6 +138,7 @@ class AbstractSourceLocatorTest extends \PHPUnit_Framework_TestCase
 
         $this->assertSame([$mockReflection], $sourceLocator->locateIdentifiersByType($mockReflector, $identifierType));
     }
+
     public function testLocateIdentifiersByTypeReturnsEmptyArrayWithoutTryingToFindReflectionsWhenUnableToLocateSource()
     {
         /** @var Reflector|\PHPUnit_Framework_MockObject_MockObject $mockReflector */


### PR DESCRIPTION
Currently it is not possible to customize the PHP parser instance in the `Ast\Locator`. This means it is not possible, f.e. to:

1. Disable throwing errors.
2. Add new attributes.

I propose adding the `Locator` as an optional argument to all source locators.