### PR TITLE
Fix exception being thrown in AutoloadSourceLocator

### DIFF
--- a/namespace-bc-aliases.php
+++ b/namespace-bc-aliases.php
@@ -44,7 +44,6 @@ class_alias(\Roave\BetterReflection\SourceLocator\Ast\Locator::class, \BetterRef
 class_alias(\Roave\BetterReflection\SourceLocator\Ast\Strategy\AstConversionStrategy::class, \BetterReflection\SourceLocator\Ast\Strategy\AstConversionStrategy::class);
 class_alias(\Roave\BetterReflection\SourceLocator\Ast\Strategy\NodeToReflection::class, \BetterReflection\SourceLocator\Ast\Strategy\NodeToReflection::class);
 class_alias(\Roave\BetterReflection\SourceLocator\Exception\EmptyPhpSourceCode::class, \BetterReflection\SourceLocator\Exception\EmptyPhpSourceCode::class);
-class_alias(\Roave\BetterReflection\SourceLocator\Exception\FunctionUndefined::class, \BetterReflection\SourceLocator\Exception\FunctionUndefined::class);
 class_alias(\Roave\BetterReflection\SourceLocator\Exception\InvalidDirectory::class, \BetterReflection\SourceLocator\Exception\InvalidDirectory::class);
 class_alias(\Roave\BetterReflection\SourceLocator\Exception\InvalidFileInfo::class, \BetterReflection\SourceLocator\Exception\InvalidFileInfo::class);
 class_alias(\Roave\BetterReflection\SourceLocator\Exception\InvalidFileLocation::class, \BetterReflection\SourceLocator\Exception\InvalidFileLocation::class);

--- a/namespace-bc-aliases.php
+++ b/namespace-bc-aliases.php
@@ -44,6 +44,7 @@ class_alias(\Roave\BetterReflection\SourceLocator\Ast\Locator::class, \BetterRef
 class_alias(\Roave\BetterReflection\SourceLocator\Ast\Strategy\AstConversionStrategy::class, \BetterReflection\SourceLocator\Ast\Strategy\AstConversionStrategy::class);
 class_alias(\Roave\BetterReflection\SourceLocator\Ast\Strategy\NodeToReflection::class, \BetterReflection\SourceLocator\Ast\Strategy\NodeToReflection::class);
 class_alias(\Roave\BetterReflection\SourceLocator\Exception\EmptyPhpSourceCode::class, \BetterReflection\SourceLocator\Exception\EmptyPhpSourceCode::class);
+class_alias(\Roave\BetterReflection\SourceLocator\Exception\FunctionUndefined::class, \BetterReflection\SourceLocator\Exception\FunctionUndefined::class);
 class_alias(\Roave\BetterReflection\SourceLocator\Exception\InvalidDirectory::class, \BetterReflection\SourceLocator\Exception\InvalidDirectory::class);
 class_alias(\Roave\BetterReflection\SourceLocator\Exception\InvalidFileInfo::class, \BetterReflection\SourceLocator\Exception\InvalidFileInfo::class);
 class_alias(\Roave\BetterReflection\SourceLocator\Exception\InvalidFileLocation::class, \BetterReflection\SourceLocator\Exception\InvalidFileLocation::class);

--- a/src/Reflector/ClassReflector.php
+++ b/src/Reflector/ClassReflector.php
@@ -42,6 +42,7 @@ class ClassReflector implements Reflector
      *
      * @param string $className
      * @return \Roave\BetterReflection\Reflection\ReflectionClass
+     * @throws \Roave\BetterReflection\Reflector\Exception\IdentifierNotFound
      */
     public function reflect($className)
     {

--- a/src/Reflector/FunctionReflector.php
+++ b/src/Reflector/FunctionReflector.php
@@ -22,13 +22,19 @@ class FunctionReflector implements Reflector
      * Create a ReflectionFunction for the specified $functionName.
      *
      * @param string $functionName
-     * @return \Roave\BetterReflection\Reflection\ReflectionFunction
+     * @return \Roave\BetterReflection\Reflection\Reflection|\Roave\BetterReflection\Reflection\ReflectionFunction
+     * @throws \Roave\BetterReflection\Reflector\Exception\IdentifierNotFound
      */
     public function reflect($functionName)
     {
-        return $this->sourceLocator->locateIdentifier(
-            ClassReflector::buildDefaultReflector(),
-            new Identifier($functionName, new IdentifierType(IdentifierType::IDENTIFIER_FUNCTION))
-        );
+        $identifier = new Identifier($functionName, new IdentifierType(IdentifierType::IDENTIFIER_FUNCTION));
+
+        $functionInfo = $this->sourceLocator->locateIdentifier(ClassReflector::buildDefaultReflector(), $identifier);
+
+        if (null === $functionInfo) {
+            throw Exception\IdentifierNotFound::fromIdentifier($identifier);
+        }
+
+        return $functionInfo;
     }
 }

--- a/src/Reflector/Reflector.php
+++ b/src/Reflector/Reflector.php
@@ -3,6 +3,7 @@
 namespace Roave\BetterReflection\Reflector;
 
 use Roave\BetterReflection\Reflection\Reflection;
+use Roave\BetterReflection\Reflector\Exception\IdentifierNotFound;
 
 /**
  * This interface is used to ensure a reflector implements these basic methods.
@@ -14,6 +15,7 @@ interface Reflector
      *
      * @param string $identifierName
      * @return Reflection
+     * @throws IdentifierNotFound
      */
     public function reflect($identifierName);
 }

--- a/src/SourceLocator/Exception/FunctionUndefined.php
+++ b/src/SourceLocator/Exception/FunctionUndefined.php
@@ -1,7 +1,0 @@
-<?php
-
-namespace Roave\BetterReflection\SourceLocator\Exception;
-
-class FunctionUndefined extends \RuntimeException
-{
-}

--- a/src/SourceLocator/Exception/FunctionUndefined.php
+++ b/src/SourceLocator/Exception/FunctionUndefined.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Roave\BetterReflection\SourceLocator\Exception;
+
+/**
+ * This is removed in PR #236 - this should never have existed, but leaving here for BC. This exception is never thrown
+ * so you should remove it from your code.
+ *
+ * You were probably looking to catch \Roave\BetterReflection\Reflector\Exception\IdentifierNotFound instead.
+ *
+ * @deprecated You're probably looking for `IdentifierNotFound`
+ * @see \Roave\BetterReflection\Reflector\Exception\IdentifierNotFound
+ */
+class FunctionUndefined extends \RuntimeException
+{
+}

--- a/src/SourceLocator/Type/AutoloadSourceLocator.php
+++ b/src/SourceLocator/Type/AutoloadSourceLocator.php
@@ -2,7 +2,6 @@
 
 namespace Roave\BetterReflection\SourceLocator\Type;
 
-use Roave\BetterReflection\SourceLocator\Exception\FunctionUndefined;
 use Roave\BetterReflection\Identifier\Identifier;
 use Roave\BetterReflection\SourceLocator\Located\LocatedSource;
 
@@ -43,7 +42,7 @@ class AutoloadSourceLocator extends AbstractSourceLocator
      * Attempts to locate the specified identifier.
      *
      * @param Identifier $identifier
-     * @return string
+     * @return string|null
      */
     private function attemptAutoloadForIdentifier(Identifier $identifier)
     {
@@ -95,13 +94,12 @@ class AutoloadSourceLocator extends AbstractSourceLocator
      * nothing so throw an exception.
      *
      * @param string $functionName
-     * @return string
-     * @throws FunctionUndefined
+     * @return string|null
      */
     private function locateFunctionByName($functionName)
     {
         if (!function_exists($functionName)) {
-            throw new FunctionUndefined('Function ' . $functionName . ' was not already defined');
+            return null;
         }
 
         $reflection = new \ReflectionFunction($functionName);

--- a/test/unit/SourceLocator/Type/AutoloadSourceLocatorTest.php
+++ b/test/unit/SourceLocator/Type/AutoloadSourceLocatorTest.php
@@ -5,6 +5,7 @@ namespace Roave\BetterReflectionTest\SourceLocator\Type;
 use Roave\BetterReflection\Identifier\Identifier;
 use Roave\BetterReflection\Identifier\IdentifierType;
 use Roave\BetterReflection\Reflector\ClassReflector;
+use Roave\BetterReflection\Reflector\Exception\IdentifierNotFound;
 use Roave\BetterReflection\Reflector\FunctionReflector;
 use Roave\BetterReflection\Reflector\Reflector;
 use Roave\BetterReflection\SourceLocator\Type\AutoloadSourceLocator;
@@ -138,7 +139,7 @@ class AutoloadSourceLocatorTest extends \PHPUnit_Framework_TestCase
     {
         $reflector = new FunctionReflector(new AutoloadSourceLocator());
 
-        $this->expectException(FunctionUndefined::class);
+        $this->expectException(IdentifierNotFound::class);
         $reflector->reflect('this function does not exist, hopefully');
     }
 


### PR DESCRIPTION
The handling in FunctionReflector was actually wrong - it was returning `null` when it should be throwing an `IdentifierNotFound` exception. In the case of using AutoloadSourceLocator when reflecting on a function, an exception `FunctionUndefined` was being thrown. This has been removed (therefore this is sadly a minor BC break) and we handle this correctly.

Fixes #234 