### PR TITLE
Fix for #243: `ReflectionType` `(string)` cast should not prepend backslash to class and interface types

### DIFF
--- a/src/Reflection/ReflectionType.php
+++ b/src/Reflection/ReflectionType.php
@@ -89,7 +89,7 @@ class ReflectionType
             case $this->type instanceof Types\Void_:
                 return 'void';
             default:
-                return (string)$this->type;
+                return ltrim((string) $this->type, '\\');
         }
     }
 }

--- a/test/unit/Reflection/ReflectionFunctionAbstractTest.php
+++ b/test/unit/Reflection/ReflectionFunctionAbstractTest.php
@@ -352,7 +352,7 @@ class ReflectionFunctionAbstractTest extends \PHPUnit_Framework_TestCase
             ['returnsInt', 'int'],
             ['returnsString', 'string'],
             ['returnsNull', 'null'],
-            ['returnsObject', '\stdClass'],
+            ['returnsObject', \stdClass::class],
             ['returnsVoid', 'void'],
         ];
     }

--- a/test/unit/Reflection/ReflectionParameterTest.php
+++ b/test/unit/Reflection/ReflectionParameterTest.php
@@ -264,7 +264,7 @@ class ReflectionParameterTest extends \PHPUnit_Framework_TestCase
         $method = $classInfo->getMethod('foo');
 
         $classParamType = $method->getParameter('classParam')->getType();
-        $this->assertSame('\stdClass', (string)$classParamType);
+        $this->assertSame(\stdClass::class, (string)$classParamType);
         $this->assertFalse($classParamType->isBuiltin());
         $this->assertFalse($classParamType->allowsNull());
     }

--- a/test/unit/Reflection/ReflectionTypeTest.php
+++ b/test/unit/Reflection/ReflectionTypeTest.php
@@ -52,7 +52,7 @@ class ReflectionTypeTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('float', (string)ReflectionType::createFromType(new Types\Float_(), false));
         $this->assertSame('void', (string)ReflectionType::createFromType(new Types\Void_(), false));
 
-        $this->assertSame('\Foo\Bar\Baz', (string)ReflectionType::createFromType(
+        $this->assertSame('Foo\Bar\Baz', (string)ReflectionType::createFromType(
             new Types\Object_(new Fqsen('\Foo\Bar\Baz')),
             false
         ));


### PR DESCRIPTION
Fixes #243