### PR TITLE
Fixed class constant value fetch when constant is declared in parent

### DIFF
--- a/src/NodeCompiler/CompileNodeToValue.php
+++ b/src/NodeCompiler/CompileNodeToValue.php
@@ -124,7 +124,7 @@ class CompileNodeToValue
 
         $classInfo = null;
         if ('self' === $className || 'static' === $className) {
-            $classInfo = $context->getSelf();
+            $classInfo = $this->getConstantDeclaringClass($node->name, $context);
         }
 
         if (null === $classInfo) {
@@ -247,4 +247,20 @@ class CompileNodeToValue
 
         throw new Exception\UnableToCompileNode('Unable to compile binary operator: ' . get_class($node));
     }
+
+    /**
+     * @param string $constantName
+     * @param \Roave\BetterReflection\NodeCompiler\CompilerContext $context
+     * @return \Roave\BetterReflection\Reflection\ReflectionClass|null
+     */
+    private function getConstantDeclaringClass(string $constantName, CompilerContext $context)
+    {
+        $classInfo = $context->getSelf();
+        while (!$classInfo->hasConstant($constantName) && $classInfo->getParentClass() !== null) {
+            $classInfo = $classInfo->getParentClass();
+        }
+
+        return $classInfo;
+    }
+
 }

--- a/test/unit/NodeCompiler/CompileNodeToValueTest.php
+++ b/test/unit/NodeCompiler/CompileNodeToValueTest.php
@@ -310,4 +310,43 @@ class CompileNodeToValueTest extends \PHPUnit_Framework_TestCase
         $classInfo = $reflector->reflect('Bar\Bat');
         $this->assertSame('My\Awesome\Foo', $classInfo->getConstant('QUX'));
     }
+
+    public function testClassConstantResolutionFromParent()
+    {
+        $phpCode = '<?php
+        namespace Bar;
+
+        class Foo {
+            const BAR = "baz";
+        }
+        class Bat extends Foo {
+            private $property = self::BAR;
+        }
+        ';
+
+        $reflector = new ClassReflector(new StringSourceLocator($phpCode));
+        $classInfo = $reflector->reflect('Bar\Bat');
+        $this->assertSame('baz', $classInfo->getProperty('property')->getDefaultValue());
+    }
+
+
+    public function testClassConstantResolutionFromParentParent()
+    {
+        $phpCode = '<?php
+        namespace Bar;
+
+        class Foo {
+            const BAR = "baz";
+        }
+        class Bar extends Foo {}
+        class Bat extends Bar {
+            private $property = self::BAR;
+        }
+        ';
+
+        $reflector = new ClassReflector(new StringSourceLocator($phpCode));
+        $classInfo = $reflector->reflect('Bar\Bat');
+        $this->assertSame('baz', $classInfo->getProperty('property')->getDefaultValue());
+    }
+
 }


### PR DESCRIPTION
Class constant value referenced via `self` was not fetched properly when the constant is declared in parent class.