### PR TITLE
Failing test - constant from different class as default value

### DIFF
--- a/test/unit/NodeCompiler/CompileNodeToValueTest.php
+++ b/test/unit/NodeCompiler/CompileNodeToValueTest.php
@@ -349,4 +349,23 @@ class CompileNodeToValueTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('baz', $classInfo->getProperty('property')->getDefaultValue());
     }
 
+    public function testDifferentClassConstantAsDefaultValue()
+    {
+        $phpCode = '<?php
+        namespace Foo;
+
+        class Foo {
+            const BAR = "baz";
+        }
+
+        class Bar {
+            private $property = Foo::BAR;
+        }
+        ';
+
+        $reflector = new ClassReflector(new StringSourceLocator($phpCode));
+        $classInfo = $reflector->reflect('Foo\Bar');
+        $this->assertSame('baz', $classInfo->getProperty('property')->getDefaultValue());
+    }
+
 }


### PR DESCRIPTION
If property default value is class constant defined in different class, call `propertyRefl->getDefaultValue()` fails with `"Foo" could not be found in the located source`. 

It only happens when "Foo:BAR" is not referenced as FQN.

I didn't figure out how to fix it, so at least failing test case...