### PR TITLE
Constant default value failing test

### DIFF
--- a/src/NodeCompiler/CompileNodeToValue.php
+++ b/src/NodeCompiler/CompileNodeToValue.php
@@ -3,6 +3,7 @@
 namespace Roave\BetterReflection\NodeCompiler;
 
 use Roave\BetterReflection\Reflection\ReflectionClass;
+use Roave\BetterReflection\TypesFinder\FindTypeFromAst;
 use Roave\BetterReflection\TypesFinder\ResolveTypes;
 use phpDocumentor\Reflection\Types\ContextFactory;
 use PhpParser\Node;
@@ -105,6 +106,7 @@ class CompileNodeToValue
      * @param Node\Expr\ClassConstFetch $node
      * @param CompilerContext $context
      * @return string
+     * @throws \Roave\BetterReflection\Reflector\Exception\IdentifierNotFound
      */
     private function compileClassConstFetch(Node\Expr\ClassConstFetch $node, CompilerContext $context)
     {
@@ -128,7 +130,13 @@ class CompileNodeToValue
         }
 
         if (null === $classInfo) {
-            $classInfo = $context->getReflector()->reflect($className);
+            $classInfo = $context->getReflector()->reflect(
+                (new FindTypeFromAst())->__invoke(
+                    $className,
+                    $context->getSelf()->getLocatedSource(),
+                    $context->getSelf()->getNamespaceName()
+                )
+            );
         }
 
         /* @var ReflectionClass $classInfo */

--- a/test/unit/NodeCompiler/CompileNodeToValueTest.php
+++ b/test/unit/NodeCompiler/CompileNodeToValueTest.php
@@ -349,4 +349,23 @@ class CompileNodeToValueTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('baz', $classInfo->getProperty('property')->getDefaultValue());
     }
 
+    public function testDifferentClassConstantAsDefaultValue()
+    {
+        $phpCode = '<?php
+        namespace Foo;
+
+        class Foo {
+            const BAR = "baz";
+        }
+
+        class Bar {
+            private $property = Foo::BAR;
+        }
+        ';
+
+        $reflector = new ClassReflector(new StringSourceLocator($phpCode));
+        $classInfo = $reflector->reflect('Foo\Bar');
+        $this->assertSame('baz', $classInfo->getProperty('property')->getDefaultValue());
+    }
+
 }

--- a/test/unit/NodeCompiler/CompileNodeToValueTest.php
+++ b/test/unit/NodeCompiler/CompileNodeToValueTest.php
@@ -365,7 +365,7 @@ class CompileNodeToValueTest extends \PHPUnit_Framework_TestCase
 
         $reflector = new ClassReflector(new StringSourceLocator($phpCode));
         $classInfo = $reflector->reflect('Foo\Bar');
-        $this->assertSame('baz', $classInfo->getProperty('property')->getDefaultValue());
+        self::assertSame('baz', $classInfo->getProperty('property')->getDefaultValue());
     }
 
 }

--- a/test/unit/NodeCompiler/CompileNodeToValueTest.php
+++ b/test/unit/NodeCompiler/CompileNodeToValueTest.php
@@ -349,7 +349,7 @@ class CompileNodeToValueTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('baz', $classInfo->getProperty('property')->getDefaultValue());
     }
 
-    public function testDifferentClassConstantAsDefaultValue()
+    public function testDifferentClassConstantAsDefaultValueWhenInNamespace()
     {
         $phpCode = '<?php
         namespace Foo;
@@ -368,4 +368,20 @@ class CompileNodeToValueTest extends \PHPUnit_Framework_TestCase
         self::assertSame('baz', $classInfo->getProperty('property')->getDefaultValue());
     }
 
+    public function testDifferentClassConstantAsDefaultValueWhenNotInNamespace()
+    {
+        $phpCode = '<?php
+        class Foo {
+            const BAR = "baz";
+        }
+
+        class Bar {
+            private $property = Foo::BAR;
+        }
+        ';
+
+        $reflector = new ClassReflector(new StringSourceLocator($phpCode));
+        $classInfo = $reflector->reflect('Bar');
+        self::assertSame('baz', $classInfo->getProperty('property')->getDefaultValue());
+    }
 }


### PR DESCRIPTION
Building on PR #247 - fixes test from @janlanger where `ClassConstFetch` node could not be resolved as we were not looking up the full qualified class name. Add some additional code into `CompileNodeToValue` to resolve this using the `FindTypeFromAst`.