### PR TITLE
Ensure locateFunctionByName returns ?string always

### DIFF
--- a/src/SourceLocator/Type/AutoloadSourceLocator.php
+++ b/src/SourceLocator/Type/AutoloadSourceLocator.php
@@ -45,6 +45,7 @@ class AutoloadSourceLocator extends AbstractSourceLocator
      *
      * @param Identifier $identifier
      * @return string|null
+     * @throws \ReflectionException
      */
     private function attemptAutoloadForIdentifier(Identifier $identifier) : ?string
     {
@@ -74,6 +75,7 @@ class AutoloadSourceLocator extends AbstractSourceLocator
      *
      * @param string $className
      * @return string|null
+     * @throws \ReflectionException
      */
     private function locateClassByName(string $className)  : ?string
     {
@@ -105,6 +107,7 @@ class AutoloadSourceLocator extends AbstractSourceLocator
      *
      * @param string $functionName
      * @return string|null
+     * @throws \ReflectionException
      */
     private function locateFunctionByName(string $functionName) : ?string
     {
@@ -113,7 +116,13 @@ class AutoloadSourceLocator extends AbstractSourceLocator
         }
 
         $reflection = new \ReflectionFunction($functionName);
-        return $reflection->getFileName();
+        $reflectionFileName = $reflection->getFileName();
+
+        if (! is_string($reflectionFileName)) {
+            return null;
+        }
+
+        return $reflectionFileName;
     }
 
     /**

--- a/test/unit/SourceLocator/Type/AutoloadSourceLocatorTest.php
+++ b/test/unit/SourceLocator/Type/AutoloadSourceLocatorTest.php
@@ -177,4 +177,15 @@ class AutoloadSourceLocatorTest extends \PHPUnit_Framework_TestCase
                 ->locateIdentifier($this->getMockReflector(), new Identifier($className, new IdentifierType(IdentifierType::IDENTIFIER_CLASS)))
         );
     }
+
+    public function testReturnsNullWithInternalFunctions() : void
+    {
+        self::assertNull(
+            (new AutoloadSourceLocator())
+                ->locateIdentifier(
+                    $this->getMockReflector(),
+                    new Identifier('strlen', new IdentifierType(IdentifierType::IDENTIFIER_FUNCTION))
+                )
+        );
+    }
 }


### PR DESCRIPTION
Fixes #237 

Now that we have strict type declarations, I don't think an additional test is necessary - this is essentially a bugfix now IMO...