### PR TITLE
Added test cases for ?nullable and iterable types in PHP 7.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
         "php": "7.1.*",
         "nikic/php-parser": "^3.0.5",
         "phpdocumentor/reflection-docblock": "^3.1.1",
-        "phpdocumentor/type-resolver": "^0.2.1",
+        "phpdocumentor/type-resolver": "dev-master#88bdcb55 as 0.2.1",
         "zendframework/zend-code": "^3.1",
         "jeremeamia/superclosure": "^2.3",
         "roave/signature": "^1.0"

--- a/composer.json
+++ b/composer.json
@@ -5,8 +5,8 @@
     "require": {
         "php": "7.1.*",
         "nikic/php-parser": "^3.0.5",
-        "phpdocumentor/reflection-docblock": "^3.1.1",
-        "phpdocumentor/type-resolver": "dev-master#88bdcb55 as 0.2.1",
+        "phpdocumentor/reflection-docblock": "^3.2.0",
+        "phpdocumentor/type-resolver": "^0.4.0",
         "zendframework/zend-code": "^3.1",
         "jeremeamia/superclosure": "^2.3",
         "roave/signature": "^1.0"

--- a/src/Reflection/ReflectionParameter.php
+++ b/src/Reflection/ReflectionParameter.php
@@ -527,16 +527,17 @@ class ReflectionParameter implements \Reflector
     public function getClass() : ?ReflectionClass
     {
         $hint = $this->getTypeHint();
-        if (!($hint instanceof Types\Object_  || $hint instanceof Types\Self_)) {
-            return null;
-        }
 
         if ($hint instanceof Types\Self_) {
             return $this->getDeclaringClass();
         }
 
-        if ('parent' === $hint->getFqsen()->getName()) {
+        if ($hint instanceof Types\Parent_) {
             return $this->getDeclaringClass()->getParentClass();
+        }
+
+        if (! $hint instanceof Types\Object_) {
+            return null;
         }
 
         if (!$this->reflector instanceof ClassReflector) {

--- a/test/unit/TypesFinder/FindParameterTypeTest.php
+++ b/test/unit/TypesFinder/FindParameterTypeTest.php
@@ -28,6 +28,8 @@ class FindParameterTypeTest extends \PHPUnit_Framework_TestCase
             ['@param \stdClass $foo', 'foo', [Types\Object_::class]],
             ['@param int|int[]|int[][] $foo', 'foo', [Types\Integer::class, Types\Array_::class, Types\Array_::class]],
             ['', 'foo', []],
+            ['@param ?string $foo', 'foo', [Types\Nullable::class]],
+            ['@param iterable $foo', 'foo', [Types\Iterable_::class]],
         ];
     }
 

--- a/test/unit/TypesFinder/ResolveTypesTest.php
+++ b/test/unit/TypesFinder/ResolveTypesTest.php
@@ -16,14 +16,6 @@ class ResolveTypesTest extends \PHPUnit_Framework_TestCase
      */
     public function basicTypesToResolveProvider() : array
     {
-        $context = new Context(
-            'My\Space',
-            [
-                'Foo\Bar',
-                'Bat\Baz',
-            ]
-        );
-
         return [
             [['array'], [Types\Array_::class]],
             [['int[]'], [Types\Array_::class]],
@@ -33,6 +25,8 @@ class ResolveTypesTest extends \PHPUnit_Framework_TestCase
             [['bool'], [Types\Boolean::class]],
             [['boolean'], [Types\Boolean::class]],
             [['int', 'string', 'bool'], [Types\Integer::class, Types\String_::class, Types\Boolean::class]],
+            [['?string'], [Types\Nullable::class]],
+            [['iterable'], [Types\Iterable_::class]],
         ];
     }
 


### PR DESCRIPTION
Fixes #202 
Fixes #242 

Adds support for these new types, but TypesResolver needs a new release (that doesn't conflict with `phpdocumentor/reflection-docblock` - `phpdocumentor/reflection-docblock 3.1.1 requires phpdocumentor/type-resolver ^0.2.0 -> satisfiable by phpdocumentor/type-resolver[0.2, 0.2.1] but these conflict with your requirements or minimum-stability.`) before we can merge really :/