### PR TITLE
[failing-test] Namespaced Trait fails to be resolved

### DIFF
--- a/test/unit/Fixture/NamespacedTraitFixture.php
+++ b/test/unit/Fixture/NamespacedTraitFixture.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Namespaced
+{
+    trait TraitFixtureTrait {
+
+    }
+
+    class ClassFixture {
+        use TraitFixtureTrait;
+    }
+}

--- a/test/unit/Fixture/NamespacedTraitFixture.php
+++ b/test/unit/Fixture/NamespacedTraitFixture.php
@@ -2,11 +2,16 @@
 
 namespace Namespaced
 {
-    trait TraitFixtureTrait {
+    trait TraitFixtureTraitA {
 
     }
 
     class ClassFixture {
-        use TraitFixtureTrait;
+        use TraitFixtureTraitA;
+    }
+
+    trait TraitFixtureTraitB
+    {
+        use TraitFixtureTraitA;
     }
 }

--- a/test/unit/Fixture/NamespacedTraitFixture.php
+++ b/test/unit/Fixture/NamespacedTraitFixture.php
@@ -1,17 +1,20 @@
 <?php
 
-namespace Namespaced
+namespace Namespaced;
+
+trait TraitFixtureTraitA
 {
-    trait TraitFixtureTraitA {
 
-    }
+}
 
-    class ClassFixture {
-        use TraitFixtureTraitA;
-    }
+// Trait in a Class
+class ClassFixture
+{
+    use TraitFixtureTraitA;
+}
 
-    trait TraitFixtureTraitB
-    {
-        use TraitFixtureTraitA;
-    }
+// Trait in a Trait
+trait TraitFixtureTraitB
+{
+    use TraitFixtureTraitA;
 }

--- a/test/unit/Fixture/TraitFixture.php
+++ b/test/unit/Fixture/TraitFixture.php
@@ -45,3 +45,9 @@ class TraitFixtureD
         TraitFixtureTraitD1::foo insteadof TraitFixtureTraitD2;
     }
 }
+
+// Trait in a Trait
+trait TraitFixtureTraitE
+{
+    use TraitFixtureTraitA;
+}

--- a/test/unit/Reflection/ReflectionClassTest.php
+++ b/test/unit/Reflection/ReflectionClassTest.php
@@ -491,6 +491,17 @@ class ReflectionClassTest extends \PHPUnit_Framework_TestCase
         self::assertCount(1, $traits);
     }
 
+    public function testGetTraitsOfATraitInANamespace() : void
+    {
+        $sourceLocator = new SingleFileSourceLocator(__DIR__ . '/../Fixture/NamespacedTraitFixture.php');
+        $reflector = new ClassReflector($sourceLocator);
+
+        $traitInfo = $reflector->reflect('Namespaced\TraitFixtureTraitB');
+
+        $traits = $traitInfo->getTraits();
+        self::assertCount(1, $traits);
+    }
+
     public function testGetTraitsReturnsEmptyArrayWhenNoTraitsUsed() : void
     {
         $sourceLocator = new SingleFileSourceLocator(__DIR__ . '/../Fixture/TraitFixture.php');

--- a/test/unit/Reflection/ReflectionClassTest.php
+++ b/test/unit/Reflection/ReflectionClassTest.php
@@ -35,6 +35,7 @@ use PhpParser\Node\Name;
 use Roave\BetterReflection\Fixture\StaticPropertyGetSet;
 use PhpParser\Node\Stmt\Class_;
 use Roave\BetterReflectionTest\FixtureOther\AnotherClass;
+use TraitFixtureTraitA;
 
 /**
  * @covers \Roave\BetterReflection\Reflection\ReflectionClass
@@ -466,6 +467,21 @@ class ReflectionClassTest extends \PHPUnit_Framework_TestCase
         self::assertCount(1, $traits);
         self::assertInstanceOf(ReflectionClass::class, $traits[0]);
         self::assertTrue($traits[0]->isTrait());
+    }
+
+    public function testGetTraitsOfATrait() : void
+    {
+        $sourceLocator = new SingleFileSourceLocator(__DIR__ . '/../Fixture/TraitFixture.php');
+        $reflector = new ClassReflector($sourceLocator);
+
+        $traitInfo = $reflector->reflect('TraitFixtureTraitE');
+        self::assertTrue($traitInfo->isTrait());
+
+        $traits = $traitInfo->getTraits();
+        self::assertCount(1, $traits);
+        self::assertInstanceOf(ReflectionClass::class, $traits[0]);
+        self::assertTrue($traits[0]->isTrait());
+        self::assertSame(TraitFixtureTraitA::class, $traits[0]->getName());
     }
 
     public function testGetTraitsReturnsEmptyArrayWhenNoTraitsUsed() : void

--- a/test/unit/Reflection/ReflectionClassTest.php
+++ b/test/unit/Reflection/ReflectionClassTest.php
@@ -35,7 +35,6 @@ use PhpParser\Node\Name;
 use Roave\BetterReflection\Fixture\StaticPropertyGetSet;
 use PhpParser\Node\Stmt\Class_;
 use Roave\BetterReflectionTest\FixtureOther\AnotherClass;
-use TraitFixtureTraitA;
 
 /**
  * @covers \Roave\BetterReflection\Reflection\ReflectionClass
@@ -479,9 +478,17 @@ class ReflectionClassTest extends \PHPUnit_Framework_TestCase
 
         $traits = $traitInfo->getTraits();
         self::assertCount(1, $traits);
-        self::assertInstanceOf(ReflectionClass::class, $traits[0]);
-        self::assertTrue($traits[0]->isTrait());
-        self::assertSame(TraitFixtureTraitA::class, $traits[0]->getName());
+    }
+
+    public function testGetTraitsInANamespace() : void
+    {
+        $sourceLocator = new SingleFileSourceLocator(__DIR__ . '/../Fixture/NamespacedTraitFixture.php');
+        $reflector = new ClassReflector($sourceLocator);
+
+        $traitInfo = $reflector->reflect('Namespaced\ClassFixture');
+
+        $traits = $traitInfo->getTraits();
+        self::assertCount(1, $traits);
     }
 
     public function testGetTraitsReturnsEmptyArrayWhenNoTraitsUsed() : void


### PR DESCRIPTION
Now sure about reasons, just found out the specific fail use case.

### Works

```php
$class->getTraits();
$trait->getTraits();
```

### Fails

```php
$namespacedClass->getTraits();
$namespacedTrait->getTraits();
```

Tests fail here: https://github.com/Roave/BetterReflection/pull/274/files#diff-b01e2d3cb81300e2f9b0259a0309f0a3R501


[See fail line in Travis](https://travis-ci.org/Roave/BetterReflection/jobs/232214382#L278)


![image](https://cloud.githubusercontent.com/assets/924196/26038035/d0db7346-38ff-11e7-8acb-b7e38d0da304.png)
