### PR TITLE
[NodeCompiler] add support for __DIR__

### DIFF
--- a/src/NodeCompiler/CompileNodeToValue.php
+++ b/src/NodeCompiler/CompileNodeToValue.php
@@ -270,8 +270,7 @@ class CompileNodeToValue
      */
     private function compileDirConstant(Node\Scalar\MagicConst\Dir $node, CompilerContext $context): string
     {
-        $fileName = $context->getSelf()->getLocatedSource()->getFileName();
-        return dirname(realpath($fileName));
+        return dirname(realpath($context->getFileName()));
     }
 
     private function getConstantDeclaringClass(string $constantName, ReflectionClass $class) : ?ReflectionClass

--- a/src/NodeCompiler/CompileNodeToValue.php
+++ b/src/NodeCompiler/CompileNodeToValue.php
@@ -47,6 +47,10 @@ class CompileNodeToValue
             return $this->compileBinaryOperator($node, $context);
         }
 
+        if ($node instanceof Node\Scalar\MagicConst\Dir) {
+            return '__DIR__';
+        }
+
         throw new Exception\UnableToCompileNode('Unable to compile expression: ' . get_class($node));
     }
 

--- a/src/NodeCompiler/CompileNodeToValue.php
+++ b/src/NodeCompiler/CompileNodeToValue.php
@@ -48,7 +48,7 @@ class CompileNodeToValue
         }
 
         if ($node instanceof Node\Scalar\MagicConst\Dir) {
-            return '__DIR__';
+            return $this->compileDirConstant($node, $context);
         }
 
         throw new Exception\UnableToCompileNode('Unable to compile expression: ' . get_class($node));
@@ -259,6 +259,19 @@ class CompileNodeToValue
         }
 
         throw new Exception\UnableToCompileNode('Unable to compile binary operator: ' . get_class($node));
+    }
+
+    /**
+     * Compile a __DIR__ node
+     *
+     * @param Node\Scalar\MagicConst\Dir $node
+     * @param CompilerContext $context
+     * @return string
+     */
+    private function compileDirConstant(Node\Scalar\MagicConst\Dir $node, CompilerContext $context): string
+    {
+        $fileName = $context->getSelf()->getLocatedSource()->getFileName();
+        return dirname(realpath($fileName));
     }
 
     private function getConstantDeclaringClass(string $constantName, ReflectionClass $class) : ?ReflectionClass

--- a/src/NodeCompiler/CompilerContext.php
+++ b/src/NodeCompiler/CompilerContext.php
@@ -48,4 +48,9 @@ class CompilerContext
     {
         return $this->reflector;
     }
+
+    public function getFileName() : string
+    {
+        return $this->getSelf()->getFileName();
+    }
 }

--- a/test/unit/Fixture/ExampleClass.php
+++ b/test/unit/Fixture/ExampleClass.php
@@ -22,7 +22,7 @@ namespace Roave\BetterReflectionTest\Fixture {
         /**
          * @var string
          */
-        public $publicProperty;
+        public $publicProperty = __DIR__;
 
         public static $publicStaticProperty;
 

--- a/test/unit/NodeCompiler/CompileNodeToValueTest.php
+++ b/test/unit/NodeCompiler/CompileNodeToValueTest.php
@@ -129,6 +129,7 @@ class CompileNodeToValueTest extends \PHPUnit_Framework_TestCase
             ['3 <= 2', false],
             ['PHP_INT_MAX', PHP_INT_MAX],
             ['PHP_EOL', PHP_EOL],
+            ['__DIR__', '__DIR__'],
         ];
     }
 

--- a/test/unit/NodeCompiler/CompileNodeToValueTest.php
+++ b/test/unit/NodeCompiler/CompileNodeToValueTest.php
@@ -129,7 +129,7 @@ class CompileNodeToValueTest extends \PHPUnit_Framework_TestCase
             ['3 <= 2', false],
             ['PHP_INT_MAX', PHP_INT_MAX],
             ['PHP_EOL', PHP_EOL],
-            ['__DIR__', '__DIR__'],
+            ['__DIR__', __DIR__],
         ];
     }
 

--- a/test/unit/NodeCompiler/CompileNodeToValueTest.php
+++ b/test/unit/NodeCompiler/CompileNodeToValueTest.php
@@ -129,7 +129,6 @@ class CompileNodeToValueTest extends \PHPUnit_Framework_TestCase
             ['3 <= 2', false],
             ['PHP_INT_MAX', PHP_INT_MAX],
             ['PHP_EOL', PHP_EOL],
-            ['__DIR__', __DIR__],
         ];
     }
 

--- a/test/unit/NodeCompiler/CompilerContextTest.php
+++ b/test/unit/NodeCompiler/CompilerContextTest.php
@@ -4,6 +4,7 @@ namespace Roave\BetterReflectionTest\NodeCompiler;
 
 use Roave\BetterReflection\NodeCompiler\CompilerContext;
 use Roave\BetterReflection\Reflector\ClassReflector;
+use Roave\BetterReflection\SourceLocator\Type\SingleFileSourceLocator;
 use Roave\BetterReflection\SourceLocator\Type\StringSourceLocator;
 
 /**
@@ -34,5 +35,29 @@ class CompilerContextTest extends \PHPUnit_Framework_TestCase
         self::assertTrue($context->hasSelf());
         self::assertSame($reflector, $context->getReflector());
         self::assertSame($self, $context->getSelf());
+    }
+
+    public function testGetFileName() : void
+    {
+        $filename = __DIR__ . '/CompilerContextTest.php';
+
+        $reflector = new ClassReflector(new SingleFileSourceLocator($filename));
+        $self = $reflector->reflect(CompilerContextTest::class);
+
+        $context = new CompilerContext($reflector, $self);
+
+        self::assertSame($filename, $context->getFileName());
+    }
+
+    public function testGetFileNameWithoutSelf() : void
+    {
+        $filename = __DIR__ . '/CompilerContextTest.php';
+
+        $reflector = new ClassReflector(new SingleFileSourceLocator($filename));
+        $context = new CompilerContext($reflector, null);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('The current context does not have a class for self');
+        $context->getFileName();
     }
 }

--- a/test/unit/Reflection/ReflectionClassTest.php
+++ b/test/unit/Reflection/ReflectionClassTest.php
@@ -255,6 +255,7 @@ class ReflectionClassTest extends \PHPUnit_Framework_TestCase
 
         self::assertInstanceOf(ReflectionProperty::class, $property);
         self::assertSame('publicProperty', $property->getName());
+        self::assertStringEndsWith('test/unit/Fixture', $property->getDefaultValue());
     }
 
     public function testGetFileName() : void


### PR DESCRIPTION
Parser is failing at the moment on misisng NodeCompiler for `__DIR__`:

```php
class ConstantInClass
{
    /**
     * @var string
     */
   protected const COMPOSED_WITH_DIR = __DIR__ . '/here';
}
```

This PR fixes it. Test included.