### PR TITLE
[PHP 7.1] Add support for ReflectionClassConstant (#281)

### DIFF
--- a/src/Reflection/Adapter/ReflectionClass.php
+++ b/src/Reflection/Adapter/ReflectionClass.php
@@ -198,6 +198,26 @@ class ReflectionClass extends CoreReflectionClass
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function getReflectionConstant($name)
+    {
+        return new ReflectionClassConstant(
+            $this->betterReflectionClass->getReflectionConstant($name)
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getReflectionConstants()
+    {
+        return array_map(function ($betterConstant) {
+            return new ReflectionClassConstant($betterConstant);
+        }, $this->betterReflectionClass->getReflectionConstants());
+    }
+
+    /**
      * {@inheritDoc}
      */
     public function getInterfaces()

--- a/src/Reflection/Adapter/ReflectionClassConstant.php
+++ b/src/Reflection/Adapter/ReflectionClassConstant.php
@@ -7,13 +7,16 @@ use Roave\BetterReflection\Reflection\ReflectionClassConstant as BetterReflectio
 
 class ReflectionClassConstant extends CoreReflectionClassConstant
 {
+
+    /**
+     * @var BetterReflectionClassConstant
+     */
     private $betterClassConstant;
 
     public function __construct(BetterReflectionClassConstant $betterClassConstant)
     {
         $this->betterClassConstant = $betterClassConstant;
     }
-
 
     /**
      * Get the name of the reflection (e.g. if this is a ReflectionClass this

--- a/src/Reflection/Adapter/ReflectionClassConstant.php
+++ b/src/Reflection/Adapter/ReflectionClassConstant.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace Roave\BetterReflection\Reflection\Adapter;
+
+use \ReflectionClassConstant as CoreReflectionClassConstant;
+use Roave\BetterReflection\Reflection\ReflectionClassConstant as BetterReflectionClassConstant;
+
+class ReflectionClassConstant extends CoreReflectionClassConstant
+{
+    private $betterClassConstant;
+
+    public function __construct(BetterReflectionClassConstant $betterClassConstant)
+    {
+        $this->betterClassConstant = $betterClassConstant;
+    }
+
+
+    /**
+     * Get the name of the reflection (e.g. if this is a ReflectionClass this
+     * will be the class name).
+     *
+     * @return string
+     */
+    public function getName() : string
+    {
+        return $this->betterClassConstant->getName();
+    }
+
+    /**
+     * Returns constant value
+     *
+     * @return mixed
+     */
+    public function getValue()
+    {
+        return $this->betterClassConstant->getValue();
+    }
+
+    /**
+     * Constant is public
+     *
+     * @return bool
+     */
+    public function isPublic() : bool
+    {
+        return $this->betterClassConstant->isPublic();
+    }
+
+    /**
+     * Cosnstant is private
+     *
+     * @return bool
+     */
+    public function isPrivate() : bool
+    {
+        return $this->betterClassConstant->isPrivate();
+    }
+
+    /**
+     * Constant is protected
+     *
+     * @return bool
+     */
+    public function isProtected() : bool
+    {
+        return $this->betterClassConstant->isProtected();
+    }
+
+    /**
+     * Returns a bitfield of the access modifiers for this constant
+     *
+     * @return int
+     */
+    public function getModifiers() : int
+    {
+        return $this->betterClassConstant->getModifiers();
+    }
+
+    /**
+     * Get the declaring class
+     *
+     * @return ReflectionClass
+     */
+    public function getDeclaringClass() : ReflectionClass
+    {
+        return new ReflectionClass($this->betterClassConstant->getDeclaringClass());
+    }
+
+    /**
+     * Returns the doc comment for this constant
+     *
+     * @return string
+     */
+    public function getDocComment() : string
+    {
+        return $this->betterClassConstant->getDocComment();
+    }
+
+    /**
+     * To string
+     *
+     * @link http://php.net/manual/en/reflector.tostring.php
+     * @return string
+     * @since 5.0
+     */
+    public function __toString()
+    {
+        return $this->betterClassConstant->__toString();
+    }
+}

--- a/src/Reflection/ReflectionClass.php
+++ b/src/Reflection/ReflectionClass.php
@@ -504,13 +504,7 @@ class ReflectionClass implements Reflection, \Reflector
      */
     public function getReflectionConstant(string $name) : ?ReflectionClassConstant
     {
-        $constants = $this->getReflectionConstants();
-
-        if (!array_key_exists($name, $constants)) {
-            return null;
-        }
-
-        return $constants[$name];
+        return $this->getReflectionConstants()[$name] ?? null;
     }
 
     /**
@@ -518,7 +512,7 @@ class ReflectionClass implements Reflection, \Reflector
      *
      * @param array $accumulator
      * @param Node\Stmt $stmt
-     * @return array
+     * @return ReflectionClassConstant[]
      */
     private function processReflectionConstants(array $accumulator, Node\Stmt $stmt) : array
     {
@@ -537,15 +531,15 @@ class ReflectionClass implements Reflection, \Reflector
      */
     public function getReflectionConstants() : array
     {
-        if (null === $this->cachedReflectionConstants) {
-            $this->cachedReflectionConstants = array_reduce(
-                $this->node->stmts,
-                [$this, 'processReflectionConstants'],
-                []
-            );
+        if (null !== $this->cachedReflectionConstants) {
+            return $this->cachedReflectionConstants;
         }
 
-        return $this->cachedReflectionConstants;
+        return $this->cachedReflectionConstants = array_reduce(
+            $this->node->stmts,
+            [$this, 'processReflectionConstants'],
+            []
+        );
     }
 
     /**

--- a/src/Reflection/ReflectionClass.php
+++ b/src/Reflection/ReflectionClass.php
@@ -136,14 +136,13 @@ class ReflectionClass implements Reflection, \Reflector
         $buildConstants = function (array $items, $indentLevel = 4) {
             $str = '';
 
-            foreach ($items as $name => $value) {
+            /**
+             * @var string $name
+             * @var ReflectionClassConstant $const
+             */
+            foreach ($items as $name => $const) {
                 $str .= "\n" . str_repeat(' ', $indentLevel);
-                $str .= sprintf(
-                    'Constant [ %s %s ] { %s }',
-                    gettype($value),
-                    $name,
-                    $value
-                );
+                $str .= trim((string)$const);
             }
 
             return $str;
@@ -160,8 +159,8 @@ class ReflectionClass implements Reflection, \Reflector
             $this->getFileName(),
             $this->getStartLine(),
             $this->getEndLine(),
-            count($this->getConstants()),
-            $buildConstants($this->getConstants()),
+            count($this->getReflectionConstants()),
+            $buildConstants($this->getReflectionConstants()),
             count($staticProperties),
             $buildString($staticProperties),
             count($staticMethods),

--- a/src/Reflection/ReflectionClass.php
+++ b/src/Reflection/ReflectionClass.php
@@ -5,7 +5,6 @@ namespace Roave\BetterReflection\Reflection;
 use phpDocumentor\Reflection\Types\Object_;
 use PhpParser\Node;
 use PhpParser\Node\Stmt\Class_ as ClassNode;
-use PhpParser\Node\Stmt\ClassConst;
 use PhpParser\Node\Stmt\ClassConst as ConstNode;
 use PhpParser\Node\Stmt\ClassLike as ClassLikeNode;
 use PhpParser\Node\Stmt\ClassMethod;
@@ -523,7 +522,7 @@ class ReflectionClass implements Reflection, \Reflector
      */
     private function processReflectionConstants(array $accumulator, Node\Stmt $stmt) : array
     {
-        if ($stmt instanceof ClassConst) {
+        if ($stmt instanceof ConstNode) {
             $const = ReflectionClassConstant::createFromNode($this->reflector, $stmt, $this);
             $accumulator[$const->getName()] = $const;
         }

--- a/src/Reflection/ReflectionClass.php
+++ b/src/Reflection/ReflectionClass.php
@@ -525,14 +525,7 @@ class ReflectionClass implements Reflection, \Reflector
     private function processReflectionConstants(array $accumulator, Node\Stmt $stmt) : array
     {
         if ($stmt instanceof ClassConst) {
-            $const = ReflectionClassConstant::createFromConstFlagsNameAndValue(
-                $stmt->flags,
-                $stmt->consts[0]->name,
-                (new CompileNodeToValue())->__invoke(
-                    $stmt->consts[0]->value,
-                    new CompilerContext($this->reflector, $this)
-                )
-            );
+            $const = ReflectionClassConstant::createFromNode($this->reflector, $stmt, $this);
             $accumulator[$const->getName()] = $const;
         }
 

--- a/src/Reflection/ReflectionClass.php
+++ b/src/Reflection/ReflectionClass.php
@@ -508,23 +508,6 @@ class ReflectionClass implements Reflection, \Reflector
     }
 
     /**
-     * Returns array of constants for this class
-     *
-     * @param array $accumulator
-     * @param Node\Stmt $stmt
-     * @return ReflectionClassConstant[]
-     */
-    private function processReflectionConstants(array $accumulator, Node\Stmt $stmt) : array
-    {
-        if ($stmt instanceof ConstNode) {
-            $const = ReflectionClassConstant::createFromNode($this->reflector, $stmt, $this);
-            $accumulator[$const->getName()] = $const;
-        }
-
-        return $accumulator;
-    }
-
-    /**
      * Get an array reflection object of the defined constants in this class.
      *
      * @return ReflectionClassConstant[]
@@ -537,7 +520,14 @@ class ReflectionClass implements Reflection, \Reflector
 
         return $this->cachedReflectionConstants = array_reduce(
             $this->node->stmts,
-            [$this, 'processReflectionConstants'],
+            function (array $accumulator, Node\Stmt $stmt) : array {
+                if ($stmt instanceof ConstNode) {
+                    $const = ReflectionClassConstant::createFromNode($this->reflector, $stmt, $this);
+                    $accumulator[$const->getName()] = $const;
+                }
+
+                return $accumulator;
+            },
             []
         );
     }

--- a/src/Reflection/ReflectionClassConstant.php
+++ b/src/Reflection/ReflectionClassConstant.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace Roave\BetterReflection\Reflection;
+
+use PhpParser\Node\Stmt\Class_;
+
+class ReflectionClassConstant implements \Reflector
+{
+
+    private $name;
+
+    private $value;
+
+    private $flags;
+
+    private function __construct()
+    {
+    }
+
+    /**
+     * Create a reflection of a class's constant by it's flags, name and value
+     *
+     * @param int $flags
+     * @param string $name
+     * @param null $value
+     * @return ReflectionClassConstant
+     */
+    public static function createFromConstFlagsNameAndValue(int $flags, string $name, $value = null)
+    {
+        $ref = new self();
+        $ref->flags = $flags === 0 ? Class_::MODIFIER_PUBLIC : $flags;
+        $ref->name = $name;
+        $ref->value = $value;
+        return $ref;
+    }
+
+    /**
+     * Get the name of the reflection (e.g. if this is a ReflectionClass this
+     * will be the class name).
+     *
+     * @return string
+     */
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    /**
+     * Returns constant value
+     *
+     * @return mixed
+     */
+    public function getValue()
+    {
+        return $this->value;
+    }
+
+    /**
+     * Constant is public
+     *
+     * @return bool
+     */
+    public function isPublic()
+    {
+        return (bool)($this->flags & Class_::MODIFIER_PUBLIC);
+    }
+
+    /**
+     * Cosnstant is private
+     *
+     * @return bool
+     */
+    public function isPrivate()
+    {
+        return (bool)($this->flags & Class_::MODIFIER_PRIVATE);
+    }
+
+    /**
+     * Constant is protected
+     *
+     * @return bool
+     */
+    public function isProtected()
+    {
+        return (bool)($this->flags & Class_::MODIFIER_PROTECTED);
+    }
+
+    private function getVisibility()
+    {
+        if ($this->isPublic()) {
+            return '<public>';
+        } elseif ($this->isPrivate()) {
+            return '<private>';
+        } elseif ($this->isProtected()) {
+            return '<protected>';
+        }
+        return '<unknown>';
+    }
+
+    /**
+     * To string
+     *
+     * @link http://php.net/manual/en/reflector.tostring.php
+     * @return string
+     * @since 5.0
+     */
+    public function __toString()
+    {
+        return sprintf(
+            '%s const %s = %s',
+            $this->getVisibility(),
+            $this->getName(),
+            $this->getValue()
+        );
+    }
+
+    /**
+     * Exports
+     *
+     * @link http://php.net/manual/en/reflector.export.php
+     * @return string
+     * @since 5.0
+     */
+    public static function export()
+    {
+        throw new \Exception('Unable to export statically');
+    }
+}

--- a/src/Reflection/ReflectionClassConstant.php
+++ b/src/Reflection/ReflectionClassConstant.php
@@ -176,11 +176,14 @@ class ReflectionClassConstant implements \Reflector
      */
     public function __toString()
     {
+        $value = $this->getValue();
+
         return sprintf(
-            'Constant [ %s %s ] { %s }' . PHP_EOL,
+            'Constant [ %s %s %s ] { %s }' . PHP_EOL,
             $this->getVisibility(),
+            gettype($value),
             $this->getName(),
-            $this->getValue()
+            $value
         );
     }
 

--- a/src/Reflection/ReflectionClassConstant.php
+++ b/src/Reflection/ReflectionClassConstant.php
@@ -97,7 +97,7 @@ class ReflectionClassConstant implements \Reflector
      */
     public function isPublic() : bool
     {
-        return (bool)($this->getModifiers() & Class_::MODIFIER_PUBLIC);
+        return $this->node->isPublic();
     }
 
     /**
@@ -107,7 +107,7 @@ class ReflectionClassConstant implements \Reflector
      */
     public function isPrivate() : bool
     {
-        return (bool)($this->getModifiers() & Class_::MODIFIER_PRIVATE);
+        return $this->node->isPrivate();
     }
 
     /**
@@ -117,7 +117,7 @@ class ReflectionClassConstant implements \Reflector
      */
     public function isProtected() : bool
     {
-        return (bool)($this->getModifiers() & Class_::MODIFIER_PROTECTED);
+        return $this->node->isProtected();
     }
 
     /**
@@ -127,7 +127,11 @@ class ReflectionClassConstant implements \Reflector
      */
     public function getModifiers() : int
     {
-        return $this->node->flags === 0 ? Class_::MODIFIER_PUBLIC : $this->node->flags;
+        $val = 0;
+        $val += $this->isPublic() ? \ReflectionProperty::IS_PUBLIC : 0;
+        $val += $this->isProtected() ? \ReflectionProperty::IS_PROTECTED : 0;
+        $val += $this->isPrivate() ? \ReflectionProperty::IS_PRIVATE : 0;
+        return $val;
     }
 
     /**

--- a/src/Reflection/ReflectionClassConstant.php
+++ b/src/Reflection/ReflectionClassConstant.php
@@ -96,15 +96,15 @@ class ReflectionClassConstant implements \Reflector
     private function getVisibility()
     {
         if ($this->isPublic()) {
-            return '<public>';
+            return 'public';
         }
         if ($this->isPrivate()) {
-            return '<private>';
+            return 'private';
         }
         if ($this->isProtected()) {
-            return '<protected>';
+            return 'protected';
         }
-        return '<unknown>';
+        return '';
     }
 
     /**
@@ -117,7 +117,7 @@ class ReflectionClassConstant implements \Reflector
     public function __toString()
     {
         return sprintf(
-            '%s const %s = %s',
+            'Constant [ %s %s ] { %s }' . PHP_EOL,
             $this->getVisibility(),
             $this->getName(),
             $this->getValue()

--- a/src/Reflection/ReflectionClassConstant.php
+++ b/src/Reflection/ReflectionClassConstant.php
@@ -154,18 +154,21 @@ class ReflectionClassConstant implements \Reflector
         return GetFirstDocComment::forNode($this->node);
     }
 
-    private function getVisibility()
+    /**
+     * Returns the constant visibility
+     *
+     * @return string
+     */
+    private function getVisibility() : string
     {
-        if ($this->isPublic()) {
-            return 'public';
-        }
         if ($this->isPrivate()) {
             return 'private';
         }
         if ($this->isProtected()) {
             return 'protected';
         }
-        return '';
+        // default visibility always is public
+        return 'public';
     }
 
     /**

--- a/src/Reflection/ReflectionClassConstant.php
+++ b/src/Reflection/ReflectionClassConstant.php
@@ -6,11 +6,19 @@ use PhpParser\Node\Stmt\Class_;
 
 class ReflectionClassConstant implements \Reflector
 {
-
+    /**
+     * @var string Name of constant
+     */
     private $name;
 
+    /**
+     * @var mixed Value of constant
+     */
     private $value;
 
+    /**
+     * @var int Constant visibility flags
+     */
     private $flags;
 
     private function __construct()
@@ -22,10 +30,10 @@ class ReflectionClassConstant implements \Reflector
      *
      * @param int $flags
      * @param string $name
-     * @param null $value
+     * @param mixed $value
      * @return ReflectionClassConstant
      */
-    public static function createFromConstFlagsNameAndValue(int $flags, string $name, $value = null)
+    public static function createFromConstFlagsNameAndValue(int $flags, string $name, $value) : self
     {
         $ref = new self();
         $ref->flags = $flags === 0 ? Class_::MODIFIER_PUBLIC : $flags;
@@ -40,7 +48,7 @@ class ReflectionClassConstant implements \Reflector
      *
      * @return string
      */
-    public function getName(): string
+    public function getName() : string
     {
         return $this->name;
     }
@@ -60,7 +68,7 @@ class ReflectionClassConstant implements \Reflector
      *
      * @return bool
      */
-    public function isPublic()
+    public function isPublic() : bool
     {
         return (bool)($this->flags & Class_::MODIFIER_PUBLIC);
     }
@@ -70,7 +78,7 @@ class ReflectionClassConstant implements \Reflector
      *
      * @return bool
      */
-    public function isPrivate()
+    public function isPrivate() : bool
     {
         return (bool)($this->flags & Class_::MODIFIER_PRIVATE);
     }
@@ -80,7 +88,7 @@ class ReflectionClassConstant implements \Reflector
      *
      * @return bool
      */
-    public function isProtected()
+    public function isProtected() : bool
     {
         return (bool)($this->flags & Class_::MODIFIER_PROTECTED);
     }
@@ -89,9 +97,11 @@ class ReflectionClassConstant implements \Reflector
     {
         if ($this->isPublic()) {
             return '<public>';
-        } elseif ($this->isPrivate()) {
+        }
+        if ($this->isPrivate()) {
             return '<private>';
-        } elseif ($this->isProtected()) {
+        }
+        if ($this->isProtected()) {
             return '<protected>';
         }
         return '<unknown>';

--- a/src/Reflection/ReflectionClassConstant.php
+++ b/src/Reflection/ReflectionClassConstant.php
@@ -3,42 +3,59 @@
 namespace Roave\BetterReflection\Reflection;
 
 use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\ClassConst;
+use Roave\BetterReflection\NodeCompiler\CompileNodeToValue;
+use Roave\BetterReflection\NodeCompiler\CompilerContext;
+use Roave\BetterReflection\Reflector\Reflector;
 
 class ReflectionClassConstant implements \Reflector
 {
-    /**
-     * @var string Name of constant
-     */
-    private $name;
 
     /**
-     * @var mixed Value of constant
+     * @var bool value of const was cached?
+     */
+    private $valueCached = false;
+
+    /**
+     * @var mixed const value
      */
     private $value;
 
     /**
-     * @var int Constant visibility flags
+     * @var
      */
-    private $flags;
+    private $reflector;
+    /**
+     * @var ReflectionClass Constant owner
+     */
+    private $owner;
+
+    /**
+     * @var ClassConst
+     */
+    private $node;
 
     private function __construct()
     {
     }
 
     /**
-     * Create a reflection of a class's constant by it's flags, name and value
+     * Create a reflection of a class's constant by Const Node
      *
-     * @param int $flags
-     * @param string $name
-     * @param mixed $value
+     * @param Reflector $reflector
+     * @param ClassConst $node
+     * @param ReflectionClass $owner
      * @return ReflectionClassConstant
      */
-    public static function createFromConstFlagsNameAndValue(int $flags, string $name, $value) : self
-    {
+    public static function createFromNode(
+        Reflector $reflector,
+        ClassConst $node,
+        ReflectionClass $owner
+    ) : self {
         $ref = new self();
-        $ref->flags = $flags === 0 ? Class_::MODIFIER_PUBLIC : $flags;
-        $ref->name = $name;
-        $ref->value = $value;
+        $ref->node = $node;
+        $ref->owner = $owner;
+        $ref->reflector = $reflector;
         return $ref;
     }
 
@@ -50,7 +67,7 @@ class ReflectionClassConstant implements \Reflector
      */
     public function getName() : string
     {
-        return $this->name;
+        return $this->node->consts[0]->name;
     }
 
     /**
@@ -60,6 +77,13 @@ class ReflectionClassConstant implements \Reflector
      */
     public function getValue()
     {
+        if (false === $this->valueCached) {
+            $this->value = (new CompileNodeToValue())->__invoke(
+                $this->node->consts[0]->value,
+                new CompilerContext($this->reflector, $this->getDeclaringClass())
+            );
+        }
+
         return $this->value;
     }
 
@@ -70,7 +94,7 @@ class ReflectionClassConstant implements \Reflector
      */
     public function isPublic() : bool
     {
-        return (bool)($this->flags & Class_::MODIFIER_PUBLIC);
+        return (bool)($this->getModifiers() & Class_::MODIFIER_PUBLIC);
     }
 
     /**
@@ -80,7 +104,7 @@ class ReflectionClassConstant implements \Reflector
      */
     public function isPrivate() : bool
     {
-        return (bool)($this->flags & Class_::MODIFIER_PRIVATE);
+        return (bool)($this->getModifiers() & Class_::MODIFIER_PRIVATE);
     }
 
     /**
@@ -90,7 +114,43 @@ class ReflectionClassConstant implements \Reflector
      */
     public function isProtected() : bool
     {
-        return (bool)($this->flags & Class_::MODIFIER_PROTECTED);
+        return (bool)($this->getModifiers() & Class_::MODIFIER_PROTECTED);
+    }
+
+    /**
+     * Returns a bitfield of the access modifiers for this constant
+     *
+     * @return int
+     */
+    public function getModifiers() : int
+    {
+        return $this->node->flags === 0 ? Class_::MODIFIER_PUBLIC : $this->node->flags;
+    }
+
+    /**
+     * Get the declaring class
+     *
+     * @return ReflectionClass
+     */
+    public function getDeclaringClass() : ReflectionClass
+    {
+        return $this->owner;
+    }
+
+    /**
+     * Returns the doc comment for this constant
+     *
+     * @return string
+     */
+    public function getDocComment() : string
+    {
+        if (!$this->node->hasAttribute('comments')) {
+            return '';
+        }
+
+        /* @var \PhpParser\Comment\Doc $comment */
+        $comment = $this->node->getAttribute('comments')[0];
+        return $comment->getReformattedText();
     }
 
     private function getVisibility()

--- a/src/Reflection/ReflectionClassConstant.php
+++ b/src/Reflection/ReflectionClassConstant.php
@@ -82,6 +82,7 @@ class ReflectionClassConstant implements \Reflector
                 $this->node->consts[0]->value,
                 new CompilerContext($this->reflector, $this->getDeclaringClass())
             );
+            $this->valueCached = true;
         }
 
         return $this->value;

--- a/src/Reflection/ReflectionClassConstant.php
+++ b/src/Reflection/ReflectionClassConstant.php
@@ -7,24 +7,25 @@ use PhpParser\Node\Stmt\ClassConst;
 use Roave\BetterReflection\NodeCompiler\CompileNodeToValue;
 use Roave\BetterReflection\NodeCompiler\CompilerContext;
 use Roave\BetterReflection\Reflector\Reflector;
+use Roave\BetterReflection\Util\GetFirstDocComment;
 
 class ReflectionClassConstant implements \Reflector
 {
-
     /**
-     * @var bool value of const was cached?
+     * @var bool
      */
-    private $valueCached = false;
+    private $valueWasCached = false;
 
     /**
-     * @var mixed const value
+     * @var int|float|array|string|bool|null const value
      */
     private $value;
 
     /**
-     * @var
+     * @var Reflector
      */
     private $reflector;
+
     /**
      * @var ReflectionClass Constant owner
      */
@@ -77,14 +78,15 @@ class ReflectionClassConstant implements \Reflector
      */
     public function getValue()
     {
-        if (false === $this->valueCached) {
-            $this->value = (new CompileNodeToValue())->__invoke(
-                $this->node->consts[0]->value,
-                new CompilerContext($this->reflector, $this->getDeclaringClass())
-            );
-            $this->valueCached = true;
+        if (false !== $this->valueWasCached) {
+            return $this->value;
         }
 
+        $this->value = (new CompileNodeToValue())->__invoke(
+            $this->node->consts[0]->value,
+            new CompilerContext($this->reflector, $this->getDeclaringClass())
+        );
+        $this->valueWasCached = true;
         return $this->value;
     }
 
@@ -145,13 +147,7 @@ class ReflectionClassConstant implements \Reflector
      */
     public function getDocComment() : string
     {
-        if (!$this->node->hasAttribute('comments')) {
-            return '';
-        }
-
-        /* @var \PhpParser\Comment\Doc $comment */
-        $comment = $this->node->getAttribute('comments')[0];
-        return $comment->getReformattedText();
+        return GetFirstDocComment::forNode($this->node);
     }
 
     private function getVisibility()

--- a/src/Reflection/ReflectionObject.php
+++ b/src/Reflection/ReflectionObject.php
@@ -244,6 +244,22 @@ class ReflectionObject extends ReflectionClass
     /**
      * {@inheritdoc}
      */
+    public function getReflectionConstant(string $name) : ?ReflectionClassConstant
+    {
+        return $this->reflectionClass->getReflectionConstant($name);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getReflectionConstants() : array
+    {
+        return $this->reflectionClass->getReflectionConstants();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function getConstructor() : ReflectionMethod
     {
         return $this->reflectionClass->getConstructor();

--- a/test/unit/Fixture/ExampleClass.php
+++ b/test/unit/Fixture/ExampleClass.php
@@ -7,6 +7,10 @@ namespace Roave\BetterReflectionTest\Fixture {
     class ExampleClass
     {
         const MY_CONST_1 = 123;
+
+        /**
+         * Documentation for constant
+         */
         const MY_CONST_2 = 234;
         public const MY_CONST_3 = 345;
         protected const MY_CONST_4 = 456;

--- a/test/unit/Fixture/ExampleClass.php
+++ b/test/unit/Fixture/ExampleClass.php
@@ -8,6 +8,9 @@ namespace Roave\BetterReflectionTest\Fixture {
     {
         const MY_CONST_1 = 123;
         const MY_CONST_2 = 234;
+        public const MY_CONST_3 = 345;
+        protected const MY_CONST_4 = 456;
+        private const MY_CONST_5 = 567;
 
         /**
          * @var int|float|\stdClass

--- a/test/unit/Fixture/ExampleClassExport.txt
+++ b/test/unit/Fixture/ExampleClassExport.txt
@@ -1,5 +1,5 @@
 Class [ <user> class Roave\BetterReflectionTest\Fixture\ExampleClass ] {
-  @@ %s/test/unit/Fixture/ExampleClass.php 7-39
+  @@ %s/test/unit/Fixture/ExampleClass.php 7-43
 
   - Constants [5] {
     Constant [ integer MY_CONST_1 ] { 123 }
@@ -24,10 +24,10 @@ Class [ <user> class Roave\BetterReflectionTest\Fixture\ExampleClass ] {
 
   - Methods [2] {
     Method [ <user, ctor> public method __construct ] {
-      @@ %s/test/unit/Fixture/ExampleClass.php 32 - 34
+      @@ %s/test/unit/Fixture/ExampleClass.php 36 - 38
     }
     Method [ <user> public method someMethod ] {
-      @@ %s/test/unit/Fixture/ExampleClass.php 36 - 38
+      @@ %s/test/unit/Fixture/ExampleClass.php 40 - 42
     }
   }
 }

--- a/test/unit/Fixture/ExampleClassExport.txt
+++ b/test/unit/Fixture/ExampleClassExport.txt
@@ -1,9 +1,12 @@
 Class [ <user> class Roave\BetterReflectionTest\Fixture\ExampleClass ] {
-  @@ %s/test/unit/Fixture/ExampleClass.php 7-36
+  @@ %s/test/unit/Fixture/ExampleClass.php 7-39
 
-  - Constants [2] {
+  - Constants [5] {
     Constant [ integer MY_CONST_1 ] { 123 }
     Constant [ integer MY_CONST_2 ] { 234 }
+    Constant [ integer MY_CONST_3 ] { 345 }
+    Constant [ integer MY_CONST_4 ] { 456 }
+    Constant [ integer MY_CONST_5 ] { 567 }
   }
 
   - Static properties [1] {
@@ -21,10 +24,10 @@ Class [ <user> class Roave\BetterReflectionTest\Fixture\ExampleClass ] {
 
   - Methods [2] {
     Method [ <user, ctor> public method __construct ] {
-      @@ %s/test/unit/Fixture/ExampleClass.php 29 - 31
+      @@ %s/test/unit/Fixture/ExampleClass.php 32 - 34
     }
     Method [ <user> public method someMethod ] {
-      @@ %s/test/unit/Fixture/ExampleClass.php 33 - 35
+      @@ %s/test/unit/Fixture/ExampleClass.php 36 - 38
     }
   }
 }

--- a/test/unit/Fixture/ExampleClassExport.txt
+++ b/test/unit/Fixture/ExampleClassExport.txt
@@ -2,11 +2,11 @@ Class [ <user> class Roave\BetterReflectionTest\Fixture\ExampleClass ] {
   @@ %s/test/unit/Fixture/ExampleClass.php 7-43
 
   - Constants [5] {
-    Constant [ integer MY_CONST_1 ] { 123 }
-    Constant [ integer MY_CONST_2 ] { 234 }
-    Constant [ integer MY_CONST_3 ] { 345 }
-    Constant [ integer MY_CONST_4 ] { 456 }
-    Constant [ integer MY_CONST_5 ] { 567 }
+    Constant [ public integer MY_CONST_1 ] { 123 }
+    Constant [ public integer MY_CONST_2 ] { 234 }
+    Constant [ public integer MY_CONST_3 ] { 345 }
+    Constant [ protected integer MY_CONST_4 ] { 456 }
+    Constant [ private integer MY_CONST_5 ] { 567 }
   }
 
   - Static properties [1] {

--- a/test/unit/Reflection/Adapter/ReflectionClassConstantTest.php
+++ b/test/unit/Reflection/Adapter/ReflectionClassConstantTest.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Roave\BetterReflectionTest\Reflection\Adapter;
+
+use ReflectionClass as CoreReflectionClass;
+use ReflectionClassConstant as CoreReflectionClassConstant;
+use Roave\BetterReflection\Reflection\Adapter\ReflectionClassConstant as ReflectionClassConstantAdapter;
+use Roave\BetterReflection\Reflection\ReflectionClass as BetterReflectionClass;
+use Roave\BetterReflection\Reflection\ReflectionClassConstant as BetterReflectionClassConstant;
+
+/**
+ * @covers \Roave\BetterReflection\Reflection\Adapter\ReflectionClassConstant
+ */
+class ReflectionClassConstantTest extends \PHPUnit_Framework_TestCase
+{
+    public function coreReflectionMethodNamesProvider() : array
+    {
+        $methods = get_class_methods(CoreReflectionClassConstant::class);
+        return array_combine($methods, array_map(function ($i) { return [$i]; }, $methods));
+    }
+
+    /**
+     * @param string $methodName
+     * @dataProvider coreReflectionMethodNamesProvider
+     */
+    public function testCoreReflectionMethods(string $methodName) : void
+    {
+        $reflectionClassConstantAdapterReflection = new CoreReflectionClass(ReflectionClassConstantAdapter::class);
+        self::assertTrue($reflectionClassConstantAdapterReflection->hasMethod($methodName));
+    }
+
+    public function methodExpectationProvider() : array
+    {
+        $mockClassLike = $this->createMock(BetterReflectionClass::class);
+
+        return [
+            ['__toString', null, '', []],
+            ['getName', null, '', []],
+            ['getValue', null, null, []],
+            ['isPublic', null, true, []],
+            ['isPrivate', null, true, []],
+            ['isProtected', null, true, []],
+            ['getModifiers', null, 123, []],
+            ['getDeclaringClass', null, $mockClassLike, []],
+            ['getDocComment', null, '', []],
+        ];
+    }
+
+    /**
+     * @param string $methodName
+     * @param string|null $expectedException
+     * @param mixed $returnValue
+     * @param array $args
+     * @dataProvider methodExpectationProvider
+     */
+    public function testAdapterMethods(string $methodName, $expectedException, $returnValue, array $args) : void
+    {
+        /* @var BetterReflectionClassConstant|\PHPUnit_Framework_MockObject_MockObject $reflectionStub */
+        $reflectionStub = $this->createMock(BetterReflectionClassConstant::class);
+
+        if (null === $expectedException) {
+            $reflectionStub->expects($this->once())
+                ->method($methodName)
+                ->with(...$args)
+                ->will($this->returnValue($returnValue));
+        }
+
+        if (null !== $expectedException) {
+            $this->expectException($expectedException);
+        }
+
+        $adapter = new ReflectionClassConstantAdapter($reflectionStub);
+        $adapter->{$methodName}(...$args);
+    }
+}

--- a/test/unit/Reflection/Adapter/ReflectionClassTest.php
+++ b/test/unit/Reflection/Adapter/ReflectionClassTest.php
@@ -8,6 +8,7 @@ use Roave\BetterReflection\Reflection\Adapter\ReflectionClass as ReflectionClass
 use Roave\BetterReflection\Reflection\ReflectionClass as BetterReflectionClass;
 use Roave\BetterReflection\Reflection\ReflectionMethod as BetterReflectionMethod;
 use Roave\BetterReflection\Reflection\ReflectionProperty as BetterReflectionProperty;
+use Roave\BetterReflection\Reflection\ReflectionClassConstant as BetterReflectionClassConstant;
 
 /**
  * @covers \Roave\BetterReflection\Reflection\Adapter\ReflectionClass
@@ -38,6 +39,8 @@ class ReflectionClassTest extends \PHPUnit_Framework_TestCase
 
         $mockClassLike = $this->createMock(BetterReflectionClass::class);
 
+        $mockConstant = $this->createMock(BetterReflectionClassConstant::class);
+
         return [
             ['__toString', null, '', []],
             ['getName', null, '', []],
@@ -59,6 +62,8 @@ class ReflectionClassTest extends \PHPUnit_Framework_TestCase
             ['hasConstant', null, true, ['foo']],
             ['getConstant', null, 'a', ['foo']],
             ['getConstants', null, ['a', 'b'], []],
+            ['getReflectionConstant', null, $mockConstant, ['foo']],
+            ['getReflectionConstants', null, [$mockConstant], []],
             ['getInterfaces', null, [$mockClassLike], []],
             ['getInterfaceNames', null, ['a', 'b'], []],
             ['isInterface', null, true, []],

--- a/test/unit/Reflection/ReflectionClassConstantTest.php
+++ b/test/unit/Reflection/ReflectionClassConstantTest.php
@@ -82,10 +82,10 @@ class ReflectionClassConstantTest extends \PHPUnit_Framework_TestCase
     public function getModifiersProvider()
     {
         return [
-            ['MY_CONST_1', Class_::MODIFIER_PUBLIC],
-            ['MY_CONST_3', Class_::MODIFIER_PUBLIC],
-            ['MY_CONST_4', Class_::MODIFIER_PROTECTED],
-            ['MY_CONST_5', Class_::MODIFIER_PRIVATE],
+            ['MY_CONST_1', \ReflectionProperty::IS_PUBLIC],
+            ['MY_CONST_3', \ReflectionProperty::IS_PUBLIC],
+            ['MY_CONST_4', \ReflectionProperty::IS_PROTECTED],
+            ['MY_CONST_5', \ReflectionProperty::IS_PRIVATE],
         ];
     }
 

--- a/test/unit/Reflection/ReflectionClassConstantTest.php
+++ b/test/unit/Reflection/ReflectionClassConstantTest.php
@@ -46,4 +46,27 @@ class ReflectionClassConstantTest extends \PHPUnit_Framework_TestCase
         $const = $classInfo->getReflectionConstant('MY_CONST_5');
         $this->assertTrue($const->isPrivate());
     }
+
+    /**
+     * @param string $const
+     * @param string $expected
+     * @dataProvider toStringProvider
+     */
+    public function testToString(string $const, string $expected)
+    {
+        $reflector = new ClassReflector($this->getComposerLocator());
+        $classInfo = $reflector->reflect(ExampleClass::class);
+        $const = $classInfo->getReflectionConstant($const);
+        $this->assertEquals($expected, (string)$const);
+    }
+
+    public function toStringProvider()
+    {
+        return [
+            ['MY_CONST_1', 'Constant [ public MY_CONST_1 ] { 123 }' . PHP_EOL],
+            ['MY_CONST_3', 'Constant [ public MY_CONST_3 ] { 345 }' . PHP_EOL],
+            ['MY_CONST_4', 'Constant [ protected MY_CONST_4 ] { 456 }' . PHP_EOL],
+            ['MY_CONST_5', 'Constant [ private MY_CONST_5 ] { 567 }' . PHP_EOL],
+        ];
+    }
 }

--- a/test/unit/Reflection/ReflectionClassConstantTest.php
+++ b/test/unit/Reflection/ReflectionClassConstantTest.php
@@ -55,7 +55,7 @@ class ReflectionClassConstantTest extends \PHPUnit_Framework_TestCase
     public function testToString(string $const, string $expected)
     {
         $const = $this->getExampleConstant($const);
-        $this->assertEquals($expected, (string)$const);
+        $this->assertSame($expected, (string)$const);
     }
 
     public function toStringProvider()
@@ -76,7 +76,7 @@ class ReflectionClassConstantTest extends \PHPUnit_Framework_TestCase
     public function testGetModifiers(string $const, int $expected)
     {
         $const = $this->getExampleConstant($const);
-        $this->assertEquals($expected, $const->getModifiers());
+        $this->assertSame($expected, $const->getModifiers());
     }
 
     public function getModifiersProvider()
@@ -98,7 +98,7 @@ class ReflectionClassConstantTest extends \PHPUnit_Framework_TestCase
     public function testGetDocCommentReturnsEmptyStringWithNoComment()
     {
         $const = $this->getExampleConstant('MY_CONST_1');
-        $this->assertEquals('', $const->getDocComment());
+        $this->assertSame('', $const->getDocComment());
     }
 
     public function testGetDeclaringClass()
@@ -106,7 +106,7 @@ class ReflectionClassConstantTest extends \PHPUnit_Framework_TestCase
         $reflector = new ClassReflector($this->getComposerLocator());
         $classInfo = $reflector->reflect(ExampleClass::class);
         $const = $classInfo->getReflectionConstant('MY_CONST_1');
-        $this->assertEquals($classInfo, $const->getDeclaringClass());
+        $this->assertSame($classInfo, $const->getDeclaringClass());
     }
 
 }

--- a/test/unit/Reflection/ReflectionClassConstantTest.php
+++ b/test/unit/Reflection/ReflectionClassConstantTest.php
@@ -10,8 +10,9 @@ class ReflectionClassConstantTest extends \PHPUnit_Framework_TestCase
 {
     private function getComposerLocator() : ComposerSourceLocator
     {
-        global $loader;
-        return new ComposerSourceLocator($loader);
+        return new ComposerSourceLocator(
+            require __DIR__ . '/../../../vendor/autoload.php'
+        );
     }
 
     public function testDefaultVisibility()

--- a/test/unit/Reflection/ReflectionClassConstantTest.php
+++ b/test/unit/Reflection/ReflectionClassConstantTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Roave\BetterReflectionTest\Reflection;
+
+use Roave\BetterReflection\Reflector\ClassReflector;
+use Roave\BetterReflection\SourceLocator\Type\ComposerSourceLocator;
+use Roave\BetterReflectionTest\Fixture\ExampleClass;
+
+class ReflectionClassConstantTest extends \PHPUnit_Framework_TestCase
+{
+    private function getComposerLocator() : ComposerSourceLocator
+    {
+        global $loader;
+        return new ComposerSourceLocator($loader);
+    }
+
+    public function testDefaultVisibility()
+    {
+        $reflector = new ClassReflector($this->getComposerLocator());
+        $classInfo = $reflector->reflect(ExampleClass::class);
+        $const = $classInfo->getReflectionConstant('MY_CONST_1');
+        $this->assertTrue($const->isPublic());
+    }
+
+    public function testPublicVisibility()
+    {
+        $reflector = new ClassReflector($this->getComposerLocator());
+        $classInfo = $reflector->reflect(ExampleClass::class);
+        $const = $classInfo->getReflectionConstant('MY_CONST_3');
+        $this->assertTrue($const->isPublic());
+    }
+
+    public function testProtectedVisibility()
+    {
+        $reflector = new ClassReflector($this->getComposerLocator());
+        $classInfo = $reflector->reflect(ExampleClass::class);
+        $const = $classInfo->getReflectionConstant('MY_CONST_4');
+        $this->assertTrue($const->isProtected());
+    }
+
+    public function testPrivateVisibility()
+    {
+        $reflector = new ClassReflector($this->getComposerLocator());
+        $classInfo = $reflector->reflect(ExampleClass::class);
+        $const = $classInfo->getReflectionConstant('MY_CONST_5');
+        $this->assertTrue($const->isPrivate());
+    }
+}

--- a/test/unit/Reflection/ReflectionClassConstantTest.php
+++ b/test/unit/Reflection/ReflectionClassConstantTest.php
@@ -61,10 +61,10 @@ class ReflectionClassConstantTest extends \PHPUnit_Framework_TestCase
     public function toStringProvider()
     {
         return [
-            ['MY_CONST_1', 'Constant [ public MY_CONST_1 ] { 123 }' . PHP_EOL],
-            ['MY_CONST_3', 'Constant [ public MY_CONST_3 ] { 345 }' . PHP_EOL],
-            ['MY_CONST_4', 'Constant [ protected MY_CONST_4 ] { 456 }' . PHP_EOL],
-            ['MY_CONST_5', 'Constant [ private MY_CONST_5 ] { 567 }' . PHP_EOL],
+            ['MY_CONST_1', 'Constant [ public integer MY_CONST_1 ] { 123 }' . PHP_EOL],
+            ['MY_CONST_3', 'Constant [ public integer MY_CONST_3 ] { 345 }' . PHP_EOL],
+            ['MY_CONST_4', 'Constant [ protected integer MY_CONST_4 ] { 456 }' . PHP_EOL],
+            ['MY_CONST_5', 'Constant [ private integer MY_CONST_5 ] { 567 }' . PHP_EOL],
         ];
     }
 

--- a/test/unit/Reflection/ReflectionClassTest.php
+++ b/test/unit/Reflection/ReflectionClassTest.php
@@ -206,6 +206,9 @@ class ReflectionClassTest extends \PHPUnit_Framework_TestCase
         self::assertSame([
             'MY_CONST_1' => 123,
             'MY_CONST_2' => 234,
+            'MY_CONST_3' => 345,
+            'MY_CONST_4' => 456,
+            'MY_CONST_5' => 567,
         ], $classInfo->getConstants());
     }
 
@@ -215,6 +218,28 @@ class ReflectionClassTest extends \PHPUnit_Framework_TestCase
         $classInfo = $reflector->reflect(ExampleClass::class);
         self::assertSame(123, $classInfo->getConstant('MY_CONST_1'));
         self::assertSame(234, $classInfo->getConstant('MY_CONST_2'));
+        self::assertSame(345, $classInfo->getConstant('MY_CONST_3'));
+        self::assertSame(456, $classInfo->getConstant('MY_CONST_4'));
+        self::assertSame(567, $classInfo->getConstant('MY_CONST_5'));
+        self::assertNull($classInfo->getConstant('NON_EXISTENT_CONSTANT'));
+    }
+
+    public function testGetReflectionConstants()
+    {
+        $reflector = new ClassReflector($this->getComposerLocator());
+        $classInfo = $reflector->reflect(ExampleClass::class);
+        $this->assertCount(5, $classInfo->getReflectionConstants());
+    }
+
+    public function testGetReflectionConstant()
+    {
+        $reflector = new ClassReflector($this->getComposerLocator());
+        $classInfo = $reflector->reflect(ExampleClass::class);
+        self::assertSame(123, $classInfo->getReflectionConstant('MY_CONST_1')->getValue());
+        self::assertSame(234, $classInfo->getReflectionConstant('MY_CONST_2')->getValue());
+        self::assertSame(345, $classInfo->getReflectionConstant('MY_CONST_3')->getValue());
+        self::assertSame(456, $classInfo->getReflectionConstant('MY_CONST_4')->getValue());
+        self::assertSame(567, $classInfo->getReflectionConstant('MY_CONST_5')->getValue());
         self::assertNull($classInfo->getConstant('NON_EXISTENT_CONSTANT'));
     }
 

--- a/test/unit/Reflection/ReflectionObjectTest.php
+++ b/test/unit/Reflection/ReflectionObjectTest.php
@@ -123,6 +123,8 @@ class ReflectionObjectTest extends \PHPUnit_Framework_TestCase
             '__toString',
             'export',
             '__clone',
+            'getReflectionConstant',
+            'getReflectionConstants',
         ];
 
         $filteredMethods = [];

--- a/test/unit/Reflection/ReflectionObjectTest.php
+++ b/test/unit/Reflection/ReflectionObjectTest.php
@@ -123,8 +123,6 @@ class ReflectionObjectTest extends \PHPUnit_Framework_TestCase
             '__toString',
             'export',
             '__clone',
-            'getReflectionConstant',
-            'getReflectionConstants',
         ];
 
         $filteredMethods = [];


### PR DESCRIPTION
https://github.com/Roave/BetterReflection/issues/281 

Note: I did not understand how testReflectionObjectOverridesAllMethodsInReflectionClass works, therefore I missed it.