### PR TITLE
fixed improper docblock retrieval

### DIFF
--- a/src/Reflection/ReflectionClass.php
+++ b/src/Reflection/ReflectionClass.php
@@ -11,6 +11,7 @@ use Roave\BetterReflection\Reflector\ClassReflector;
 use Roave\BetterReflection\Reflector\Reflector;
 use Roave\BetterReflection\SourceLocator\Located\LocatedSource;
 use Roave\BetterReflection\TypesFinder\FindTypeFromAst;
+use Roave\BetterReflection\Util\GetFirstDocComment;
 use phpDocumentor\Reflection\Types\Object_;
 use PhpParser\Node;
 use PhpParser\Node\Stmt\ClassMethod;
@@ -690,13 +691,7 @@ class ReflectionClass implements Reflection, \Reflector
      */
     public function getDocComment() : string
     {
-        if (!$this->node->hasAttribute('comments')) {
-            return '';
-        }
-
-        /* @var \PhpParser\Comment\Doc $comment */
-        $comment = $this->node->getAttribute('comments')[0];
-        return $comment->getReformattedText();
+        return GetFirstDocComment::forNode($this->node);
     }
 
     /**

--- a/src/Reflection/ReflectionFunctionAbstract.php
+++ b/src/Reflection/ReflectionFunctionAbstract.php
@@ -7,6 +7,7 @@ use Roave\BetterReflection\SourceLocator\Located\LocatedSource;
 use Roave\BetterReflection\TypesFinder\FindReturnType;
 use Roave\BetterReflection\TypesFinder\FindTypeFromAst;
 use Roave\BetterReflection\Util\Visitor\ReturnNodeVisitor;
+use Roave\BetterReflection\Util\GetFirstDocComment;
 use Closure;
 use PhpParser\Node;
 use PhpParser\Node\Stmt\Namespace_ as NamespaceNode;
@@ -233,12 +234,7 @@ abstract class ReflectionFunctionAbstract implements \Reflector
      */
     public function getDocComment() : string
     {
-        if (!$this->node->hasAttribute('comments')) {
-            return '';
-        }
-        /* @var \PhpParser\Comment\Doc $comment */
-        $comment = $this->node->getAttribute('comments')[0];
-        return $comment->getReformattedText();
+        return GetFirstDocComment::forNode($this->node);
     }
 
     /**

--- a/src/Reflection/ReflectionProperty.php
+++ b/src/Reflection/ReflectionProperty.php
@@ -6,6 +6,7 @@ use Roave\BetterReflection\NodeCompiler\CompileNodeToValue;
 use Roave\BetterReflection\NodeCompiler\CompilerContext;
 use Roave\BetterReflection\Reflector\Reflector;
 use Roave\BetterReflection\TypesFinder\FindPropertyType;
+use Roave\BetterReflection\Util\GetFirstDocComment;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\Property as PropertyNode;
 use phpDocumentor\Reflection\Type;
@@ -264,13 +265,7 @@ class ReflectionProperty implements \Reflector
      */
     public function getDocComment() : string
     {
-        if (!$this->node->hasAttribute('comments')) {
-            return '';
-        }
-
-        /* @var \PhpParser\Comment\Doc $comment */
-        $comment = $this->node->getAttribute('comments')[0];
-        return $comment->getReformattedText();
+        return GetFirstDocComment::forNode($this->node);
     }
 
     /**

--- a/src/Util/GetFirstDocComment.php
+++ b/src/Util/GetFirstDocComment.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Roave\BetterReflection\Util;
+
+use PhpParser\NodeAbstract;
+use PhpParser\Comment\Doc;
+
+/**
+ * @internal
+ */
+final class GetFirstDocComment
+{
+    public static function forNode(NodeAbstract $node): string
+    {
+        if (!$node->hasAttribute('comments')) {
+            return '';
+        }
+
+        foreach ($node->getAttribute('comments') as $comment) {
+            if ($comment instanceof Doc) {
+                return $comment->getReformattedText();
+            }
+        }
+
+        return '';
+    }
+}

--- a/test/unit/Reflection/ReflectionClassTest.php
+++ b/test/unit/Reflection/ReflectionClassTest.php
@@ -384,6 +384,19 @@ class ReflectionClassTest extends \PHPUnit_Framework_TestCase
         self::assertContains('Some comments here', $classInfo->getDocComment());
     }
 
+    public function testGetDocCommentBetweeenComments() : void
+    {
+        $php = '<?php
+            /* A comment */
+            /** Class description */
+            /* An another comment */
+            class Bar implements Foo {}
+        ';
+        $reflector = (new ClassReflector(new StringSourceLocator($php)))->reflect('Bar');
+
+        self::assertContains('Class description', $reflector->getDocComment());
+    }
+
     public function testGetDocCommentReturnsEmptyStringWithNoComment() : void
     {
         $reflector = new ClassReflector(new SingleFileSourceLocator(__DIR__ . '/../Fixture/ExampleClass.php'));

--- a/test/unit/Reflection/ReflectionFunctionAbstractTest.php
+++ b/test/unit/Reflection/ReflectionFunctionAbstractTest.php
@@ -254,6 +254,8 @@ class ReflectionFunctionAbstractTest extends \PHPUnit_Framework_TestCase
     public function testGetDocCommentWithComment() : void
     {
         $php = '<?php
+        /* --- This is a separator --------------- */
+
         /**
          * Some function comment
          */

--- a/test/unit/Reflection/ReflectionPropertyTest.php
+++ b/test/unit/Reflection/ReflectionPropertyTest.php
@@ -7,6 +7,7 @@ use Roave\BetterReflection\Reflection\ReflectionProperty;
 use Roave\BetterReflection\Reflector\ClassReflector;
 use Roave\BetterReflection\SourceLocator\Type\ComposerSourceLocator;
 use Roave\BetterReflection\SourceLocator\Type\SingleFileSourceLocator;
+use Roave\BetterReflection\SourceLocator\Type\StringSourceLocator;
 use Roave\BetterReflectionTest\Fixture\ClassForHinting;
 use phpDocumentor\Reflection\Types;
 use PhpParser\Node\Stmt\Class_;
@@ -143,6 +144,22 @@ class ReflectionPropertyTest extends \PHPUnit_Framework_TestCase
         $property = $classInfo->getProperty('publicProperty');
 
         self::assertSame($expectedDoc, $property->getDocComment());
+    }
+
+    public function testGetDocCommentBetweeenComments() : void
+    {
+        $php = '<?php
+            class Bar implements Foo {
+                /* A comment  */
+                /** Property description */
+                /* An another comment */
+                public $prop;
+            }
+        ';
+        $reflector = (new ClassReflector(new StringSourceLocator($php)))->reflect('Bar');
+        $property = $reflector->getProperty('prop');
+
+        self::assertContains('Property description', $property->getDocComment());
     }
 
     public function testGetDocCommentReturnsEmptyStringWithNoComment() : void

--- a/test/unit/Util/GetFirstDocCommentTest.php
+++ b/test/unit/Util/GetFirstDocCommentTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Roave\BetterReflectionTest\Util;
+
+use Roave\BetterReflection\Util\GetFirstDocComment;
+use PhpParser\Node\Stmt\Function_;
+use PhpParser\Comment;
+use PhpParser\Comment\Doc;
+
+/**
+ * @covers \Roave\BetterReflection\Util\GetFirstDocComment
+ */
+class GetFirstDocCommentTest extends \PHPUnit_Framework_TestCase
+{
+    public function testWithComment() : void
+    {
+        $comment = new Comment('/* An ordinary comment */');
+        $node = new Function_('test', [], ['comments' => [$comment]]);
+
+        self::assertSame('', GetFirstDocComment::forNode($node));
+    }
+
+    public function testWithoutComment() : void
+    {
+        $node = new Function_('test');
+
+        self::assertSame('', GetFirstDocComment::forNode($node));
+    }
+
+    public function testWithMixedCommentTypes() : void
+    {
+        $comment = new Comment('/* An ordinary comment */');
+        $docComment = new Doc('/** Property description */');
+        $node = new Function_('test', [], ['comments' => [$comment, $docComment]]);
+
+        self::assertSame('/** Property description */', GetFirstDocComment::forNode($node));
+    }
+
+    public function testWithMultipleDocComments() : void
+    {
+        $comment1 = new Doc('/** First doc comment */');
+        $comment2 = new Doc('/** Second doc comment */');
+        $node = new Function_('test', [], ['comments' => [$comment1, $comment2]]);
+
+        self::assertSame('/** First doc comment */', GetFirstDocComment::forNode($node));
+    }
+}


### PR DESCRIPTION
Before this, it could happen that comment returned is not really instance of `\PhpParser\Comment\Doc` but just instance of an ordinary comment.