### PR TITLE
FindReflectionOnLine cannot be configured to load dependencies

### DIFF
--- a/test/unit/Fixture/FindReflectionOnLineFixture.php
+++ b/test/unit/Fixture/FindReflectionOnLineFixture.php
@@ -22,3 +22,7 @@ trait SomeFooTrait
 interface SomeFooInterface
 {
 }
+
+class SomeFooClassWithImplementedInterface implements \Roave\BetterReflectionTest\Fixture\AutoloadableInterface
+{
+}

--- a/test/unit/Util/FindReflectionOnLineTest.php
+++ b/test/unit/Util/FindReflectionOnLineTest.php
@@ -62,4 +62,13 @@ class FindReflectionOnLineTest extends \PHPUnit_Framework_TestCase
         $finder = new FindReflectionOnLine();
         self::assertNull($finder(__DIR__ . '/../Fixture/FindReflectionOnLineFixture.php', 1));
     }
+
+    public function testInvokeFindsClassWithImplementedInterface() : void
+    {
+        $finder = new FindReflectionOnLine();
+        $reflection = $finder(__DIR__ . '/../Fixture/FindReflectionOnLineFixture.php', 26);
+
+        self::assertInstanceOf(ReflectionClass::class, $reflection);
+        self::assertSame('SomeFooClassWithImplementedInterface', $reflection->getName());
+    }
 }


### PR DESCRIPTION
This PR contains a failing test to show a limitation of the `FindReflectionOnLine` class.

SourceLocators for the class cannot be configured. Consequently, you cannot use the `FindReflectionOnLine` class on any class that extends/implements a class/interface that needs to be autoloaded.

I'll send a PR for improving the `FindReflectionOnLine` class in a few minutes.
