### PR TITLE
getDefaultValueAsString removals/deprecation

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ $classInfo = ReflectionClass::createFromName('Foo\Bar\MyClass');
  * `CompilerContext` requires second parameter (no longer optional, but still `null`able)
  * `Reflector` now requires a `string` for `$identiferName` parameter
  * Namespace moved to `\Roave\BetterReflection` instead of just `\BetterReflection`
+ * `ReflectionParameter#getDefaultValueAsString` is deprecated in favour of using `var_export` directly.
 
 ## More documentation
 

--- a/src/Reflection/ReflectionParameter.php
+++ b/src/Reflection/ReflectionParameter.php
@@ -173,7 +173,7 @@ class ReflectionParameter implements \Reflector
             $this->isPassedByReference() ? '&' : '',
             $this->getName(),
             ($this->isOptional() && $this->isDefaultValueAvailable())
-                ? (' = ' . $this->getDefaultValueAsString())
+                ? (' = ' . var_export($this->getDefaultValue(), true))
                 : ''
         );
     }
@@ -314,6 +314,7 @@ class ReflectionParameter implements \Reflector
      * Get the default value represented as a string.
      *
      * @return string
+     * @deprecated Use `var_export($reflection->getDefaultValue(), true)` instead
      */
     public function getDefaultValueAsString() : string
     {

--- a/src/Reflection/ReflectionProperty.php
+++ b/src/Reflection/ReflectionProperty.php
@@ -309,16 +309,6 @@ class ReflectionProperty implements \Reflector
     }
 
     /**
-     * Get the default value represented as a string.
-     *
-     * @return string
-     */
-    public function getDefaultValueAsString() : string
-    {
-        return var_export($this->getDefaultValue(), true);
-    }
-
-    /**
      * {@inheritdoc}
      * @throws Exception\Uncloneable
      */

--- a/test/unit/Reflection/ReflectionParameterTest.php
+++ b/test/unit/Reflection/ReflectionParameterTest.php
@@ -522,6 +522,7 @@ class ReflectionParameterTest extends \PHPUnit_Framework_TestCase
      * @param string $defaultValue
      * @param string $expectedValue
      * @dataProvider defaultValueStringProvider
+     * @deprecated
      */
     public function testGetDefaultValueAsString(string $defaultValue, string $expectedValue) : void
     {

--- a/test/unit/Reflection/ReflectionPropertyTest.php
+++ b/test/unit/Reflection/ReflectionPropertyTest.php
@@ -254,25 +254,6 @@ class ReflectionPropertyTest extends \PHPUnit_Framework_TestCase
         self::assertNull($classInfo->getProperty('noDefault')->getDefaultValue());
     }
 
-    public function testGetDefaultAsStringProperty() : void
-    {
-        $php = '<?php
-            class Bar {
-                public $none;
-                public $integer = 11;
-                public $array = [\'cat\', \'dog\'];
-            }
-        ';
-        $reflector = (new ClassReflector(new StringSourceLocator($php)))->reflect('Bar');
-
-        self::assertSame('NULL', $reflector->getProperty('none')->getDefaultValueAsString());
-        self::assertSame('11', $reflector->getProperty('integer')->getDefaultValueAsString());
-        self::assertSame("array (\n"
-            . "  0 => 'cat',\n"
-            . "  1 => 'dog',\n"
-            . ")", $reflector->getProperty('array')->getDefaultValueAsString());
-    }
-
     public function testCannotClone() : void
     {
         $classInfo = $this->reflector->reflect(ExampleClass::class);


### PR DESCRIPTION
 * Removes `ReflectionProperty->getDefaultValueAsString()`
 * Deprecates `ReflectionParameter->getDefaultValueAsString()`