### PR TITLE
ReflectionParameter::parseDefaultValueNode() - case insensitive check of TRUE, FALSE and NULL

### DIFF
--- a/src/Reflection/ReflectionParameter.php
+++ b/src/Reflection/ReflectionParameter.php
@@ -214,7 +214,7 @@ class ReflectionParameter implements \Reflector
         }
 
         if ($defaultValueNode instanceof Node\Expr\ConstFetch
-            && !in_array($defaultValueNode->name->parts[0], ['true', 'false', 'null'])) {
+            && !in_array(strtolower($defaultValueNode->name->parts[0]), ['true', 'false', 'null'])) {
             $this->isDefaultValueConstant = true;
             $this->defaultValueConstantName = $defaultValueNode->name->parts[0];
             $this->defaultValueConstantType = self::CONST_TYPE_DEFINED;

--- a/test/unit/Fixture/Methods.php
+++ b/test/unit/Fixture/Methods.php
@@ -82,4 +82,8 @@ abstract class Methods
     public function methodWithConstAsDefault($intDefault = 1, $constDefault = self::SOME_CONST, $definedDefault = SOME_DEFINED_VALUE)
     {
     }
+
+    public function methodWithUpperCasedDefaults($boolUpper = TRUE, $boolLower = false, $nullUpper = NULL)
+    {
+    }
 }

--- a/test/unit/Reflection/ReflectionClassTest.php
+++ b/test/unit/Reflection/ReflectionClassTest.php
@@ -133,7 +133,7 @@ class ReflectionClassTest extends \PHPUnit_Framework_TestCase
             [\ReflectionMethod::IS_STATIC, 1],
             [\ReflectionMethod::IS_ABSTRACT, 1],
             [\ReflectionMethod::IS_FINAL, 1],
-            [\ReflectionMethod::IS_PUBLIC, 15],
+            [\ReflectionMethod::IS_PUBLIC, 16],
             [\ReflectionMethod::IS_PROTECTED, 1],
             [\ReflectionMethod::IS_PRIVATE, 1],
             [
@@ -143,7 +143,7 @@ class ReflectionClassTest extends \PHPUnit_Framework_TestCase
                 \ReflectionMethod::IS_PUBLIC |
                 \ReflectionMethod::IS_PROTECTED |
                 \ReflectionMethod::IS_PRIVATE,
-                17
+                18
             ]
         ];
     }

--- a/test/unit/Reflection/ReflectionParameterTest.php
+++ b/test/unit/Reflection/ReflectionParameterTest.php
@@ -451,8 +451,18 @@ class ReflectionParameterTest extends \PHPUnit_Framework_TestCase
     public function testIsDefaultValueConstantAndGetDefaultValueConstantName() : void
     {
         $classInfo = $this->reflector->reflect(Methods::class);
-        $method = $classInfo->getMethod('methodWithConstAsDefault');
+        $method = $classInfo->getMethod('methodWithUpperCasedDefaults');
 
+        $boolUpper = $method->getParameter('boolUpper');
+        self::assertFalse($boolUpper->isDefaultValueConstant());
+
+        $boolLower = $method->getParameter('boolLower');
+        self::assertFalse($boolLower->isDefaultValueConstant());
+
+        $nullUpper = $method->getParameter('nullUpper');
+        self::assertFalse($nullUpper->isDefaultValueConstant());
+
+        $method = $classInfo->getMethod('methodWithConstAsDefault');
         $constDefault = $method->getParameter('constDefault');
         self::assertTrue($constDefault->isDefaultValueConstant());
         self::assertSame('SOME_CONST', $constDefault->getDefaultValueConstantName());


### PR DESCRIPTION
With code style using uppercased `TRUE`, `FALSE` and `NULL`, the condition did not work.