### PR TITLE
ReflectionParameter: return full name if default value is class' constant

### DIFF
--- a/src/Reflection/ReflectionParameter.php
+++ b/src/Reflection/ReflectionParameter.php
@@ -235,6 +235,9 @@ class ReflectionParameter implements \Reflector
         );
     }
 
+    /**
+     * @throws \LogicException
+     */
     private function findParentClassDeclaringConstant(string $constantName): string
     {
         $class = $this->function->getDeclaringClass();
@@ -243,6 +246,8 @@ class ReflectionParameter implements \Reflector
                 return $class->getName();
             }
         } while ($class = $class->getParentClass());
+
+        throw new LogicException("Failed to find parent class of constant '$constantName'.");
     }
 
     /**

--- a/test/unit/Fixture/ClassWithConstantsAsDefaultValues.php
+++ b/test/unit/Fixture/ClassWithConstantsAsDefaultValues.php
@@ -3,6 +3,9 @@
 namespace Roave\BetterReflectionTest\Fixture {
 
     use Roave\BetterReflectionTest\FixtureOther\OtherClass;
+    use Roave\BetterReflectionTest\FixtureOther\OTHER_NAMESPACE_CONST;
+
+    const THIS_NAMESPACE_CONST = 'this_namespace';
 
     class ParentClassWithConstant
     {
@@ -13,13 +16,18 @@ namespace Roave\BetterReflectionTest\Fixture {
     {
         public const MY_CONST = 'my';
 
-        public function method($param1 = self::MY_CONST, $param2 = self::PARENT_CONST, $param3 = OtherClass::MY_CONST)
+        public function method($param1 = self::MY_CONST, $param2 = self::PARENT_CONST,
+            $param3 = OtherClass::MY_CONST, $param4 = THIS_NAMESPACE_CONST,
+            $param5 = OTHER_NAMESPACE_CONST)
         {
         }
     }
 }
 
 namespace Roave\BetterReflectionTest\FixtureOther {
+
+    const OTHER_NAMESPACE_CONST = 'other_namespace';
+
     class OtherClass
     {
         public const MY_CONST = 'other';

--- a/test/unit/Fixture/ClassWithConstantsAsDefaultValues.php
+++ b/test/unit/Fixture/ClassWithConstantsAsDefaultValues.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Roave\BetterReflectionTest\Fixture {
+
+    use Roave\BetterReflectionTest\FixtureOther\OtherClass;
+
+    class ParentClassWithConstant
+    {
+        public const PARENT_CONST = 'parent';
+    }
+
+    class ClassWithConstantsAsDefaultValues extends ParentClassWithConstant
+    {
+        public const MY_CONST = 'my';
+
+        public function method($param1 = self::MY_CONST, $param2 = self::PARENT_CONST, $param3 = OtherClass::MY_CONST)
+        {
+        }
+    }
+}
+
+namespace Roave\BetterReflectionTest\FixtureOther {
+    class OtherClass
+    {
+        public const MY_CONST = 'other';
+    }
+}

--- a/test/unit/Reflection/ReflectionParameterTest.php
+++ b/test/unit/Reflection/ReflectionParameterTest.php
@@ -483,7 +483,7 @@ class ReflectionParameterTest extends \PHPUnit_Framework_TestCase
         $intDefault->getDefaultValueConstantName();
     }
 
-    public function testGetDefaultValueConstantNameAcrossClasses() : void
+    public function testGetDefaultValueConstantNameClassConstants() : void
     {
         $reflector = new ClassReflector(new SingleFileSourceLocator(
             __DIR__ . '/../Fixture/ClassWithConstantsAsDefaultValues.php')
@@ -499,6 +499,23 @@ class ReflectionParameterTest extends \PHPUnit_Framework_TestCase
 
         $param3 = $method->getParameter('param3');
         self::assertSame(OtherClass::class . '::MY_CONST', $param3->getDefaultValueConstantName());
+    }
+
+    public function testGetDefaultValueConstantNameNamespacedConstants() : void
+    {
+        $this->markTestSkipped('@todo - implement reflection of constants outside a class');
+
+        $reflector = new ClassReflector(new SingleFileSourceLocator(
+            __DIR__ . '/../Fixture/ClassWithConstantsAsDefaultValues.php')
+        );
+        $classInfo = $reflector->reflect(ClassWithConstantsAsDefaultValues::class);
+        $method = $classInfo->getMethod('method');
+
+        $param4 = $method->getParameter('param4');
+        self::assertSame('Roave\BetterReflectionTest\Fixture\THIS_NAMESPACE_CONST', $param4->getDefaultValueConstantName());
+
+        $param5 = $method->getParameter('param5');
+        self::assertSame('Roave\BetterReflectionTest\FixtureOther\OTHER_NAMESPACE_CONST', $param5->getDefaultValueConstantName());
     }
 
     public function testGetDeclaringFunction() : void


### PR DESCRIPTION
In short: `AClass::SOME` !== `BClass::SOME` !== `SOME`

In reflection of this method

```php
public function method($param1 = AClass::SOME, $param2 = BClass::SOME);
```

method `getDefaultValueConstantName()` cannot return just `SOME` for it is not precise description of what constant it really is.