### PR TITLE
TypeFinder: add support for indexed @param annotations

### DIFF
--- a/src/TypesFinder/FindParameterType.php
+++ b/src/TypesFinder/FindParameterType.php
@@ -8,6 +8,7 @@ use phpDocumentor\Reflection\Types\Context;
 use phpDocumentor\Reflection\Types\ContextFactory;
 use PhpParser\Node\Param as ParamNode;
 use phpDocumentor\Reflection\DocBlock;
+use phpDocumentor\Reflection\DocBlock\Tags\Param;
 use phpDocumentor\Reflection\Type;
 use Roave\BetterReflection\Reflection\ReflectionFunctionAbstract;
 
@@ -43,10 +44,28 @@ class FindParameterType
         foreach ($paramTags as $paramTag) {
             /* @var $paramTag \phpDocumentor\Reflection\DocBlock\Tags\Param */
             if ($paramTag->getVariableName() === $node->name) {
-                return (new ResolveTypes())->__invoke(explode('|', $paramTag->getType()), $context);
+                return $this->resolveFromTag($paramTag, $context);
             }
         }
+
+        foreach ($function->getParameters() as $index => $parameter) {
+            /* @var $parameter \Roave\BetterReflection\Reflection\ReflectionParameter */
+            if ($parameter->getName() === $node->name) {
+                if (isset($paramTags[$index]) && !$paramTags[$index]->getVariableName()) {
+                    return $this->resolveFromTag($paramTags[$index], $context);
+                }
+            }
+        }
+
         return [];
+    }
+
+    /**
+     * @return Type[]
+     */
+    private function resolveFromTag(Param $paramTag, Context $context): array
+    {
+        return (new ResolveTypes())->__invoke(explode('|', $paramTag->getType()), $context);
     }
 
     /**

--- a/test/unit/TypesFinder/FindParameterTypeTest.php
+++ b/test/unit/TypesFinder/FindParameterTypeTest.php
@@ -5,6 +5,7 @@ namespace Roave\BetterReflectionTest\TypesFinder;
 use Roave\BetterReflection\Reflection\ReflectionClass;
 use Roave\BetterReflection\Reflection\ReflectionFunction;
 use Roave\BetterReflection\Reflection\ReflectionMethod;
+use Roave\BetterReflection\Reflection\ReflectionParameter;
 use Roave\BetterReflection\Reflector\ClassReflector;
 use Roave\BetterReflection\SourceLocator\Located\LocatedSource;
 use Roave\BetterReflection\SourceLocator\Type\StringSourceLocator;
@@ -33,6 +34,8 @@ class FindParameterTypeTest extends \PHPUnit_Framework_TestCase
             ['@param ?iterable $foo', 'foo', [Types\Nullable::class]],
             ['@param object $foo', 'foo', [Types\Object_::class]],
             ['@param ?object $foo', 'foo', [Types\Nullable::class]],
+            ['@param int|string', 'foo', [Types\Integer::class, Types\String_::class]],
+            ['@param ?string', 'foo', [Types\Nullable::class]],
         ];
     }
 
@@ -71,6 +74,12 @@ class FindParameterTypeTest extends \PHPUnit_Framework_TestCase
         $node = new ParamNode($nodeName);
         $docBlock = "/**\n * $docBlock\n */";
 
+        $parameter = $this->createMock(ReflectionParameter::class);
+
+        $parameter
+            ->method('getName')
+            ->will($this->returnValue('foo'));
+
         $function = $this->createMock(ReflectionFunction::class);
 
         $function
@@ -82,6 +91,10 @@ class FindParameterTypeTest extends \PHPUnit_Framework_TestCase
             ->expects($this->once())
             ->method('getLocatedSource')
             ->will($this->returnValue(new LocatedSource('<?php', null)));
+
+        $function
+            ->method('getParameters')
+            ->will($this->returnValue([$parameter]));
 
         /* @var ReflectionFunction $function */
         $foundTypes = (new FindParameterType())->__invoke($function, $node);
@@ -111,6 +124,12 @@ class FindParameterTypeTest extends \PHPUnit_Framework_TestCase
             ->method('getLocatedSource')
             ->will($this->returnValue(new LocatedSource('<?php', null)));
 
+        $parameter = $this->createMock(ReflectionParameter::class);
+
+        $parameter
+            ->method('getName')
+            ->will($this->returnValue('foo'));
+
         $method = $this->createMock(ReflectionMethod::class);
 
         $method
@@ -122,6 +141,10 @@ class FindParameterTypeTest extends \PHPUnit_Framework_TestCase
             ->expects($this->once())
             ->method('getDeclaringClass')
             ->will($this->returnValue($class));
+
+        $method
+            ->method('getParameters')
+            ->will($this->returnValue([$parameter]));
 
         /* @var ReflectionMethod $method */
         $foundTypes = (new FindParameterType())->__invoke($method, $node);


### PR DESCRIPTION
Many projects, including Nette Framework, are ommiting variable name for `@param` annotation and are using the annotation's index.

```php
/**
 * @param string
 * @param int
 */
function xxx($str, $int)
{
}
```

Coould we add fallback support for this behaviour?