### PR TITLE
Cached locator and AST parsing

### DIFF
--- a/src/Reflector/ClassReflector.php
+++ b/src/Reflector/ClassReflector.php
@@ -3,9 +3,12 @@ declare(strict_types=1);
 
 namespace Roave\BetterReflection\Reflector;
 
+use PhpParser\ParserFactory;
 use Roave\BetterReflection\Identifier\Identifier;
 use Roave\BetterReflection\Identifier\IdentifierType;
 use Roave\BetterReflection\Reflection\Reflection;
+use Roave\BetterReflection\SourceLocator\Ast\Parser\MemoizingParser;
+use Roave\BetterReflection\SourceLocator\Ast\PhpParserLocator;
 use Roave\BetterReflection\SourceLocator\Type\AggregateSourceLocator;
 use Roave\BetterReflection\SourceLocator\Type\AutoloadSourceLocator;
 use Roave\BetterReflection\SourceLocator\Type\EvaledCodeSourceLocator;
@@ -33,10 +36,14 @@ class ClassReflector implements Reflector
      */
     public static function buildDefaultReflector() : self
     {
+        $locator = new PhpParserLocator(
+            new MemoizingParser((new ParserFactory())->create(ParserFactory::PREFER_PHP7))
+        );
+
         return new self(new MemoizingSourceLocator(new AggregateSourceLocator([
-            new PhpInternalSourceLocator(),
-            new EvaledCodeSourceLocator(),
-            new AutoloadSourceLocator(),
+            new PhpInternalSourceLocator($locator),
+            new EvaledCodeSourceLocator($locator),
+            new AutoloadSourceLocator($locator),
         ])));
     }
 

--- a/src/Reflector/ClassReflector.php
+++ b/src/Reflector/ClassReflector.php
@@ -9,6 +9,7 @@ use Roave\BetterReflection\Reflection\Reflection;
 use Roave\BetterReflection\SourceLocator\Type\AggregateSourceLocator;
 use Roave\BetterReflection\SourceLocator\Type\AutoloadSourceLocator;
 use Roave\BetterReflection\SourceLocator\Type\EvaledCodeSourceLocator;
+use Roave\BetterReflection\SourceLocator\Type\MemoizingSourceLocator;
 use Roave\BetterReflection\SourceLocator\Type\PhpInternalSourceLocator;
 use Roave\BetterReflection\SourceLocator\Type\SourceLocator;
 
@@ -32,11 +33,11 @@ class ClassReflector implements Reflector
      */
     public static function buildDefaultReflector() : self
     {
-        return new self(new AggregateSourceLocator([
+        return new self(new MemoizingSourceLocator(new AggregateSourceLocator([
             new PhpInternalSourceLocator(),
             new EvaledCodeSourceLocator(),
             new AutoloadSourceLocator(),
-        ]));
+        ])));
     }
 
     /**

--- a/src/SourceLocator/Ast/Locator.php
+++ b/src/SourceLocator/Ast/Locator.php
@@ -5,36 +5,15 @@ namespace Roave\BetterReflection\SourceLocator\Ast;
 
 use Roave\BetterReflection\Identifier\Identifier;
 use Roave\BetterReflection\Identifier\IdentifierType;
-use Roave\BetterReflection\SourceLocator\Ast\Strategy\NodeToReflection;
 use Roave\BetterReflection\Reflection\Reflection;
 use Roave\BetterReflection\Reflector\Reflector;
-use Roave\BetterReflection\Reflector\Exception\IdentifierNotFound;
 use Roave\BetterReflection\SourceLocator\Located\LocatedSource;
-use PhpParser\Parser;
-use PhpParser\ParserFactory;
 
 /**
  * @internal
  */
-class Locator
+interface Locator
 {
-    /**
-     * @var FindReflectionsInTree
-     */
-    private $findReflectionsInTree;
-
-    /**
-     * @var Parser
-     */
-    private $parser;
-
-    public function __construct()
-    {
-        $this->findReflectionsInTree = new FindReflectionsInTree(new NodeToReflection());
-
-        $this->parser = (new ParserFactory())->create(ParserFactory::PREFER_PHP7);
-    }
-
     /**
      * @param Reflector $reflector
      * @param LocatedSource $locatedSource
@@ -47,16 +26,7 @@ class Locator
         Reflector $reflector,
         LocatedSource $locatedSource,
         Identifier $identifier
-    ) : Reflection {
-        return $this->findInArray(
-            $this->findReflectionsOfType(
-                $reflector,
-                $locatedSource,
-                $identifier->getType()
-            ),
-            $identifier
-        );
-    }
+    ) : Reflection;
 
     /**
      * Get an array of reflections found in some code.
@@ -71,37 +41,5 @@ class Locator
         Reflector $reflector,
         LocatedSource $locatedSource,
         IdentifierType $identifierType
-    ) : array {
-        try {
-            return $this->findReflectionsInTree->__invoke(
-                $reflector,
-                $this->parser->parse($locatedSource->getSource()),
-                $identifierType,
-                $locatedSource
-            );
-        } catch (\Exception $exception) {
-            throw Exception\ParseToAstFailure::fromLocatedSource($locatedSource, $exception);
-        } catch (\Throwable $exception) {
-            throw Exception\ParseToAstFailure::fromLocatedSource($locatedSource, $exception);
-        }
-    }
-
-    /**
-     * Given an array of Reflections, try to find the identifier.
-     *
-     * @param Reflection[] $reflections
-     * @param Identifier $identifier
-     * @return Reflection
-     * @throws \Roave\BetterReflection\Reflector\Exception\IdentifierNotFound
-     */
-    private function findInArray(array $reflections, Identifier $identifier) : Reflection
-    {
-        foreach ($reflections as $reflection) {
-            if ($reflection->getName() === $identifier->getName()) {
-                return $reflection;
-            }
-        }
-
-        throw IdentifierNotFound::fromIdentifier($identifier);
-    }
+    ) : array;
 }

--- a/src/SourceLocator/Ast/Parser/MemoizingParser.php
+++ b/src/SourceLocator/Ast/Parser/MemoizingParser.php
@@ -1,0 +1,44 @@
+<?php
+declare(strict_types=1);
+
+namespace Roave\BetterReflection\SourceLocator\Ast\Parser;
+
+use PhpParser\ErrorHandler;
+use PhpParser\Node;
+use PhpParser\Parser;
+
+/**
+ * @internal
+ */
+final class MemoizingParser implements Parser
+{
+    /**
+     * @var Node[][]|null[] indexed by source hash
+     */
+    private $sourceHashToAst = [];
+
+    /**
+     * @var Parser
+     */
+    private $wrappedParser;
+
+    public function __construct(Parser $wrappedParser)
+    {
+        $this->wrappedParser = $wrappedParser;
+    }
+
+    public function parse($code, ErrorHandler $errorHandler = null)
+    {
+        // note: this code is mathematically buggy by default, as we are using a hash to identify
+        //       cache entries. The string length is added to further reduce likeliness (although
+        //       already imperceptible) of key collisions.
+        //       In the "real world", this code will work just fine.
+        $hash = \sha1($code) . ':' . \strlen($code);
+
+        if (\array_key_exists($hash, $this->sourceHashToAst)) {
+            return $this->sourceHashToAst[$hash];
+        }
+
+        return $this->sourceHashToAst[$hash] = $this->wrappedParser->parse($code, $errorHandler);
+    }
+}

--- a/src/SourceLocator/Ast/Parser/MemoizingParser.php
+++ b/src/SourceLocator/Ast/Parser/MemoizingParser.php
@@ -33,7 +33,7 @@ final class MemoizingParser implements Parser
         //       cache entries. The string length is added to further reduce likeliness (although
         //       already imperceptible) of key collisions.
         //       In the "real world", this code will work just fine.
-        $hash = \sha1($code) . ':' . \strlen($code);
+        $hash = \hash('sha256', $code) . ':' . \strlen($code);
 
         if (\array_key_exists($hash, $this->sourceHashToAst)) {
             return $this->sourceHashToAst[$hash];

--- a/src/SourceLocator/Ast/PhpParserLocator.php
+++ b/src/SourceLocator/Ast/PhpParserLocator.php
@@ -16,7 +16,7 @@ use PhpParser\ParserFactory;
 /**
  * @internal
  */
-class PhpParserLocator implements Locator
+final class PhpParserLocator implements Locator
 {
     /**
      * @var FindReflectionsInTree

--- a/src/SourceLocator/Ast/PhpParserLocator.php
+++ b/src/SourceLocator/Ast/PhpParserLocator.php
@@ -1,0 +1,107 @@
+<?php
+declare(strict_types=1);
+
+namespace Roave\BetterReflection\SourceLocator\Ast;
+
+use Roave\BetterReflection\Identifier\Identifier;
+use Roave\BetterReflection\Identifier\IdentifierType;
+use Roave\BetterReflection\SourceLocator\Ast\Strategy\NodeToReflection;
+use Roave\BetterReflection\Reflection\Reflection;
+use Roave\BetterReflection\Reflector\Reflector;
+use Roave\BetterReflection\Reflector\Exception\IdentifierNotFound;
+use Roave\BetterReflection\SourceLocator\Located\LocatedSource;
+use PhpParser\Parser;
+use PhpParser\ParserFactory;
+
+/**
+ * @internal
+ */
+class PhpParserLocator implements Locator
+{
+    /**
+     * @var FindReflectionsInTree
+     */
+    private $findReflectionsInTree;
+
+    /**
+     * @var Parser
+     */
+    private $parser;
+
+    public function __construct()
+    {
+        $this->findReflectionsInTree = new FindReflectionsInTree(new NodeToReflection());
+
+        $this->parser = (new ParserFactory())->create(ParserFactory::PREFER_PHP7);
+    }
+
+    /**
+     * @param Reflector $reflector
+     * @param LocatedSource $locatedSource
+     * @param Identifier $identifier
+     * @return Reflection
+     * @throws \Roave\BetterReflection\Reflector\Exception\IdentifierNotFound
+     * @throws Exception\ParseToAstFailure
+     */
+    public function findReflection(
+        Reflector $reflector,
+        LocatedSource $locatedSource,
+        Identifier $identifier
+    ) : Reflection {
+        return $this->findInArray(
+            $this->findReflectionsOfType(
+                $reflector,
+                $locatedSource,
+                $identifier->getType()
+            ),
+            $identifier
+        );
+    }
+
+    /**
+     * Get an array of reflections found in some code.
+     *
+     * @param Reflector $reflector
+     * @param LocatedSource $locatedSource
+     * @param IdentifierType $identifierType
+     * @return \Roave\BetterReflection\Reflection\Reflection[]
+     * @throws Exception\ParseToAstFailure
+     */
+    public function findReflectionsOfType(
+        Reflector $reflector,
+        LocatedSource $locatedSource,
+        IdentifierType $identifierType
+    ) : array {
+        try {
+            return $this->findReflectionsInTree->__invoke(
+                $reflector,
+                $this->parser->parse($locatedSource->getSource()),
+                $identifierType,
+                $locatedSource
+            );
+        } catch (\Exception $exception) {
+            throw Exception\ParseToAstFailure::fromLocatedSource($locatedSource, $exception);
+        } catch (\Throwable $exception) {
+            throw Exception\ParseToAstFailure::fromLocatedSource($locatedSource, $exception);
+        }
+    }
+
+    /**
+     * Given an array of Reflections, try to find the identifier.
+     *
+     * @param Reflection[] $reflections
+     * @param Identifier $identifier
+     * @return Reflection
+     * @throws \Roave\BetterReflection\Reflector\Exception\IdentifierNotFound
+     */
+    private function findInArray(array $reflections, Identifier $identifier) : Reflection
+    {
+        foreach ($reflections as $reflection) {
+            if ($reflection->getName() === $identifier->getName()) {
+                return $reflection;
+            }
+        }
+
+        throw IdentifierNotFound::fromIdentifier($identifier);
+    }
+}

--- a/src/SourceLocator/Ast/PhpParserLocator.php
+++ b/src/SourceLocator/Ast/PhpParserLocator.php
@@ -35,14 +35,6 @@ final class PhpParserLocator implements Locator
         $this->parser = (new ParserFactory())->create(ParserFactory::PREFER_PHP7);
     }
 
-    /**
-     * @param Reflector $reflector
-     * @param LocatedSource $locatedSource
-     * @param Identifier $identifier
-     * @return Reflection
-     * @throws \Roave\BetterReflection\Reflector\Exception\IdentifierNotFound
-     * @throws Exception\ParseToAstFailure
-     */
     public function findReflection(
         Reflector $reflector,
         LocatedSource $locatedSource,
@@ -58,15 +50,6 @@ final class PhpParserLocator implements Locator
         );
     }
 
-    /**
-     * Get an array of reflections found in some code.
-     *
-     * @param Reflector $reflector
-     * @param LocatedSource $locatedSource
-     * @param IdentifierType $identifierType
-     * @return \Roave\BetterReflection\Reflection\Reflection[]
-     * @throws Exception\ParseToAstFailure
-     */
     public function findReflectionsOfType(
         Reflector $reflector,
         LocatedSource $locatedSource,
@@ -91,8 +74,10 @@ final class PhpParserLocator implements Locator
      *
      * @param Reflection[] $reflections
      * @param Identifier $identifier
+     *
      * @return Reflection
-     * @throws \Roave\BetterReflection\Reflector\Exception\IdentifierNotFound
+     *
+     * @throws IdentifierNotFound
      */
     private function findInArray(array $reflections, Identifier $identifier) : Reflection
     {

--- a/src/SourceLocator/Ast/PhpParserLocator.php
+++ b/src/SourceLocator/Ast/PhpParserLocator.php
@@ -5,6 +5,7 @@ namespace Roave\BetterReflection\SourceLocator\Ast;
 
 use Roave\BetterReflection\Identifier\Identifier;
 use Roave\BetterReflection\Identifier\IdentifierType;
+use Roave\BetterReflection\SourceLocator\Ast\Parser\MemoizingParser;
 use Roave\BetterReflection\SourceLocator\Ast\Strategy\NodeToReflection;
 use Roave\BetterReflection\Reflection\Reflection;
 use Roave\BetterReflection\Reflector\Reflector;
@@ -28,11 +29,11 @@ final class PhpParserLocator implements Locator
      */
     private $parser;
 
-    public function __construct()
+    public function __construct(?Parser $parser = null)
     {
         $this->findReflectionsInTree = new FindReflectionsInTree(new NodeToReflection());
 
-        $this->parser = (new ParserFactory())->create(ParserFactory::PREFER_PHP7);
+        $this->parser = $parser ?: new MemoizingParser((new ParserFactory())->create(ParserFactory::PREFER_PHP7));
     }
 
     public function findReflection(

--- a/src/SourceLocator/Type/AbstractSourceLocator.php
+++ b/src/SourceLocator/Type/AbstractSourceLocator.php
@@ -9,6 +9,7 @@ use Roave\BetterReflection\Reflection\Reflection;
 use Roave\BetterReflection\Reflector\Exception\IdentifierNotFound;
 use Roave\BetterReflection\Reflector\Reflector;
 use Roave\BetterReflection\SourceLocator\Ast\Locator as AstLocator;
+use Roave\BetterReflection\SourceLocator\Ast\PhpParserLocator;
 use Roave\BetterReflection\SourceLocator\Located\LocatedSource;
 
 abstract class AbstractSourceLocator implements SourceLocator
@@ -33,7 +34,7 @@ abstract class AbstractSourceLocator implements SourceLocator
 
     public function __construct(AstLocator $astLocator = null)
     {
-        $this->astLocator = (null !== $astLocator) ? $astLocator : new AstLocator();
+        $this->astLocator = $astLocator ?? new PhpParserLocator();
     }
 
     /**

--- a/src/SourceLocator/Type/ComposerSourceLocator.php
+++ b/src/SourceLocator/Type/ComposerSourceLocator.php
@@ -3,7 +3,9 @@ declare(strict_types=1);
 
 namespace Roave\BetterReflection\SourceLocator\Type;
 
+use PhpParser\Parser;
 use Roave\BetterReflection\Identifier\IdentifierType;
+use Roave\BetterReflection\SourceLocator\Ast\Locator;
 use Roave\BetterReflection\SourceLocator\Located\LocatedSource;
 use Composer\Autoload\ClassLoader;
 use Roave\BetterReflection\Identifier\Identifier;
@@ -22,9 +24,9 @@ class ComposerSourceLocator extends AbstractSourceLocator
      */
     private $classLoader;
 
-    public function __construct(ClassLoader $classLoader)
+    public function __construct(ClassLoader $classLoader, ?Locator $locator = null)
     {
-        parent::__construct();
+        parent::__construct($locator);
         $this->classLoader = $classLoader;
     }
 

--- a/src/SourceLocator/Type/DirectoriesSourceLocator.php
+++ b/src/SourceLocator/Type/DirectoriesSourceLocator.php
@@ -7,6 +7,7 @@ use Roave\BetterReflection\Identifier\Identifier;
 use Roave\BetterReflection\Identifier\IdentifierType;
 use Roave\BetterReflection\Reflection\Reflection;
 use Roave\BetterReflection\Reflector\Reflector;
+use Roave\BetterReflection\SourceLocator\Ast\Locator;
 use Roave\BetterReflection\SourceLocator\Exception\InvalidDirectory;
 use Roave\BetterReflection\SourceLocator\Exception\InvalidFileInfo;
 use RecursiveDirectoryIterator;
@@ -28,10 +29,10 @@ class DirectoriesSourceLocator implements SourceLocator
      * @throws InvalidDirectory
      * @throws InvalidFileInfo
      */
-    public function __construct(array $directories)
+    public function __construct(array $directories, ?Locator $locator = null)
     {
         $this->aggregateSourceLocator = new AggregateSourceLocator(array_values(array_map(
-            function ($directory) {
+            function ($directory) use ($locator) {
                 if (! is_string($directory)) {
                     throw InvalidDirectory::fromNonStringValue($directory);
                 }
@@ -40,10 +41,13 @@ class DirectoriesSourceLocator implements SourceLocator
                     throw InvalidDirectory::fromNonDirectory($directory);
                 }
 
-                return new FileIteratorSourceLocator(new RecursiveIteratorIterator(new RecursiveDirectoryIterator(
-                    $directory,
-                    RecursiveDirectoryIterator::SKIP_DOTS
-                )));
+                return new FileIteratorSourceLocator(
+                    new RecursiveIteratorIterator(new RecursiveDirectoryIterator(
+                        $directory,
+                        RecursiveDirectoryIterator::SKIP_DOTS
+                    )),
+                    $locator
+                );
             },
             $directories
         )));

--- a/src/SourceLocator/Type/EvaledCodeSourceLocator.php
+++ b/src/SourceLocator/Type/EvaledCodeSourceLocator.php
@@ -3,7 +3,9 @@ declare(strict_types=1);
 
 namespace Roave\BetterReflection\SourceLocator\Type;
 
+use PhpParser\Parser;
 use Roave\BetterReflection\Identifier\Identifier;
+use Roave\BetterReflection\SourceLocator\Ast\Locator;
 use Roave\BetterReflection\SourceLocator\Located\EvaledLocatedSource;
 use Roave\BetterReflection\SourceLocator\Located\LocatedSource;
 use Roave\BetterReflection\SourceLocator\Reflection\SourceStubber;
@@ -16,9 +18,9 @@ final class EvaledCodeSourceLocator extends AbstractSourceLocator
      */
     private $stubber;
 
-    public function __construct()
+    public function __construct(?Locator $locator = null)
     {
-        parent::__construct();
+        parent::__construct($locator);
         $this->stubber = new SourceStubber();
     }
 

--- a/src/SourceLocator/Type/FileIteratorSourceLocator.php
+++ b/src/SourceLocator/Type/FileIteratorSourceLocator.php
@@ -3,10 +3,12 @@ declare(strict_types=1);
 
 namespace Roave\BetterReflection\SourceLocator\Type;
 
+use PhpParser\Parser;
 use Roave\BetterReflection\Identifier\Identifier;
 use Roave\BetterReflection\Identifier\IdentifierType;
 use Roave\BetterReflection\Reflection\Reflection;
 use Roave\BetterReflection\Reflector\Reflector;
+use Roave\BetterReflection\SourceLocator\Ast\Locator;
 use Roave\BetterReflection\SourceLocator\Exception\InvalidFileInfo;
 use Roave\BetterReflection\SourceLocator\Exception\InvalidFileLocation;
 
@@ -26,11 +28,16 @@ class FileIteratorSourceLocator implements SourceLocator
     private $fileSystemIterator;
 
     /**
+     * @var null|Locator
+     */
+    private $locator;
+
+    /**
      * @param \Iterator|\SplFileInfo[] $fileInfoIterator note: only \SplFileInfo allowed in this iterator
      *
      * @throws InvalidFileInfo In case of iterator not contains only SplFileInfo
      */
-    public function __construct(\Iterator $fileInfoIterator)
+    public function __construct(\Iterator $fileInfoIterator, ?Locator $locator = null)
     {
         foreach ($fileInfoIterator as $fileInfo) {
             if (! $fileInfo instanceof \SplFileInfo) {
@@ -39,6 +46,7 @@ class FileIteratorSourceLocator implements SourceLocator
         }
 
         $this->fileSystemIterator = $fileInfoIterator;
+        $this->locator            = $locator;
     }
 
     /**
@@ -53,7 +61,7 @@ class FileIteratorSourceLocator implements SourceLocator
                     return null;
                 }
 
-                return new SingleFileSourceLocator($item->getRealPath());
+                return new SingleFileSourceLocator($item->getRealPath(), $this->locator);
             },
             iterator_to_array($this->fileSystemIterator)
         ))));

--- a/src/SourceLocator/Type/MemoizingSourceLocator.php
+++ b/src/SourceLocator/Type/MemoizingSourceLocator.php
@@ -1,0 +1,83 @@
+<?php
+declare(strict_types=1);
+
+namespace Roave\BetterReflection\SourceLocator\Type;
+
+use Roave\BetterReflection\Identifier\Identifier;
+use Roave\BetterReflection\Identifier\IdentifierType;
+use Roave\BetterReflection\Reflection\Reflection;
+use Roave\BetterReflection\Reflector\Reflector;
+
+final class MemoizingSourceLocator implements SourceLocator
+{
+    /**
+     * @var SourceLocator
+     */
+    private $wrappedSourceLocator;
+
+    /**
+     * @var Reflection[][] indexed by reflector key and identifier cache key
+     */
+    private $cacheByIdentifierKeyAndOid = [];
+
+    /**
+     * @var Reflection[][][] indexed by reflector key and identifier type cache key
+     */
+    private $cacheByIdentifierTypeKeyAndOid = [];
+
+    public function __construct(SourceLocator $wrappedSourceLocator)
+    {
+        $this->wrappedSourceLocator = $wrappedSourceLocator;
+    }
+
+    public function locateIdentifier(Reflector $reflector, Identifier $identifier) : ?Reflection
+    {
+        $cacheKey     = $this->identifierToCacheKey($identifier);
+        $reflectorKey = $this->reflectorCacheKey($reflector);
+
+        if (! isset($this->cacheByIdentifierKeyAndOid[$reflectorKey])) {
+            $this->cacheByIdentifierKeyAndOid[$reflectorKey] = [];
+        }
+
+        if (\array_key_exists($cacheKey, $this->cacheByIdentifierKeyAndOid[$reflectorKey])) {
+            return $this->cacheByIdentifierKeyAndOid[$reflectorKey][$cacheKey];
+        }
+
+        return $this->cacheByIdentifierKeyAndOid[$reflectorKey][$cacheKey]
+            = $this->wrappedSourceLocator->locateIdentifier($reflector, $identifier);
+    }
+
+    public function locateIdentifiersByType(Reflector $reflector, IdentifierType $identifierType) : array
+    {
+        $cacheKey     = $this->identifierTypeToCacheKey($identifierType);
+        $reflectorKey = $this->reflectorCacheKey($reflector);
+
+        if (! isset($this->cacheByIdentifierTypeKeyAndOid[$reflectorKey])) {
+            $this->cacheByIdentifierTypeKeyAndOid[$reflectorKey] = [];
+        }
+
+        if (\array_key_exists($cacheKey, $this->cacheByIdentifierTypeKeyAndOid[$reflectorKey])) {
+            return $this->cacheByIdentifierTypeKeyAndOid[$reflectorKey][$cacheKey];
+        }
+
+        return $this->cacheByIdentifierTypeKeyAndOid[$reflectorKey][$cacheKey]
+            = $this->wrappedSourceLocator->locateIdentifiersByType($reflector, $identifierType);
+    }
+
+    private function reflectorCacheKey(Reflector $reflector) : string
+    {
+        return 'type:' . \get_class($reflector)
+            . '#oid:' . \spl_object_hash($reflector);
+    }
+
+    private function identifierToCacheKey(Identifier $identifier) : string
+    {
+        return $this->identifierTypeToCacheKey($identifier->getType())
+            . '#name:' . $identifier->getName();
+    }
+
+    private function identifierTypeToCacheKey(IdentifierType $identifierType) : string
+    {
+        return 'type:' . $identifierType->getName();
+    }
+}

--- a/src/SourceLocator/Type/PhpInternalSourceLocator.php
+++ b/src/SourceLocator/Type/PhpInternalSourceLocator.php
@@ -3,7 +3,9 @@ declare(strict_types=1);
 
 namespace Roave\BetterReflection\SourceLocator\Type;
 
+use PhpParser\Parser;
 use Roave\BetterReflection\Identifier\Identifier;
+use Roave\BetterReflection\SourceLocator\Ast\Locator;
 use Roave\BetterReflection\SourceLocator\Located\InternalLocatedSource;
 use Roave\BetterReflection\SourceLocator\Located\LocatedSource;
 use Roave\BetterReflection\SourceLocator\Reflection\SourceStubber;
@@ -16,9 +18,9 @@ final class PhpInternalSourceLocator extends AbstractSourceLocator
      */
     private $stubber;
 
-    public function __construct()
+    public function __construct(?Locator $locator = null)
     {
-        parent::__construct();
+        parent::__construct($locator);
         $this->stubber = new SourceStubber();
     }
 

--- a/src/SourceLocator/Type/SingleFileSourceLocator.php
+++ b/src/SourceLocator/Type/SingleFileSourceLocator.php
@@ -3,7 +3,9 @@ declare(strict_types=1);
 
 namespace Roave\BetterReflection\SourceLocator\Type;
 
+use PhpParser\Parser;
 use Roave\BetterReflection\Identifier\Identifier;
+use Roave\BetterReflection\SourceLocator\Ast\Locator;
 use Roave\BetterReflection\SourceLocator\Exception\InvalidFileLocation;
 use Roave\BetterReflection\SourceLocator\Located\LocatedSource;
 
@@ -26,9 +28,9 @@ class SingleFileSourceLocator extends AbstractSourceLocator
      * @param string $filename
      * @throws \Roave\BetterReflection\SourceLocator\Exception\InvalidFileLocation
      */
-    public function __construct(string $filename)
+    public function __construct(string $filename, ?Locator $locator = null)
     {
-        parent::__construct();
+        parent::__construct($locator);
         $this->filename = $filename;
 
         if (empty($this->filename)) {

--- a/src/SourceLocator/Type/StringSourceLocator.php
+++ b/src/SourceLocator/Type/StringSourceLocator.php
@@ -3,7 +3,9 @@ declare(strict_types=1);
 
 namespace Roave\BetterReflection\SourceLocator\Type;
 
+use PhpParser\Parser;
 use Roave\BetterReflection\Identifier\Identifier;
+use Roave\BetterReflection\SourceLocator\Ast\Locator;
 use Roave\BetterReflection\SourceLocator\Exception\EmptyPhpSourceCode;
 use Roave\BetterReflection\SourceLocator\Located\LocatedSource;
 
@@ -25,9 +27,9 @@ class StringSourceLocator extends AbstractSourceLocator
      * @param string $source
      * @throws \Roave\BetterReflection\SourceLocator\Exception\EmptyPhpSourceCode
      */
-    public function __construct(string $source)
+    public function __construct(string $source, ?Locator $locator = null)
     {
-        parent::__construct();
+        parent::__construct($locator);
         $this->source = $source;
 
         if (empty($this->source)) {

--- a/src/Util/FindReflectionOnLine.php
+++ b/src/Util/FindReflectionOnLine.php
@@ -3,12 +3,17 @@ declare(strict_types=1);
 
 namespace Roave\BetterReflection\Util;
 
+use PhpParser\Parser;
+use PhpParser\ParserFactory;
 use Roave\BetterReflection\Identifier\IdentifierType;
 use Roave\BetterReflection\Reflection\Reflection;
 use Roave\BetterReflection\Reflection\ReflectionClass;
 use Roave\BetterReflection\Reflection\ReflectionFunction;
 use Roave\BetterReflection\Reflection\ReflectionMethod;
 use Roave\BetterReflection\Reflector\ClassReflector;
+use Roave\BetterReflection\SourceLocator\Ast\Locator;
+use Roave\BetterReflection\SourceLocator\Ast\Parser\MemoizingParser;
+use Roave\BetterReflection\SourceLocator\Ast\PhpParserLocator;
 use Roave\BetterReflection\SourceLocator\Type\AggregateSourceLocator;
 use Roave\BetterReflection\SourceLocator\Type\AutoloadSourceLocator;
 use Roave\BetterReflection\SourceLocator\Type\EvaledCodeSourceLocator;
@@ -24,9 +29,17 @@ final class FindReflectionOnLine
      */
     private $sourceLocator;
 
-    public function __construct(SourceLocator $sourceLocator)
+    /**
+     * @var Locator
+     */
+    private $locator;
+
+    public function __construct(SourceLocator $sourceLocator, ?Locator $locator = null)
     {
         $this->sourceLocator = $sourceLocator;
+        $this->locator       = $locator ?? new PhpParserLocator(
+            new MemoizingParser((new ParserFactory())->create(ParserFactory::PREFER_PHP7))
+        );
     }
 
     /**
@@ -34,10 +47,14 @@ final class FindReflectionOnLine
      */
     public static function buildDefaultFinder() : self
     {
+        $locator = new PhpParserLocator(
+            new MemoizingParser((new ParserFactory())->create(ParserFactory::PREFER_PHP7))
+        );
+
         return new self(new MemoizingSourceLocator(new AggregateSourceLocator([
-            new PhpInternalSourceLocator(),
-            new EvaledCodeSourceLocator(),
-            new AutoloadSourceLocator(),
+            new PhpInternalSourceLocator($locator),
+            new EvaledCodeSourceLocator($locator),
+            new AutoloadSourceLocator($locator),
         ])));
     }
 
@@ -86,7 +103,7 @@ final class FindReflectionOnLine
      */
     private function computeReflections(string $filename) : array
     {
-        $singleFileSourceLocator = new SingleFileSourceLocator($filename);
+        $singleFileSourceLocator = new SingleFileSourceLocator($filename, $this->locator);
         $reflector = new ClassReflector(new AggregateSourceLocator([$singleFileSourceLocator, $this->sourceLocator]));
 
         return array_merge(

--- a/src/Util/FindReflectionOnLine.php
+++ b/src/Util/FindReflectionOnLine.php
@@ -12,6 +12,7 @@ use Roave\BetterReflection\Reflector\ClassReflector;
 use Roave\BetterReflection\SourceLocator\Type\AggregateSourceLocator;
 use Roave\BetterReflection\SourceLocator\Type\AutoloadSourceLocator;
 use Roave\BetterReflection\SourceLocator\Type\EvaledCodeSourceLocator;
+use Roave\BetterReflection\SourceLocator\Type\MemoizingSourceLocator;
 use Roave\BetterReflection\SourceLocator\Type\PhpInternalSourceLocator;
 use Roave\BetterReflection\SourceLocator\Type\SingleFileSourceLocator;
 use Roave\BetterReflection\SourceLocator\Type\SourceLocator;
@@ -33,11 +34,11 @@ final class FindReflectionOnLine
      */
     public static function buildDefaultFinder() : self
     {
-        return new self(new AggregateSourceLocator([
+        return new self(new MemoizingSourceLocator(new AggregateSourceLocator([
             new PhpInternalSourceLocator(),
             new EvaledCodeSourceLocator(),
             new AutoloadSourceLocator(),
-        ]));
+        ])));
     }
 
     /**

--- a/test/unit/Reflector/ClassReflectorTest.php
+++ b/test/unit/Reflector/ClassReflectorTest.php
@@ -7,7 +7,9 @@ use Roave\BetterReflection\Reflection\ReflectionClass;
 use Roave\BetterReflection\Reflector\ClassReflector;
 use Roave\BetterReflection\Reflector\Exception\IdentifierNotFound;
 use Roave\BetterReflection\SourceLocator\Type\AggregateSourceLocator;
+use Roave\BetterReflection\SourceLocator\Type\MemoizingSourceLocator;
 use Roave\BetterReflection\SourceLocator\Type\SingleFileSourceLocator;
+use Roave\BetterReflection\SourceLocator\Type\SourceLocator;
 use Roave\BetterReflection\SourceLocator\Type\StringSourceLocator;
 
 /**
@@ -49,8 +51,10 @@ class ClassReflectorTest extends \PHPUnit_Framework_TestCase
     {
         $defaultReflector = ClassReflector::buildDefaultReflector();
 
-        $sourceLocator = $this->getObjectAttribute($defaultReflector, 'sourceLocator');
-        self::assertInstanceOf(AggregateSourceLocator::class, $sourceLocator);
+        self::assertInstanceOf(
+            SourceLocator::class,
+            $this->getObjectAttribute($defaultReflector, 'sourceLocator')
+        );
     }
 
     public function testThrowsExceptionWhenIdentifierNotFound() : void

--- a/test/unit/SourceLocator/Ast/PhpParserLocatorTest.php
+++ b/test/unit/SourceLocator/Ast/PhpParserLocatorTest.php
@@ -12,13 +12,14 @@ use Roave\BetterReflection\Reflector\Exception\IdentifierNotFound;
 use Roave\BetterReflection\Reflector\FunctionReflector;
 use Roave\BetterReflection\SourceLocator\Ast\Exception\ParseToAstFailure;
 use Roave\BetterReflection\SourceLocator\Ast\Locator;
+use Roave\BetterReflection\SourceLocator\Ast\PhpParserLocator;
 use Roave\BetterReflection\SourceLocator\Located\LocatedSource;
 use Roave\BetterReflection\SourceLocator\Type\StringSourceLocator;
 
 /**
- * @covers \Roave\BetterReflection\SourceLocator\Ast\Locator
+ * @covers \Roave\BetterReflection\SourceLocator\Ast\PhpParserLocator
  */
-class LocatorTest extends \PHPUnit_Framework_TestCase
+class PhpParserLocatorTest extends \PHPUnit_Framework_TestCase
 {
     private function getIdentifier($name, $type) : Identifier
     {
@@ -32,7 +33,7 @@ class LocatorTest extends \PHPUnit_Framework_TestCase
         class Bar {}
         ';
 
-        $classInfo = (new Locator())->findReflection(
+        $classInfo = (new PhpParserLocator())->findReflection(
             new ClassReflector(new StringSourceLocator($php)),
             new LocatedSource($php, null),
             $this->getIdentifier('Foo\Bar', IdentifierType::IDENTIFIER_CLASS)
@@ -47,7 +48,7 @@ class LocatorTest extends \PHPUnit_Framework_TestCase
         class Foo {}
         ';
 
-        $classInfo = (new Locator())->findReflection(
+        $classInfo = (new PhpParserLocator())->findReflection(
             new ClassReflector(new StringSourceLocator($php)),
             new LocatedSource($php, null),
             $this->getIdentifier('Foo', IdentifierType::IDENTIFIER_CLASS)
@@ -62,7 +63,7 @@ class LocatorTest extends \PHPUnit_Framework_TestCase
         function foo() {}
         ';
 
-        $functionInfo = (new Locator())->findReflection(
+        $functionInfo = (new PhpParserLocator())->findReflection(
             new FunctionReflector(new StringSourceLocator($php)),
             new LocatedSource($php, null),
             $this->getIdentifier('foo', IdentifierType::IDENTIFIER_FUNCTION)
@@ -76,7 +77,7 @@ class LocatorTest extends \PHPUnit_Framework_TestCase
         $php = '<?php';
 
         $this->expectException(IdentifierNotFound::class);
-        (new Locator())->findReflection(
+        (new PhpParserLocator())->findReflection(
             new ClassReflector(new StringSourceLocator($php)),
             new LocatedSource($php, null),
             $this->getIdentifier('Foo', IdentifierType::IDENTIFIER_CLASS)
@@ -91,7 +92,7 @@ class LocatorTest extends \PHPUnit_Framework_TestCase
         ";
 
         $this->expectException(IdentifierNotFound::class);
-        (new Locator())->findReflection(
+        (new PhpParserLocator())->findReflection(
             new ClassReflector(new StringSourceLocator($php)),
             new LocatedSource($php, null),
             $this->getIdentifier('Foo', IdentifierType::IDENTIFIER_CLASS)
@@ -100,7 +101,7 @@ class LocatorTest extends \PHPUnit_Framework_TestCase
 
     public function testFindReflectionsOfTypeThrowsParseToAstFailureExceptionWithInvalidCode() : void
     {
-        $locator = new Locator();
+        $locator = new PhpParserLocator();
 
         $phpCode = '<?php syntax error';
 


### PR DESCRIPTION
This is another stab at caching parsing operations. This comes at the expense of memory, but YOLO.

This cannot be opt-out, so the patch is just an example: it should only be handled when building source locators via dependency injection.

The results are as following:

### Before

```
Time: 19.22 seconds, Memory: 70.00MB

OK, but incomplete, skipped, or risky tests!
Tests: 1658, Assertions: 29353, Skipped: 7.

real	0m19.263s
user	0m19.104s
sys	0m0.144s
```

### After

```
Time: 17.56 seconds, Memory: 70.00MB

OK, but incomplete, skipped, or risky tests!
Tests: 1658, Assertions: 29353, Skipped: 7.

real	0m17.593s
user	0m17.436s
sys	0m0.136s
```

I'll check parsing large class trees in a sec.