### PR TITLE
`PhpParser\BuilderFactory` instead of `Zend\Code\Generator\ClassGenerator` in the `SourceStubber`

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ $classInfo = ReflectionClass::createFromName('Foo\Bar\MyClass');
  * `ReflectionType::getTypeObject()` was removed
  * `ReflectionType::createFromType()` now requires `string` for `$type` parameter
  * `ReflectionFunctionAbstract::setReturnType()` now requires `string` for `$newReturnType` parameter
+ * `SourceStubber::__invoke()` now requires `\ReflectionClass` for `$classReflection` parameter
 
 ## More documentation
 

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,6 @@
         "nikic/php-parser": "^3.1.0",
         "phpdocumentor/reflection-docblock": "^3.2.0",
         "phpdocumentor/type-resolver": "^0.4.0",
-        "zendframework/zend-code": "^3.1",
         "roave/signature": "^1.0"
     },
     "require-dev": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -3,5 +3,4 @@ parameters:
         # Some parent constructors are explicitly to be ignored
         - '#does not call parent constructor#'
         - '#Access to an undefined property PhpParser\\Node\\Param::\$isOptional#'
-        - '#Access to an undefined property PhpParser\\Node::\$stmts#'
         - '#Access to an undefined property PhpParser\\Node\\Stmt\\ClassLike::\$namespacedName#'

--- a/src/SourceLocator/Type/EvaledCodeSourceLocator.php
+++ b/src/SourceLocator/Type/EvaledCodeSourceLocator.php
@@ -8,7 +8,6 @@ use Roave\BetterReflection\Identifier\Identifier;
 use Roave\BetterReflection\SourceLocator\Located\EvaledLocatedSource;
 use Roave\BetterReflection\SourceLocator\Located\LocatedSource;
 use Roave\BetterReflection\SourceLocator\Reflection\SourceStubber;
-use Zend\Code\Reflection\ClassReflection;
 
 final class EvaledCodeSourceLocator extends AbstractSourceLocator
 {
@@ -30,23 +29,20 @@ final class EvaledCodeSourceLocator extends AbstractSourceLocator
      */
     protected function createLocatedSource(Identifier $identifier) : ?LocatedSource
     {
-        if ( ! $name = $this->getInternalReflectionClassName($identifier)) {
+        $classReflection = $this->getInternalReflectionClass($identifier);
+
+        if (null === $classReflection) {
             return null;
         }
 
         $stubber = $this->stubber;
 
         return new EvaledLocatedSource(
-            "<?php\n\n" . $stubber(new ClassReflection($name))
+            "<?php\n\n" . $stubber($classReflection)
         );
     }
 
-    /**
-     * @param Identifier $identifier
-     *
-     * @return null|string
-     */
-    private function getInternalReflectionClassName(Identifier $identifier) : ?string
+    private function getInternalReflectionClass(Identifier $identifier) : ?ReflectionClass
     {
         if ( ! $identifier->isClass()) {
             return null;
@@ -62,6 +58,6 @@ final class EvaledCodeSourceLocator extends AbstractSourceLocator
         $sourceFile = $reflection->getFileName();
 
         return ($sourceFile && \file_exists($sourceFile))
-            ? null : $reflection->getName();
+            ? null : $reflection;
     }
 }

--- a/test/unit/Fixture/ClassForSourceStubber.php
+++ b/test/unit/Fixture/ClassForSourceStubber.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace Roave\BetterReflectionTest\Fixture;
+
+use JsonSerializable;
+use Serializable;
+
+class ParentClassForSourceStubber
+{
+    public function methodFromParentClass()
+    {
+    }
+}
+
+interface ImplementedInterfaceForSourceStubber extends JsonSerializable
+{
+    public function methodFromInterface();
+}
+
+trait UsedParentTraitForSourceStubber
+{
+    public $propertyFromParentTrait;
+
+    public function methodFromParentTrait()
+    {
+    }
+}
+
+trait UsedTraitForSourceStubber
+{
+    use UsedParentTraitForSourceStubber;
+
+    protected $propertyFromTrait;
+
+    public function methodFromTrait()
+    {
+    }
+}
+
+trait UsedTraitToAliasForSourceStubber
+{
+    public function methodFromTraitToAlias()
+    {
+    }
+}
+
+/**
+ * Class comment
+ */
+abstract class ClassForSourceStubber extends ParentClassForSourceStubber implements ImplementedInterfaceForSourceStubber, Serializable
+{
+    use UsedTraitForSourceStubber;
+    use UsedTraitToAliasForSourceStubber {
+        UsedTraitToAliasForSourceStubber::methodFromTraitToAlias as aliasMethodFromTrait;
+    }
+
+    /**
+     * Constant comment
+     */
+    const CONSTANT_WITHOUT_VISIBILITY = 1;
+    public const PUBLIC_CONSTANT = 0.0;
+    protected const PROTECTED_CONSTANT = 'string';
+    private const PRIVATE_CONSTANT = [1, 2, 3];
+
+    var $propertyWithoutVisibility = 0;
+
+    /**
+     * @var int|float|\stdClass
+     */
+    private $privateProperty = 1.1;
+
+    /**
+     * @var bool|bool[]|bool[][]
+     */
+    protected $protectedProperty = false;
+
+    /**
+     * @var string
+     */
+    public $publicProperty = 'string';
+
+    public static $publicStaticProperty;
+
+    function methodWithoutVisibility() : ?\stdClass
+    {
+    }
+
+    /**
+     * Method comment
+     */
+    public function publicMethod() : bool
+    {
+    }
+
+    public function protectedMethod() : int
+    {
+    }
+
+    public function privateMethod() : ?string
+    {
+    }
+
+    public static function publicStaticMethod() : void
+    {
+    }
+
+    abstract public function publicAbstractMethod();
+
+    final public function publicFinalMethod() : float
+    {
+    }
+
+    public function methodWithParameters($string, $int, $float, $bool, $iterable, $callable) : void
+    {
+    }
+
+    public function methodWithParametersWithTypes(string $string, int $int, float $float, bool $bool, iterable $iterable, callable $callable) : void
+    {
+    }
+
+    public function methodWithParametersWithNullableTypes(?string $string, ?int $int, ?float $float, ?bool $bool, ?iterable $iterable, ?callable $callable) : void
+    {
+    }
+
+    public function methodWithOptionalParameters(string $string = 'string', int $int = 123, float $float = 0.0, bool $bool = true, iterable $iterable = [], ?callable $callable = null) : void
+    {
+    }
+
+    public function methodWithSelfAndParentParameters(self $self, parent $parent) : void
+    {
+    }
+
+    public function methodWithVariadicParameter(string ...$variadic) : void
+    {
+    }
+
+    public function methodWithParameterPassedByReference(bool &$bool) : void
+    {
+    }
+
+    public function &methodReturnsReference() : array
+    {
+    }
+}

--- a/test/unit/Fixture/ClassForSourceStubberExpected.php
+++ b/test/unit/Fixture/ClassForSourceStubberExpected.php
@@ -1,0 +1,80 @@
+<?php
+namespace Roave\BetterReflectionTest\Fixture;
+
+/**
+ * Class comment
+ */
+abstract class ClassForSourceStubber extends \Roave\BetterReflectionTest\Fixture\ParentClassForSourceStubber implements \Roave\BetterReflectionTest\Fixture\ImplementedInterfaceForSourceStubber, \Serializable
+{
+    use \Roave\BetterReflectionTest\Fixture\UsedTraitToAliasForSourceStubber {
+        \Roave\BetterReflectionTest\Fixture\UsedTraitToAliasForSourceStubber::methodFromTraitToAlias as aliasMethodFromTrait;
+    }
+    use \Roave\BetterReflectionTest\Fixture\UsedTraitForSourceStubber;
+    /**
+     * Constant comment
+     */
+    public const CONSTANT_WITHOUT_VISIBILITY = 1;
+    public const PUBLIC_CONSTANT = 0.0;
+    protected const PROTECTED_CONSTANT = 'string';
+    private const PRIVATE_CONSTANT = [1, 2, 3];
+    public $propertyWithoutVisibility = 0;
+    /**
+     * @var int|float|\stdClass
+     */
+    private $privateProperty = 1.1;
+    /**
+     * @var bool|bool[]|bool[][]
+     */
+    protected $protectedProperty = false;
+    /**
+     * @var string
+     */
+    public $publicProperty = 'string';
+    public static $publicStaticProperty = null;
+    public function methodWithoutVisibility() : ?\stdClass
+    {
+    }
+    /**
+     * Method comment
+     */
+    public function publicMethod() : bool
+    {
+    }
+    public function protectedMethod() : int
+    {
+    }
+    public function privateMethod() : ?string
+    {
+    }
+    public static function publicStaticMethod() : void
+    {
+    }
+    public abstract function publicAbstractMethod();
+    public final function publicFinalMethod() : float
+    {
+    }
+    public function methodWithParameters($string, $int, $float, $bool, $iterable, $callable) : void
+    {
+    }
+    public function methodWithParametersWithTypes(string $string, int $int, float $float, bool $bool, iterable $iterable, callable $callable) : void
+    {
+    }
+    public function methodWithParametersWithNullableTypes(?string $string, ?int $int, ?float $float, ?bool $bool, ?iterable $iterable, ?callable $callable) : void
+    {
+    }
+    public function methodWithOptionalParameters(string $string = 'string', int $int = 123, float $float = 0.0, bool $bool = true, iterable $iterable = [], ?callable $callable = null) : void
+    {
+    }
+    public function methodWithSelfAndParentParameters(self $self, parent $parent) : void
+    {
+    }
+    public function methodWithVariadicParameter(string ...$variadic) : void
+    {
+    }
+    public function methodWithParameterPassedByReference(bool &$bool) : void
+    {
+    }
+    public function &methodReturnsReference() : array
+    {
+    }
+}

--- a/test/unit/Fixture/ClassWithoutNamespaceForSourceStubber.php
+++ b/test/unit/Fixture/ClassWithoutNamespaceForSourceStubber.php
@@ -1,0 +1,5 @@
+<?php
+
+class ClassWithoutNamespaceForSourceStubber
+{
+}

--- a/test/unit/Fixture/ClassWithoutNamespaceForSourceStubberExpected.php
+++ b/test/unit/Fixture/ClassWithoutNamespaceForSourceStubberExpected.php
@@ -1,0 +1,4 @@
+<?php
+class ClassWithoutNamespaceForSourceStubber
+{
+}

--- a/test/unit/Fixture/InterfaceForSourceStubber.php
+++ b/test/unit/Fixture/InterfaceForSourceStubber.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Roave\BetterReflectionTest\Fixture;
+
+use JsonSerializable;
+use Serializable;
+
+/**
+ * Interface comment
+ */
+interface InterfaceForSourceStubber extends JsonSerializable, Serializable
+{
+}

--- a/test/unit/Fixture/InterfaceForSourceStubberExpected.php
+++ b/test/unit/Fixture/InterfaceForSourceStubberExpected.php
@@ -1,0 +1,9 @@
+<?php
+namespace Roave\BetterReflectionTest\Fixture;
+
+/**
+ * Interface comment
+ */
+interface InterfaceForSourceStubber extends \JsonSerializable, \Serializable
+{
+}

--- a/test/unit/Fixture/TraitForSourceStubber.php
+++ b/test/unit/Fixture/TraitForSourceStubber.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Roave\BetterReflectionTest\Fixture;
+
+trait TraitForSourceStubber
+{
+    public function methodFromTrait()
+    {
+    }
+}

--- a/test/unit/Fixture/TraitForSourceStubberExpected.php
+++ b/test/unit/Fixture/TraitForSourceStubberExpected.php
@@ -1,0 +1,9 @@
+<?php
+namespace Roave\BetterReflectionTest\Fixture;
+
+trait TraitForSourceStubber
+{
+    public function methodFromTrait()
+    {
+    }
+}

--- a/test/unit/SourceLocator/Reflection/SourceStubberTest.php
+++ b/test/unit/SourceLocator/Reflection/SourceStubberTest.php
@@ -3,11 +3,15 @@ declare(strict_types=1);
 
 namespace Roave\BetterReflectionTest\SourceLocator\Reflection;
 
+use ClassWithoutNamespaceForSourceStubber;
 use PHPUnit\Framework\TestCase;
+use ReflectionClass as CoreReflectionClass;
 use Roave\BetterReflection\SourceLocator\Reflection\SourceStubber;
+use Roave\BetterReflectionTest\Fixture\ClassForSourceStubber;
 use Roave\BetterReflectionTest\Fixture\EmptyTrait;
+use Roave\BetterReflectionTest\Fixture\InterfaceForSourceStubber;
+use Roave\BetterReflectionTest\Fixture\TraitForSourceStubber;
 use Traversable;
-use Zend\Code\Reflection\ClassReflection;
 
 /**
  * @covers \Roave\BetterReflection\SourceLocator\Reflection\SourceStubber
@@ -31,7 +35,7 @@ class SourceStubberTest extends TestCase
     {
         self::assertStringMatchesFormat(
             '%Aclass stdClass%A{%A}%A',
-            $this->stubber->__invoke(new ClassReflection('stdClass'))
+            $this->stubber->__invoke(new CoreReflectionClass('stdClass'))
         );
     }
 
@@ -39,7 +43,7 @@ class SourceStubberTest extends TestCase
     {
         self::assertStringMatchesFormat(
             '%Ainterface Traversable%A{%A}%A',
-            $this->stubber->__invoke(new ClassReflection(Traversable::class))
+            $this->stubber->__invoke(new CoreReflectionClass(Traversable::class))
         );
     }
 
@@ -47,7 +51,32 @@ class SourceStubberTest extends TestCase
     {
         self::assertStringMatchesFormat(
             '%Atrait EmptyTrait%A{%A}%A',
-            $this->stubber->__invoke(new ClassReflection(EmptyTrait::class))
+            $this->stubber->__invoke(new CoreReflectionClass(EmptyTrait::class))
         );
+    }
+
+    public function testClassStub() : void
+    {
+        $classReflection = new CoreReflectionClass(ClassForSourceStubber::class);
+        self::assertStringEqualsFile(__DIR__ . '/../../Fixture/ClassForSourceStubberExpected.php', "<?php\n" . $this->stubber->__invoke($classReflection) . "\n");
+    }
+
+    public function testClassWithoutNamespaceStub() : void
+    {
+        require __DIR__ . '/../../Fixture/ClassWithoutNamespaceForSourceStubber.php';
+        $classReflection = new CoreReflectionClass(ClassWithoutNamespaceForSourceStubber::class);
+        self::assertStringEqualsFile(__DIR__ . '/../../Fixture/ClassWithoutNamespaceForSourceStubberExpected.php', "<?php\n" . $this->stubber->__invoke($classReflection) . "\n");
+    }
+
+    public function testInterfaceStub() : void
+    {
+        $classReflection = new CoreReflectionClass(InterfaceForSourceStubber::class);
+        self::assertStringEqualsFile(__DIR__ . '/../../Fixture/InterfaceForSourceStubberExpected.php', "<?php\n" . $this->stubber->__invoke($classReflection) . "\n");
+    }
+
+    public function testTraitStub() : void
+    {
+        $classReflection = new CoreReflectionClass(TraitForSourceStubber::class);
+        self::assertStringEqualsFile(__DIR__ . '/../../Fixture/TraitForSourceStubberExpected.php', "<?php\n" . $this->stubber->__invoke($classReflection) . "\n");
     }
 }


### PR DESCRIPTION
There's already PhpParser so we can use its `BuilderFactory` to remove dependency on `zendframework/zend-code`.

It should be probably a little faster too because this code has been removed: https://github.com/Roave/BetterReflection/blob/master/src/SourceLocator/Reflection/SourceStubber.php#L51