### PR TITLE
Check if identifier name is valid

### DIFF
--- a/src/Identifier/Exception/InvalidIdentifierName.php
+++ b/src/Identifier/Exception/InvalidIdentifierName.php
@@ -1,0 +1,14 @@
+<?php
+declare(strict_types=1);
+
+namespace Roave\BetterReflection\Identifier\Exception;
+
+use InvalidArgumentException;
+
+class InvalidIdentifierName extends InvalidArgumentException
+{
+    public static function fromInvalidName(string $name) : self
+    {
+        return new self(\sprintf('Invalid identifier name "%s"', $name));
+    }
+}

--- a/src/SourceLocator/Type/AbstractSourceLocator.php
+++ b/src/SourceLocator/Type/AbstractSourceLocator.php
@@ -59,7 +59,7 @@ abstract class AbstractSourceLocator implements SourceLocator
      */
     final public function locateIdentifiersByType(Reflector $reflector, IdentifierType $identifierType) : array
     {
-        if ( ! ($locatedSource = $this->createLocatedSource(new Identifier('*', $identifierType)))) {
+        if ( ! ($locatedSource = $this->createLocatedSource(new Identifier(Identifier::WILDCARD, $identifierType)))) {
             return [];
         }
 

--- a/test/unit/Identifier/Exception/InvalidIdentifierNameTest.php
+++ b/test/unit/Identifier/Exception/InvalidIdentifierNameTest.php
@@ -1,0 +1,21 @@
+<?php
+declare(strict_types=1);
+
+namespace Roave\BetterReflectionTest\Identifier\Exception;
+
+use PHPUnit\Framework\TestCase;
+use Roave\BetterReflection\Identifier\Exception\InvalidIdentifierName;
+
+/**
+ * @covers \Roave\BetterReflection\Identifier\Exception\InvalidIdentifierName
+ */
+class InvalidIdentifierNameTest extends TestCase
+{
+    public function testFromInvalidName() : void
+    {
+        $exception = InvalidIdentifierName::fromInvalidName('!@#$%^&*()');
+
+        self::assertInstanceOf(InvalidIdentifierName::class, $exception);
+        self::assertSame('Invalid identifier name "!@#$%^&*()"', $exception->getMessage());
+    }
+}


### PR DESCRIPTION
Implemented https://github.com/Roave/BetterReflection/issues/20

I've slightly modifed the regexp:

Before: `/([a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]+)(\\\\[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]+)*/`
After:  `'/([a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*)(\\\\[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*)*/'`

The first one did not support names with only one letter.