### PR TITLE
ReflectionClass::newInstance() and ReflectionObject::newInstance() compatibility in all PHP versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,16 @@ jobs:
       env: DEPENDENCIES="--prefer-lowest --prefer-stable"
       script: vendor/bin/phpunit
 
+    - stage: Test
+      php: 7.2
+      env: DEPENDENCIES=""
+      script: vendor/bin/phpunit
+
+    - stage: Test
+      php: 7.2
+      env: DEPENDENCIES="--prefer-lowest --prefer-stable"
+      script: vendor/bin/phpunit
+
     - stage: Test Compatibility
       php: 7.1
       env: DEPENDENCIES=""
@@ -25,6 +35,16 @@ jobs:
       env: DEPENDENCIES="--prefer-lowest --prefer-stable"
       script: vendor/bin/phpunit test/compat
 
+    - stage: Test Compatibility
+      php: 7.2
+      env: DEPENDENCIES=""
+      script: vendor/bin/phpunit test/compat
+
+    - stage: Test Compatibility
+      php: 7.2
+      env: DEPENDENCIES="--prefer-lowest --prefer-stable"
+      script: vendor/bin/phpunit test/compat
+
     - stage: Check Demo Scripts
       php: 7.1
       env: DEPENDENCIES=""
@@ -32,6 +52,16 @@ jobs:
 
     - stage: Check Demo Scripts
       php: 7.1
+      env: DEPENDENCIES="--prefer-lowest --prefer-stable"
+      script: test/demo/check-demo.sh
+
+    - stage: Check Demo Scripts
+      php: 7.2
+      env: DEPENDENCIES=""
+      script: test/demo/check-demo.sh
+
+    - stage: Check Demo Scripts
+      php: 7.2
       env: DEPENDENCIES="--prefer-lowest --prefer-stable"
       script: test/demo/check-demo.sh
 
@@ -58,6 +88,9 @@ jobs:
       script:
         - vendor/bin/phpunit --coverage-text --coverage-clover=clover.xml
         - php ocular.phar code-coverage:upload --format=php-clover clover.xml
+
+  allow_failures:
+    - php: 7.2
 
 cache:
   directories:

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Better Reflection - an improved code reflection API",
     "license": "MIT",
     "require": {
-        "php": "7.1.*",
+        "php": ">7.1.0,<7.3.0",
         "nikic/php-parser": "^3.1.0",
         "phpdocumentor/reflection-docblock": "^3.2.0",
         "phpdocumentor/type-resolver": "^0.4.0",

--- a/src/Reflection/Adapter/ReflectionClass.php
+++ b/src/Reflection/Adapter/ReflectionClass.php
@@ -344,7 +344,7 @@ class ReflectionClass extends CoreReflectionClass
     /**
      * {@inheritDoc}
      */
-    public function newInstance($args = null, $_ = null)
+    public function newInstance($arg = null, ...$args)
     {
         throw new Exception\NotImplemented('Not implemented');
     }

--- a/src/Reflection/Adapter/ReflectionObject.php
+++ b/src/Reflection/Adapter/ReflectionObject.php
@@ -315,7 +315,7 @@ class ReflectionObject extends CoreReflectionObject
     /**
      * {@inheritDoc}
      */
-    public function newInstance($args)
+    public function newInstance($arg = null, ...$args)
     {
         throw new Exception\NotImplemented('Not implemented');
     }


### PR DESCRIPTION
Fix of https://github.com/Roave/BetterReflection/issues/317

Inspired by https://github.com/goaop/parser-reflection/issues/70