### PR TITLE
Fixed stubs searching

### DIFF
--- a/src/SourceLocator/Type/PhpInternalSourceLocator.php
+++ b/src/SourceLocator/Type/PhpInternalSourceLocator.php
@@ -96,7 +96,7 @@ final class PhpInternalSourceLocator extends AbstractSourceLocator
             return null;
         }
 
-        return __DIR__ . '/../../stub/' . $className . '.stub';
+        return __DIR__ . '/../../../stub/' . $className . '.stub';
     }
 
     /**

--- a/stub/mysqli_result.stub
+++ b/stub/mysqli_result.stub
@@ -1,5 +1,3 @@
-<?php
-
 class mysqli_result implements Traversable
 {
 


### PR DESCRIPTION
Build is failing because a lot of stubs is out of date...

The stubs searching is broken since https://github.com/Roave/BetterReflection/commit/3f9a4b317a6c1bc29ab207e4a6b259622bca5813 so it doesn't work almost two years.

May I remove the stubs functionality?