### PR TITLE
Introduced PHPBench with sample benchmark

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -89,6 +89,11 @@ jobs:
         - vendor/bin/phpunit --coverage-text --coverage-clover=clover.xml
         - php ocular.phar code-coverage:upload --format=php-clover clover.xml
 
+    - stage: Run benchmarks
+      php: 7.1
+      env: DEPENDENCIES=""
+      script: ./vendor/bin/phpbench run --progress=dots --iterations=1
+
   allow_failures:
     - php: 7.2
 

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,8 @@
         "roave/signature": "^1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.3.0"
+        "phpunit/phpunit": "^6.3.0",
+        "phpbench/phpbench": "^0.13.0"
     },
     "autoload": {
         "psr-4": {
@@ -19,7 +20,8 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "Roave\\BetterReflectionTest\\": "test/unit"
+            "Roave\\BetterReflectionTest\\": "test/unit",
+            "Roave\\BetterReflectionBenchmark\\": "test/benchmark"
         }
     },
     "suggest": {

--- a/phpbench.json
+++ b/phpbench.json
@@ -1,0 +1,4 @@
+{
+    "bootstrap": "vendor/autoload.php",
+    "path": "test/benchmark"
+}

--- a/test/benchmark/PhpUnitTestCaseBench.php
+++ b/test/benchmark/PhpUnitTestCaseBench.php
@@ -8,6 +8,9 @@ use Roave\BetterReflection\Reflector\ClassReflector;
 use Roave\BetterReflection\Reflection\ReflectionMethod;
 use Roave\BetterReflection\Reflection\ReflectionParameter;
 
+/**
+ * @Iterations(10)
+ */
 class PhpUnitTestCaseBench
 {
     /**

--- a/test/benchmark/PhpUnitTestCaseBench.php
+++ b/test/benchmark/PhpUnitTestCaseBench.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Roave\BetterReflectionBenchmark;
+
+use PHPUnit\Framework\TestCase;
+use Roave\BetterReflection\BetterReflection;
+use Roave\BetterReflection\Reflector\ClassReflector;
+use Roave\BetterReflection\Reflection\ReflectionMethod;
+use Roave\BetterReflection\Reflection\ReflectionParameter;
+
+class PhpUnitTestCaseBench
+{
+    /**
+     * @var ClassReflector
+     */
+    private $reflector;
+
+    public function __construct()
+    {
+        $reflection = new BetterReflection();
+        $this->reflector = $reflection->classReflector();
+    }
+
+    /**
+     * @Subject()
+     */
+    public function reflect_phpunit_test_case()
+    {
+        $reflection = $this->reflector->reflect(TestCase::class);
+
+        /** @var $method ReflectionMethod */
+        foreach ($reflection->getMethods() as $method) {
+            $method->hasReturnType() ? $method->getReturnType()->__toString() : null;
+
+            /** @var $parameter ReflectionParameter */
+            foreach ($method->getParameters() as $parameter) {
+                $parameter->hasType() ? $parameter->getType()->__toString() : null;
+            }
+        }
+    }
+}
+

--- a/test/benchmark/PhpUnitTestCaseBench.php
+++ b/test/benchmark/PhpUnitTestCaseBench.php
@@ -7,9 +7,10 @@ use Roave\BetterReflection\BetterReflection;
 use Roave\BetterReflection\Reflector\ClassReflector;
 use Roave\BetterReflection\Reflection\ReflectionMethod;
 use Roave\BetterReflection\Reflection\ReflectionParameter;
+use Roave\BetterReflection\Reflection\ReflectionProperty;
 
 /**
- * @Iterations(10)
+ * @Iterations(5)
  */
 class PhpUnitTestCaseBench
 {
@@ -18,27 +19,60 @@ class PhpUnitTestCaseBench
      */
     private $reflector;
 
+    /**
+     * @var ReflectionClass
+     */
+    private $reflectionClass;
+
     public function __construct()
     {
         $reflection = new BetterReflection();
         $this->reflector = $reflection->classReflector();
+        $this->reflectionClass = $this->reflector->reflect(TestCase::class);
     }
 
     /**
      * @Subject()
      */
-    public function reflect_phpunit_test_case()
+    public function reflect_class()
     {
-        $reflection = $this->reflector->reflect(TestCase::class);
+        $this->reflector->reflect(TestCase::class);
+    }
 
+    /**
+     * @Subject()
+     */
+    public function reflect_methods()
+    {
         /** @var $method ReflectionMethod */
-        foreach ($reflection->getMethods() as $method) {
-            $method->hasReturnType() ? $method->getReturnType()->__toString() : null;
+        foreach ($this->reflectionClass->getMethods() as $method) {
+            $method->getReturnType();
+        }
+    }
 
-            /** @var $parameter ReflectionParameter */
+    /**
+     * @Subject()
+     */
+    public function reflect_method_parameters()
+    {
+        /** @var $method ReflectionMethod */
+        foreach ($this->reflectionClass->getMethods() as $method) {
+            $method->getReturnType();
+
             foreach ($method->getParameters() as $parameter) {
-                $parameter->hasType() ? $parameter->getType()->__toString() : null;
+                $parameter->getType();
             }
+        }
+    }
+
+    /**
+     * @Subject()
+     */
+    public function reflect_methods_doc_return_types()
+    {
+        /** @var $method ReflectionMethod */
+        foreach ($this->reflectionClass->getMethods() as $method) {
+            $method->getDocBlockReturnTypes();
         }
     }
 }


### PR DESCRIPTION
Added PHPBench and a sample benchmark.

The sample benchmark reflects the PHPUnit `TestCase` class - this isn't ideal as it can obviously change, but a class of that magnitude is a good candidate.

I compared the memonising PR with the master branch below:

```
phpbench report --uuid=latest --uuid=latest-1 --report='{extends: aggregate, break: [ benchmark ], cols: [ mem_peak, best, mean, mode, worst, stdev ]}'
benchmark: PhpUnitTestCaseBench
+-------------+---------------+---------------+---------------+---------------+---------+
| mem_peak    | best          | mean          | mode          | worst         | stdev   |
+-------------+---------------+---------------+---------------+---------------+---------+
| 15,263,800b | 269,072.000μs | 269,072.000μs | 269,072.000μs | 269,072.000μs | 0.000μs |
| 15,247,312b | 414,300.000μs | 414,300.000μs | 414,300.000μs | 414,300.000μs | 0.000μs |
+-------------+---------------+---------------+---------------+---------------+---------+
```