### PR TITLE
Improved SourceStubber trait tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "license": "MIT",
     "require": {
         "php": ">7.1.0,<7.3.0",
-        "nikic/php-parser": "^3.1.0",
+        "nikic/php-parser": "^3.1.1",
         "phpdocumentor/reflection-docblock": "^3.2.0",
         "phpdocumentor/type-resolver": "^0.4.0",
         "roave/signature": "^1.0"

--- a/test/unit/Fixture/TraitForSourceStubber.php
+++ b/test/unit/Fixture/TraitForSourceStubber.php
@@ -2,8 +2,14 @@
 
 namespace Roave\BetterReflectionTest\Fixture;
 
+trait OtherTraitForSourceStubber
+{
+}
+
 trait TraitForSourceStubber
 {
+    use OtherTraitForSourceStubber;
+
     public function methodFromTrait()
     {
     }

--- a/test/unit/Fixture/TraitForSourceStubberExpected.php
+++ b/test/unit/Fixture/TraitForSourceStubberExpected.php
@@ -3,6 +3,7 @@ namespace Roave\BetterReflectionTest\Fixture;
 
 trait TraitForSourceStubber
 {
+    use \Roave\BetterReflectionTest\Fixture\OtherTraitForSourceStubber;
     public function methodFromTrait()
     {
     }


### PR DESCRIPTION
There was a bug in php-parser 3.1.0. It's fixed in [3.1.1](https://github.com/nikic/PHP-Parser/releases/tag/v3.1.1) so it's possible to improve one test.