### PR TITLE
Replacing internal `assertObject` return type with `object`, removing therefore the implicit upcast

### DIFF
--- a/src/Reflection/ReflectionMethod.php
+++ b/src/Reflection/ReflectionMethod.php
@@ -348,10 +348,10 @@ class ReflectionMethod extends ReflectionFunctionAbstract
             };
         }
 
-        $this->assertObject($object);
+        $instance = $this->assertObject($object);
 
-        return function (...$args) use ($object) {
-            return $this->callObjectMethod($object, $args);
+        return function (...$args) use ($instance) {
+            return $this->callObjectMethod($instance, $args);
         };
     }
 
@@ -392,9 +392,7 @@ class ReflectionMethod extends ReflectionFunctionAbstract
             return $this->callStaticMethod($args);
         }
 
-        $this->assertObject($object);
-
-        return $this->callObjectMethod($object, $args);
+        return $this->callObjectMethod($this->assertObject($object), $args);
     }
 
     /**
@@ -435,13 +433,15 @@ class ReflectionMethod extends ReflectionFunctionAbstract
     }
 
     /**
-     * @param object $object
+     * @param mixed $object
      *
      * @throws NoObjectProvided
      * @throws NotAnObject
      * @throws ObjectNotInstanceOfClass
+     *
+     * @return object
      */
-    private function assertObject($object) : void
+    private function assertObject($object)
     {
         if (null === $object) {
             throw NoObjectProvided::create();
@@ -456,5 +456,7 @@ class ReflectionMethod extends ReflectionFunctionAbstract
         if (\get_class($object) !== $declaringClassName) {
             throw ObjectNotInstanceOfClass::fromClassName($declaringClassName);
         }
+
+        return $object;
     }
 }

--- a/src/Reflection/ReflectionProperty.php
+++ b/src/Reflection/ReflectionProperty.php
@@ -400,11 +400,11 @@ class ReflectionProperty implements CoreReflector
             }, null, $declaringClassName)->__invoke($declaringClassName, $this->getName());
         }
 
-        $this->assertObject($object);
+        $instance = $this->assertObject($object);
 
-        return Closure::bind(function ($object, string $propertyName) {
-            return $object->{$propertyName};
-        }, $object, $declaringClassName)->__invoke($object, $this->getName());
+        return Closure::bind(function ($instance, string $propertyName) {
+            return $instance->{$propertyName};
+        }, $instance, $declaringClassName)->__invoke($instance, $this->getName());
     }
 
     /**
@@ -431,11 +431,11 @@ class ReflectionProperty implements CoreReflector
             return;
         }
 
-        $this->assertObject($object);
+        $instance = $this->assertObject($object);
 
-        Closure::bind(function ($object, string $propertyName, $value) : void {
-            $object->{$propertyName} = $value;
-        }, $object, $declaringClassName)->__invoke($object, $this->getName(), $value);
+        Closure::bind(function ($instance, string $propertyName, $value) : void {
+            $instance->{$propertyName} = $value;
+        }, $instance, $declaringClassName)->__invoke($instance, $this->getName(), $value);
     }
 
     /**
@@ -449,13 +449,15 @@ class ReflectionProperty implements CoreReflector
     }
 
     /**
-     * @param object $object
+     * @param mixed $object
      *
      * @throws NoObjectProvided
      * @throws NotAnObject
      * @throws ObjectNotInstanceOfClass
+     *
+     * @return object
      */
-    private function assertObject($object) : void
+    private function assertObject($object)
     {
         if (null === $object) {
             throw NoObjectProvided::create();
@@ -470,5 +472,7 @@ class ReflectionProperty implements CoreReflector
         if (\get_class($object) !== $declaringClassName) {
             throw ObjectNotInstanceOfClass::fromClassName($declaringClassName);
         }
+
+        return $object;
     }
 }


### PR DESCRIPTION
Just hunting for static analysis issues. 7.2 will make this more pleasant in the future.