### PR TITLE
Mark `*::createFromNode` methods as `@internal` to indicate they…

### DIFF
--- a/src/Reflection/ReflectionClass.php
+++ b/src/Reflection/ReflectionClass.php
@@ -222,6 +222,7 @@ class ReflectionClass implements Reflection, CoreReflector
     /**
      * Create from a Class Node.
      *
+     * @internal
      * @param Reflector          $reflector
      * @param ClassLikeNode      $node Node has to be processed by the PhpParser\NodeVisitor\NameResolver
      * @param LocatedSource      $locatedSource

--- a/src/Reflection/ReflectionClassConstant.php
+++ b/src/Reflection/ReflectionClassConstant.php
@@ -47,6 +47,7 @@ class ReflectionClassConstant implements CoreReflector
     /**
      * Create a reflection of a class's constant by Const Node
      *
+     * @internal
      * @param Reflector $reflector
      * @param ClassConst $node Node has to be processed by the PhpParser\NodeVisitor\NameResolver
      * @param ReflectionClass $owner

--- a/src/Reflection/ReflectionFunction.php
+++ b/src/Reflection/ReflectionFunction.php
@@ -69,6 +69,7 @@ class ReflectionFunction extends ReflectionFunctionAbstract implements Reflectio
     }
 
     /**
+     * @internal
      * @param Reflector $reflector
      * @param FunctionNode $node Node has to be processed by the PhpParser\NodeVisitor\NameResolver
      * @param LocatedSource $locatedSource

--- a/src/Reflection/ReflectionMethod.php
+++ b/src/Reflection/ReflectionMethod.php
@@ -31,6 +31,7 @@ class ReflectionMethod extends ReflectionFunctionAbstract
     private $methodNode;
 
     /**
+     * @internal
      * @param Reflector       $reflector
      * @param MethodNode      $node Node has to be processed by the PhpParser\NodeVisitor\NameResolver
      * @param Namespace_|null $namespace

--- a/src/Reflection/ReflectionParameter.php
+++ b/src/Reflection/ReflectionParameter.php
@@ -193,6 +193,7 @@ class ReflectionParameter implements CoreReflector
     }
 
     /**
+     * @internal
      * @param Reflector                  $reflector
      * @param ParamNode                  $node               Node has to be processed by the PhpParser\NodeVisitor\NameResolver
      * @param Namespace_|null            $declaringNamespace namespace of the declaring function/method

--- a/src/Reflection/ReflectionProperty.php
+++ b/src/Reflection/ReflectionProperty.php
@@ -111,6 +111,7 @@ class ReflectionProperty implements CoreReflector
     }
 
     /**
+     * @internal
      * @param Reflector       $reflector
      * @param PropertyNode    $node Node has to be processed by the PhpParser\NodeVisitor\NameResolver
      * @param Namespace_      $declaringNamespace


### PR DESCRIPTION
… shouldn't be used outside the library #358 