### PR TITLE
MemoizingParser: Fix parent interface misstype of parse() method

### DIFF
--- a/src/SourceLocator/Ast/Parser/MemoizingParser.php
+++ b/src/SourceLocator/Ast/Parser/MemoizingParser.php
@@ -32,7 +32,7 @@ final class MemoizingParser implements Parser
      *
      * @phpcsSuppress SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingParameterTypeHint
      */
-    public function parse($code, ?ErrorHandler $errorHandler = null) : ?array
+    public function parse(string $code, ?ErrorHandler $errorHandler = null) : ?array
     {
         // note: this code is mathematically buggy by default, as we are using a hash to identify
         //       cache entries. The string length is added to further reduce likeliness (although


### PR DESCRIPTION
I believe this is PHP 7.2 feature. The parsing fails otherwise

![image](https://user-images.githubusercontent.com/924196/30683046-14f3d3ea-9eac-11e7-81bd-251129a0d669.png)
