### PR TITLE
Return empty ast for interface method body

### DIFF
--- a/src/Reflection/ReflectionFunctionAbstract.php
+++ b/src/Reflection/ReflectionFunctionAbstract.php
@@ -498,7 +498,7 @@ abstract class ReflectionFunctionAbstract implements CoreReflector
      */
     public function getBodyAst() : array
     {
-        return $this->node->stmts;
+        return $this->node->stmts ?: [];
     }
 
     /**

--- a/test/unit/Fixture/InterfaceWithMethod.php
+++ b/test/unit/Fixture/InterfaceWithMethod.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Roave\BetterReflectionTest\Fixture;
+
+interface InterfaceWithMethod
+{
+    public function someMethod();
+}

--- a/test/unit/Reflection/ReflectionMethodTest.php
+++ b/test/unit/Reflection/ReflectionMethodTest.php
@@ -33,6 +33,7 @@ use Roave\BetterReflectionTest\BetterReflectionSingleton;
 use Roave\BetterReflectionTest\Fixture\ClassWithNonStaticMethod;
 use Roave\BetterReflectionTest\Fixture\ClassWithStaticMethod;
 use Roave\BetterReflectionTest\Fixture\ExampleClass;
+use Roave\BetterReflectionTest\Fixture\InterfaceWithMethod;
 use Roave\BetterReflectionTest\Fixture\Methods;
 use Roave\BetterReflectionTest\Fixture\Php4StyleConstructInNamespace;
 use Roave\BetterReflectionTest\Fixture\UpperCaseConstructDestruct;
@@ -614,5 +615,13 @@ PHP;
 
         self::assertSame(103, $methodReflection->invoke($object, 1, 2));
         self::assertSame(107, $methodReflection->invoke($object, 3, 4));
+    }
+
+    public function testInterfaceMethodBodyAst() : void
+    {
+        $classInfo  = $this->reflector->reflect(InterfaceWithMethod::class);
+        $methodInfo = $classInfo->getMethod('someMethod');
+
+        self::assertSame([], $methodInfo->getBodyAst());
     }
 }


### PR DESCRIPTION
Fixes: #378 

Problem is caused when inspecting method of an interface. See also https://github.com/nikic/PHP-Parser/issues/235#issuecomment-194505139

