### PR TITLE
#379 `UConverter#getAliases($name)` is not an optional parameter anymore as per latest PHP releases

### DIFF
--- a/stub/UConverter.stub
+++ b/stub/UConverter.stub
@@ -151,7 +151,7 @@ class UConverter
     {
     }
 
-    public static function getAliases($name = null)
+    public static function getAliases($name)
     {
     }
 

--- a/test/unit/SourceLocator/Type/PhpInternalSourceLocatorTest.php
+++ b/test/unit/SourceLocator/Type/PhpInternalSourceLocatorTest.php
@@ -362,7 +362,11 @@ class PhpInternalSourceLocatorTest extends TestCase
         if (\PHP_VERSION_ID < 70200
             && \in_array(
                 $parameterName,
-                ['DateTime#createFromFormat.object', 'DateTimeImmutable#createFromFormat.object'],
+                [
+                    'DateTime#createFromFormat.object',
+                    'DateTimeImmutable#createFromFormat.object',
+                    'UConverter#getAliases.name',
+                ],
                 true
             )
         ) {


### PR DESCRIPTION
This patch updates the stub and prevents testing of the parameter on older PHP versions.

Ref https://github.com/php/php-src/commit/ec3d864784aa14187ca20a7644ee78c813d8b744
Ref https://bugs.php.net/bug.php?id=75318