### PR TITLE
Fix wrong parameter name

### DIFF
--- a/docs/types.md
+++ b/docs/types.md
@@ -7,9 +7,9 @@ ways:
 class MyClass
 {
     /**
-     * @param array $myMethod
+     * @param array $myParameter
      */
-    public function myMethod(array $myMethod = [])
+    public function myMethod(array $myParameter = [])
     {
         // ... stuff ...
     }


### PR DESCRIPTION
rename $myMethod to $myParameter as expected by getParameter('myParameter')