### PR TITLE
Fix behaviour of ReflectionClass::export/ReflectionObject::export to match behaviour of core classes

### DIFF
--- a/src/Reflection/ReflectionClass.php
+++ b/src/Reflection/ReflectionClass.php
@@ -46,6 +46,7 @@ use function get_class;
 use function implode;
 use function in_array;
 use function is_object;
+use function is_string;
 use function ltrim;
 use function sha1;
 use function sprintf;
@@ -101,6 +102,8 @@ class ReflectionClass implements Reflection, CoreReflector
 
     /**
      * Create a reflection and return the string representation of a named class
+     *
+     * @param string|object $argument
      */
     public static function export($argument, bool $return = false) : ?string
     {

--- a/src/Reflection/ReflectionClass.php
+++ b/src/Reflection/ReflectionClass.php
@@ -102,13 +102,24 @@ class ReflectionClass implements Reflection, CoreReflector
     /**
      * Create a reflection and return the string representation of a named class
      */
-    public static function export(?string $className) : string
+    public static function export($argument, bool $return = false) : ?string
     {
-        if ($className === null) {
-            throw new InvalidArgumentException('Class name must be provided');
+        if (is_string($argument) || is_object($argument)) {
+            if (is_string($argument)) {
+                $output = self::createFromName($argument)->__toString();
+            } else {
+                $output = ReflectionObject::createFromInstance($argument)->__toString();
+            }
+
+            if ($return) {
+                return $output;
+            }
+
+            echo $output;
+            return null;
         }
 
-        return self::createFromName($className)->__toString();
+        throw new InvalidArgumentException('Class name must be provided');
     }
 
     public function __toString() : string

--- a/src/Reflection/ReflectionObject.php
+++ b/src/Reflection/ReflectionObject.php
@@ -57,13 +57,16 @@ class ReflectionObject extends ReflectionClass
      * @throws \ReflectionException
      * @throws \InvalidArgumentException
      */
-    public static function export($instance = null) : string
+    public static function export($instance, bool $return = false) : ?string
     {
-        if ($instance === null) {
-            throw new InvalidArgumentException('Class instance must be provided');
+        $output = self::createFromInstance($instance)->__toString();
+
+        if ($return) {
+            return $output;
         }
 
-        return self::createFromInstance($instance)->__toString();
+        echo $output;
+        return null;
     }
 
     /**

--- a/test/unit/Reflection/Adapter/ReflectionClassTest.php
+++ b/test/unit/Reflection/Adapter/ReflectionClassTest.php
@@ -129,7 +129,7 @@ class ReflectionClassTest extends TestCase
 
     public function testExport() : void
     {
-        $exported = ReflectionClassAdapter::export('\stdClass');
+        $exported = ReflectionClassAdapter::export('\stdClass', true);
 
         self::assertInternalType('string', $exported);
         self::assertContains('stdClass', $exported);

--- a/test/unit/Reflection/Adapter/ReflectionObjectTest.php
+++ b/test/unit/Reflection/Adapter/ReflectionObjectTest.php
@@ -125,7 +125,7 @@ class ReflectionObjectTest extends TestCase
 
     public function testExport() : void
     {
-        $exported = ReflectionObjectAdapter::export(new stdClass());
+        $exported = ReflectionObjectAdapter::export(new stdClass(), true);
 
         self::assertInternalType('string', $exported);
         self::assertContains('stdClass', $exported);

--- a/test/unit/Reflection/ReflectionClassTest.php
+++ b/test/unit/Reflection/ReflectionClassTest.php
@@ -1331,7 +1331,7 @@ PHP;
     {
         self::assertStringMatchesFormat(
             file_get_contents(__DIR__ . '/../Fixture/ExampleClassExport.txt'),
-            ReflectionClass::export(ExampleClass::class)
+            ReflectionClass::export(ExampleClass::class, true)
         );
     }
 

--- a/test/unit/Reflection/ReflectionObjectTest.php
+++ b/test/unit/Reflection/ReflectionObjectTest.php
@@ -288,7 +288,7 @@ Object of class [ <user> class Roave\BetterReflectionTest\Fixture\ClassForHintin
   }
 }
 BLAH;
-        $actualExport   = ReflectionObject::export($foo);
+        $actualExport   = ReflectionObject::export($foo, true);
 
         self::assertStringMatchesFormat($expectedExport, $actualExport);
     }


### PR DESCRIPTION
`Roave\BetterReflection\Reflection\ReflectionClass::export` and `Roave\BetterReflection\Reflection\ReflectionObject::export` would always `return` values. However, `ReflectionClass::export` and `ReflectionObject::export` echo values to stdout by default,.

This PR changes the default behaviour of the BetterReflection classes to match up with the core ones. Now the `return` functionality is hidden behind an explicit `bool $return` argument.

It also allows `ReflectionClass::export` to take an object instance, like its core equivalent.