### PR TITLE
Account for case insensitivity

### DIFF
--- a/src/SourceLocator/Ast/Locator.php
+++ b/src/SourceLocator/Ast/Locator.php
@@ -86,8 +86,10 @@ class Locator
      */
     private function findInArray(array $reflections, Identifier $identifier) : Reflection
     {
+        $identifierName = strtolower($identifier->getName());
+
         foreach ($reflections as $reflection) {
-            if ($reflection->getName() === $identifier->getName()) {
+            if (strtolower($reflection->getName()) === $identifierName) {
                 return $reflection;
             }
         }

--- a/test/unit/SourceLocator/Ast/LocatorTest.php
+++ b/test/unit/SourceLocator/Ast/LocatorTest.php
@@ -56,6 +56,22 @@ class LocatorTest extends TestCase
         self::assertInstanceOf(ReflectionClass::class, $classInfo);
     }
 
+    public function testTheReflectionLookupIsCaseInsensitive() : void
+    {
+        $php = '<?php
+        namespace Foo;
+        class Bar {}
+        ';
+
+        $classInfo = $this->locator->findReflection(
+            new ClassReflector(new StringSourceLocator($php, $this->locator)),
+            new LocatedSource($php, null),
+            $this->getIdentifier('Foo\BAR', IdentifierType::IDENTIFIER_CLASS)
+        );
+
+        self::assertInstanceOf(ReflectionClass::class, $classInfo);
+    }
+
     public function testReflectingTopLevelClass() : void
     {
         $php = '<?php


### PR DESCRIPTION
The PR is a bit incomplete (missing tests) but it's more for myself to not forget about it :)

The issue is that [PHP is case insensitive](https://3v4l.org/SYNgh) for namespaces, classes and methods. However BetterReflection does not account for that as a result if you have:

```php
use PHAR;
```

Instead of:

```php
use Phar;
```

BetterReflection is going to fail.