### PR TITLE
Improved `ReflectionType` API so that a target reflection class can be found, removed existing named constructor

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -4,6 +4,13 @@ This document serves as a reference to upgrade your current
 BetterReflection installation if improvements, deprecations
 or backwards compatibility (BC) breakages occur.
 
+## 4.0.0
+
+### BC breaks
+
+* Method `Roave\BetterReflection\Reflection\ReflectionType::createFromType()` has been removed,
+do use `Roave\BetterReflection\Reflection\ReflectionType::createFromTypeAndReflector()` instead.
+
 ## 3.0.0
 
 ### BC breaks

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -4,17 +4,12 @@ This document serves as a reference to upgrade your current
 BetterReflection installation if improvements, deprecations
 or backwards compatibility (BC) breakages occur.
 
-## 4.0.0
+## 3.0.0
 
 ### BC breaks
 
 * Method `Roave\BetterReflection\Reflection\ReflectionType::createFromType()` has been removed,
 do use `Roave\BetterReflection\Reflection\ReflectionType::createFromTypeAndReflector()` instead.
-
-## 3.0.0
-
-### BC breaks
-
 * Method `Roave\BetterReflection\Reflection\Adapter\ReflectionClass#getProperty()` throws exception
 when property does not exist to be compatible with core reflection.
 * Method `Roave\BetterReflection\Reflection\Adapter\ReflectionObject#getProperty()` throws exception

--- a/src/Reflection/Exception/ClassDoesNotExist.php
+++ b/src/Reflection/Exception/ClassDoesNotExist.php
@@ -4,8 +4,14 @@ declare(strict_types=1);
 
 namespace Roave\BetterReflection\Reflection\Exception;
 
+use Roave\BetterReflection\Reflection\Reflection;
 use RuntimeException;
+use function sprintf;
 
 class ClassDoesNotExist extends RuntimeException
 {
+    public static function forDifferentReflectionType(Reflection $reflection) : self
+    {
+        return new self(sprintf('The reflected type "%s" is not a class', $reflection->getName()));
+    }
 }

--- a/src/Reflection/Exception/ReflectionTypeDoesNotPointToAClassAlikeType.php
+++ b/src/Reflection/Exception/ReflectionTypeDoesNotPointToAClassAlikeType.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Roave\BetterReflection\Reflection\Exception;
+
+use LogicException;
+use Roave\BetterReflection\Reflection\ReflectionType;
+use function get_class;
+use function sprintf;
+
+class ReflectionTypeDoesNotPointToAClassAlikeType extends LogicException
+{
+    public static function for(ReflectionType $type) : self
+    {
+        return new self(sprintf(
+            'Provided %s instance does not point to a class-alike type, but to "%s"',
+            get_class($type),
+            $type->__toString()
+        ));
+    }
+}

--- a/src/Reflection/ReflectionFunctionAbstract.php
+++ b/src/Reflection/ReflectionFunctionAbstract.php
@@ -409,10 +409,10 @@ abstract class ReflectionFunctionAbstract implements CoreReflector
         }
 
         if ($returnType instanceof NullableType) {
-            return ReflectionType::createFromType((string) $returnType->type, true);
+            return ReflectionType::createFromTypeAndReflector((string) $returnType->type, true, $this->reflector);
         }
 
-        return ReflectionType::createFromType((string) $returnType, false);
+        return ReflectionType::createFromTypeAndReflector((string) $returnType, false, $this->reflector);
     }
 
     /**

--- a/src/Reflection/ReflectionParameter.php
+++ b/src/Reflection/ReflectionParameter.php
@@ -388,7 +388,7 @@ class ReflectionParameter implements CoreReflector
             $type = $type->type;
         }
 
-        return ReflectionType::createFromType((string) $type, $this->allowsNull());
+        return ReflectionType::createFromTypeAndReflector((string) $type, $this->allowsNull(), $this->reflector);
     }
 
     /**

--- a/src/Reflection/ReflectionType.php
+++ b/src/Reflection/ReflectionType.php
@@ -47,20 +47,6 @@ class ReflectionType
     {
     }
 
-    /**
-     * @deprecated please use {@see \Roave\BetterReflection\Reflection\ReflectionType::createFromTypeAndReflector()}
-     *             instead
-     */
-    public static function createFromType(string $type, bool $allowsNull) : self
-    {
-        $reflectionType             = new self();
-
-        $reflectionType->type       = ltrim($type, '\\');
-        $reflectionType->allowsNull = $allowsNull;
-
-        return $reflectionType;
-    }
-
     public static function createFromTypeAndReflector(
         string $type,
         bool $allowsNull,

--- a/src/Reflection/ReflectionType.php
+++ b/src/Reflection/ReflectionType.php
@@ -80,11 +80,9 @@ class ReflectionType
     }
 
     /**
-     * @return ReflectionClass
-     *
-     * @throws IdentifierNotFound if the target type could not be resolved
-     * @throws ReflectionTypeDoesNotPointToAClassAlikeType if the type is not pointing to a class-alike symbol
-     * @throws ClassDoesNotExist if the target type is not a class
+     * @throws IdentifierNotFound The target type could not be resolved.
+     * @throws ReflectionTypeDoesNotPointToAClassAlikeType The type is not pointing to a class-alike symbol.
+     * @throws ClassDoesNotExist The target type is not a class.
      */
     public function targetReflectionClass() : ReflectionClass
     {

--- a/src/Reflection/ReflectionType.php
+++ b/src/Reflection/ReflectionType.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 
 namespace Roave\BetterReflection\Reflection;
 
+use Roave\BetterReflection\Reflection\Exception\ClassDoesNotExist;
+use Roave\BetterReflection\Reflection\Exception\ReflectionTypeDoesNotPointToAClassAlikeType;
+use Roave\BetterReflection\Reflector\Exception\IdentifierNotFound;
+use Roave\BetterReflection\Reflector\Reflector;
 use function array_key_exists;
 use function ltrim;
 use function strtolower;
@@ -34,15 +38,40 @@ class ReflectionType
      */
     private $allowsNull;
 
+    /**
+     * @var Reflector
+     */
+    private $reflector;
+
     private function __construct()
     {
     }
 
+    /**
+     * @deprecated please use {@see \Roave\BetterReflection\Reflection\ReflectionType::createFromTypeAndReflector()}
+     *             instead
+     */
     public static function createFromType(string $type, bool $allowsNull) : self
     {
         $reflectionType             = new self();
+
         $reflectionType->type       = ltrim($type, '\\');
         $reflectionType->allowsNull = $allowsNull;
+
+        return $reflectionType;
+    }
+
+    public static function createFromTypeAndReflector(
+        string $type,
+        bool $allowsNull,
+        Reflector $classReflector
+    ) : self {
+        $reflectionType = new self();
+
+        $reflectionType->type       = ltrim($type, '\\');
+        $reflectionType->allowsNull = $allowsNull;
+        $reflectionType->reflector  = $classReflector;
+
         return $reflectionType;
     }
 
@@ -62,6 +91,28 @@ class ReflectionType
     public function isBuiltin() : bool
     {
         return array_key_exists(strtolower($this->type), self::BUILT_IN_TYPES);
+    }
+
+    /**
+     * @return ReflectionClass
+     *
+     * @throws IdentifierNotFound if the target type could not be resolved
+     * @throws ReflectionTypeDoesNotPointToAClassAlikeType if the type is not pointing to a class-alike symbol
+     * @throws ClassDoesNotExist if the target type is not a class
+     */
+    public function targetReflectionClass() : ReflectionClass
+    {
+        if ($this->isBuiltin()) {
+            throw ReflectionTypeDoesNotPointToAClassAlikeType::for($this);
+        }
+
+        $reflectionClass = $this->reflector->reflect($this->type);
+
+        if (! $reflectionClass instanceof ReflectionClass) {
+            throw ClassDoesNotExist::forDifferentReflectionType($reflectionClass);
+        }
+
+        return $reflectionClass;
     }
 
     /**

--- a/test/compat/ResolvePHP7Types.phpt
+++ b/test/compat/ResolvePHP7Types.phpt
@@ -24,29 +24,39 @@ $reflector = new \Roave\BetterReflection\Reflector\FunctionReflector(
 
 $functionInfo = $reflector->reflect('myFunction');
 
-var_dump($functionInfo->getReturnType());
+$returnType = $functionInfo->getReturnType();
+
+var_dump([
+    'builtIn' => $returnType->isBuiltin(),
+    'type' => $returnType->__toString(),
+]);
 
 array_map(function (\Roave\BetterReflection\Reflection\ReflectionParameter $param) {
-    var_dump($param->getType());
+    $type = $param->getType();
+
+    var_dump([
+        'builtIn' => $type->isBuiltin(),
+        'type' => $type->__toString(),
+    ]);
 }, $functionInfo->getParameters());
 
 ?>
 --EXPECTF--
-object(Roave\BetterReflection\Reflection\ReflectionType)#%d (2) {
-  ["type":"Roave\BetterReflection\Reflection\ReflectionType":private]=>
-  string(4) "bool"
-  ["allowsNull":"Roave\BetterReflection\Reflection\ReflectionType":private]=>
-  bool(false)
-}
-object(Roave\BetterReflection\Reflection\ReflectionType)#%d (2) {
-  ["type":"Roave\BetterReflection\Reflection\ReflectionType":private]=>
-  string(3) "int"
-  ["allowsNull":"Roave\BetterReflection\Reflection\ReflectionType":private]=>
-  bool(false)
-}
-object(Roave\BetterReflection\Reflection\ReflectionType)#%d (2) {
-  ["type":"Roave\BetterReflection\Reflection\ReflectionType":private]=>
-  string(6) "string"
-  ["allowsNull":"Roave\BetterReflection\Reflection\ReflectionType":private]=>
+array(2) {
+  'builtIn' =>
   bool(true)
+  'type' =>
+  string(4) "bool"
+}
+array(2) {
+  'builtIn' =>
+  bool(true)
+  'type' =>
+  string(3) "int"
+}
+array(2) {
+  'builtIn' =>
+  bool(true)
+  'type' =>
+  string(6) "string"
 }

--- a/test/compat/ResolvePHP7Types.phpt
+++ b/test/compat/ResolvePHP7Types.phpt
@@ -43,20 +43,20 @@ array_map(function (\Roave\BetterReflection\Reflection\ReflectionParameter $para
 ?>
 --EXPECTF--
 array(2) {
-  'builtIn' =>
+  ["builtIn"]=>
   bool(true)
-  'type' =>
+  ["type"]=>
   string(4) "bool"
 }
 array(2) {
-  'builtIn' =>
+  ["builtIn"]=>
   bool(true)
-  'type' =>
+  ["type"]=>
   string(3) "int"
 }
 array(2) {
-  'builtIn' =>
+  ["builtIn"]=>
   bool(true)
-  'type' =>
+  ["type"]=>
   string(6) "string"
 }

--- a/test/unit/Reflection/Adapter/ReflectionTypeTest.php
+++ b/test/unit/Reflection/Adapter/ReflectionTypeTest.php
@@ -7,13 +7,13 @@ namespace Roave\BetterReflectionTest\Reflection\Adapter;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass as CoreReflectionClass;
 use ReflectionType as CoreReflectionType;
-use Roave\BetterReflection\Reflection\Adapter\ReflectionType as ReflectionTypeAdapter;
 use Roave\BetterReflection\Reflection\Adapter\ReflectionType;
+use Roave\BetterReflection\Reflection\Adapter\ReflectionType as ReflectionTypeAdapter;
 use Roave\BetterReflection\Reflection\ReflectionType as BetterReflectionType;
+use Roave\BetterReflection\Reflector\Reflector;
 use function array_combine;
 use function array_map;
 use function get_class_methods;
-use Roave\BetterReflection\Reflector\Reflector;
 
 /**
  * @covers \Roave\BetterReflection\Reflection\Adapter\ReflectionType
@@ -83,7 +83,7 @@ class ReflectionTypeTest extends TestCase
 
     public function testSelfIsNotBuiltin() : void
     {
-        /** @var $reflector Reflector */
+        /** @var Reflector $reflector */
         $reflector             = $this->createMock(Reflector::class);
         $betterReflectionType  = BetterReflectionType::createFromTypeAndReflector('self', false, $reflector);
         $reflectionTypeAdapter = new ReflectionTypeAdapter($betterReflectionType);
@@ -93,7 +93,7 @@ class ReflectionTypeTest extends TestCase
 
     public function testParentIsNotBuiltin() : void
     {
-        /** @var $reflector Reflector */
+        /** @var Reflector $reflector */
         $reflector             = $this->createMock(Reflector::class);
         $betterReflectionType  = BetterReflectionType::createFromTypeAndReflector('parent', false, $reflector);
         $reflectionTypeAdapter = new ReflectionTypeAdapter($betterReflectionType);

--- a/test/unit/Reflection/Adapter/ReflectionTypeTest.php
+++ b/test/unit/Reflection/Adapter/ReflectionTypeTest.php
@@ -13,6 +13,7 @@ use Roave\BetterReflection\Reflection\ReflectionType as BetterReflectionType;
 use function array_combine;
 use function array_map;
 use function get_class_methods;
+use Roave\BetterReflection\Reflector\Reflector;
 
 /**
  * @covers \Roave\BetterReflection\Reflection\Adapter\ReflectionType
@@ -82,7 +83,9 @@ class ReflectionTypeTest extends TestCase
 
     public function testSelfIsNotBuiltin() : void
     {
-        $betterReflectionType  = BetterReflectionType::createFromType('self', false);
+        /** @var $reflector Reflector */
+        $reflector             = $this->createMock(Reflector::class);
+        $betterReflectionType  = BetterReflectionType::createFromTypeAndReflector('self', false, $reflector);
         $reflectionTypeAdapter = new ReflectionTypeAdapter($betterReflectionType);
 
         self::assertFalse($reflectionTypeAdapter->isBuiltin());
@@ -90,7 +93,9 @@ class ReflectionTypeTest extends TestCase
 
     public function testParentIsNotBuiltin() : void
     {
-        $betterReflectionType  = BetterReflectionType::createFromType('parent', false);
+        /** @var $reflector Reflector */
+        $reflector             = $this->createMock(Reflector::class);
+        $betterReflectionType  = BetterReflectionType::createFromTypeAndReflector('parent', false, $reflector);
         $reflectionTypeAdapter = new ReflectionTypeAdapter($betterReflectionType);
 
         self::assertFalse($reflectionTypeAdapter->isBuiltin());

--- a/test/unit/Reflection/Exception/ClassDoesNotExistTest.php
+++ b/test/unit/Reflection/Exception/ClassDoesNotExistTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Roave\BetterReflectionTest\Reflection\Exception;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Roave\BetterReflection\Reflection\Exception\ClassDoesNotExist;
+use Roave\BetterReflection\Reflection\Reflection;
+
+/**
+ * @covers \Roave\BetterReflection\Reflection\Exception\ClassDoesNotExist
+ */
+class ClassDoesNotExistTest extends TestCase
+{
+    public function testForDifferentReflectionType() : void
+    {
+        /** @var Reflection|MockObject $reflection */
+        $reflection = $this->createMock(Reflection::class);
+
+        $reflection
+            ->expects(self::any())
+            ->method('getName')
+            ->willReturn('potato');
+
+        $exception = ClassDoesNotExist::forDifferentReflectionType($reflection);
+
+        self::assertInstanceOf(ClassDoesNotExist::class, $exception);
+        self::assertSame('The reflected type "potato" is not a class', $exception->getMessage());
+    }
+}

--- a/test/unit/Reflection/Exception/ReflectionTypeDoesNotPointToAClassAlikeTypeTest.php
+++ b/test/unit/Reflection/Exception/ReflectionTypeDoesNotPointToAClassAlikeTypeTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Roave\BetterReflectionTest\Reflection\Exception;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Roave\BetterReflection\Reflection\Exception\ClassDoesNotExist;
+use Roave\BetterReflection\Reflection\Exception\ReflectionTypeDoesNotPointToAClassAlikeType;
+use Roave\BetterReflection\Reflection\ReflectionType;
+
+/**
+ * @covers \Roave\BetterReflection\Reflection\Exception\ReflectionTypeDoesNotPointToAClassAlikeType
+ */
+class ReflectionTypeDoesNotPointToAClassAlikeTypeTest extends TestCase
+{
+    public function testFor() : void
+    {
+        /** @var ReflectionType|MockObject $type */
+        $type = $this->createMock(ReflectionType::class);
+
+        $type
+            ->expects(self::any())
+            ->method('__toString')
+            ->willReturn('another potato');
+
+        $exception = ReflectionTypeDoesNotPointToAClassAlikeType::for($type);
+
+        self::assertInstanceOf(ReflectionTypeDoesNotPointToAClassAlikeType::class, $exception);
+        self::assertSame('The reflected type "potato" is not a class', $exception->getMessage());
+    }
+}

--- a/test/unit/Reflection/Exception/ReflectionTypeDoesNotPointToAClassAlikeTypeTest.php
+++ b/test/unit/Reflection/Exception/ReflectionTypeDoesNotPointToAClassAlikeTypeTest.php
@@ -28,6 +28,9 @@ class ReflectionTypeDoesNotPointToAClassAlikeTypeTest extends TestCase
         $exception = ReflectionTypeDoesNotPointToAClassAlikeType::for($type);
 
         self::assertInstanceOf(ReflectionTypeDoesNotPointToAClassAlikeType::class, $exception);
-        self::assertSame('The reflected type "potato" is not a class', $exception->getMessage());
+        self::assertStringMatchesFormat(
+            'Provided %s instance does not point to a class-alike type, but to "another potato"',
+            $exception->getMessage()
+        );
     }
 }

--- a/test/unit/Reflection/Exception/ReflectionTypeDoesNotPointToAClassAlikeTypeTest.php
+++ b/test/unit/Reflection/Exception/ReflectionTypeDoesNotPointToAClassAlikeTypeTest.php
@@ -6,7 +6,6 @@ namespace Roave\BetterReflectionTest\Reflection\Exception;
 
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use Roave\BetterReflection\Reflection\Exception\ClassDoesNotExist;
 use Roave\BetterReflection\Reflection\Exception\ReflectionTypeDoesNotPointToAClassAlikeType;
 use Roave\BetterReflection\Reflection\ReflectionType;
 

--- a/test/unit/Reflection/ReflectionTypeTest.php
+++ b/test/unit/Reflection/ReflectionTypeTest.php
@@ -4,53 +4,129 @@ declare(strict_types=1);
 
 namespace Roave\BetterReflectionTest\Reflection;
 
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Roave\BetterReflection\Reflection\Exception\ClassDoesNotExist;
+use Roave\BetterReflection\Reflection\Exception\ReflectionTypeDoesNotPointToAClassAlikeType;
+use Roave\BetterReflection\Reflection\Reflection;
+use Roave\BetterReflection\Reflection\ReflectionClass;
 use Roave\BetterReflection\Reflection\ReflectionType;
+use Roave\BetterReflection\Reflector\Reflector;
 
 /**
  * @covers \Roave\BetterReflection\Reflection\ReflectionType
  */
 class ReflectionTypeTest extends TestCase
 {
+    /** @var Reflector|MockObject */
+    private $reflector;
+
+    protected function setUp() : void
+    {
+        parent::setUp();
+
+        $this->reflector = $this->createMock(Reflector::class);
+    }
+
     public function testCreateFromType() : void
     {
-        $typeInfo = ReflectionType::createFromType('string', false);
+        $typeInfo = ReflectionType::createFromTypeAndReflector('string', false, $this->reflector);
         self::assertInstanceOf(ReflectionType::class, $typeInfo);
     }
 
     public function testAllowsNull() : void
     {
-        $noNullType = ReflectionType::createFromType('string', false);
+        $noNullType = ReflectionType::createFromTypeAndReflector('string', false, $this->reflector);
         self::assertFalse($noNullType->allowsNull());
 
-        $allowsNullType = ReflectionType::createFromType('string', true);
+        $allowsNullType = ReflectionType::createFromTypeAndReflector('string', true, $this->reflector);
         self::assertTrue($allowsNullType->allowsNull());
     }
 
     public function testIsBuiltin() : void
     {
-        self::assertTrue(ReflectionType::createFromType('string', false)->isBuiltin());
-        self::assertTrue(ReflectionType::createFromType('int', false)->isBuiltin());
-        self::assertTrue(ReflectionType::createFromType('array', false)->isBuiltin());
-        self::assertTrue(ReflectionType::createFromType('object', false)->isBuiltin());
-        self::assertTrue(ReflectionType::createFromType('iterable', false)->isBuiltin());
-        self::assertFalse(ReflectionType::createFromType('foo', false)->isBuiltin());
-        self::assertFalse(ReflectionType::createFromType('\foo', false)->isBuiltin());
+        self::assertTrue(ReflectionType::createFromTypeAndReflector('string', false, $this->reflector)->isBuiltin());
+        self::assertTrue(ReflectionType::createFromTypeAndReflector('int', false, $this->reflector)->isBuiltin());
+        self::assertTrue(ReflectionType::createFromTypeAndReflector('array', false, $this->reflector)->isBuiltin());
+        self::assertTrue(ReflectionType::createFromTypeAndReflector('object', false, $this->reflector)->isBuiltin());
+        self::assertTrue(ReflectionType::createFromTypeAndReflector('iterable', false, $this->reflector)->isBuiltin());
+        self::assertFalse(ReflectionType::createFromTypeAndReflector('foo', false, $this->reflector)->isBuiltin());
+        self::assertFalse(ReflectionType::createFromTypeAndReflector('\foo', false, $this->reflector)->isBuiltin());
     }
 
     public function testImplicitCastToString() : void
     {
-        self::assertSame('int', (string) ReflectionType::createFromType('int', false));
-        self::assertSame('string', (string) ReflectionType::createFromType('string', false));
-        self::assertSame('array', (string) ReflectionType::createFromType('array', false));
-        self::assertSame('callable', (string) ReflectionType::createFromType('callable', false));
-        self::assertSame('bool', (string) ReflectionType::createFromType('bool', false));
-        self::assertSame('float', (string) ReflectionType::createFromType('float', false));
-        self::assertSame('void', (string) ReflectionType::createFromType('void', false));
-        self::assertSame('object', (string) ReflectionType::createFromType('object', false));
-        self::assertSame('iterable', (string) ReflectionType::createFromType('iterable', false));
+        self::assertSame('int', (string) ReflectionType::createFromTypeAndReflector('int', false, $this->reflector));
+        self::assertSame('string', (string) ReflectionType::createFromTypeAndReflector('string', false, $this->reflector));
+        self::assertSame('array', (string) ReflectionType::createFromTypeAndReflector('array', false, $this->reflector));
+        self::assertSame('callable', (string) ReflectionType::createFromTypeAndReflector('callable', false, $this->reflector));
+        self::assertSame('bool', (string) ReflectionType::createFromTypeAndReflector('bool', false, $this->reflector));
+        self::assertSame('float', (string) ReflectionType::createFromTypeAndReflector('float', false, $this->reflector));
+        self::assertSame('void', (string) ReflectionType::createFromTypeAndReflector('void', false, $this->reflector));
+        self::assertSame('object', (string) ReflectionType::createFromTypeAndReflector('object', false, $this->reflector));
+        self::assertSame('iterable', (string) ReflectionType::createFromTypeAndReflector('iterable', false, $this->reflector));
 
-        self::assertSame('Foo\Bar\Baz', (string) ReflectionType::createFromType('Foo\Bar\Baz', false));
-        self::assertSame('Foo\Bar\Baz', (string) ReflectionType::createFromType('\Foo\Bar\Baz', false));
+        self::assertSame('Foo\Bar\Baz', (string) ReflectionType::createFromTypeAndReflector('Foo\Bar\Baz', false, $this->reflector));
+        self::assertSame('Foo\Bar\Baz', (string) ReflectionType::createFromTypeAndReflector('\Foo\Bar\Baz', false, $this->reflector));
+    }
+
+    public function testWillDisallowFetchingTargetClassForInternalTypes() : void
+    {
+        $type = ReflectionType::createFromTypeAndReflector(
+            'int',
+            true,
+            $this->reflector
+        );
+
+        $this
+            ->reflector
+            ->expects(self::never())
+            ->method('reflect');
+
+        $this->expectException(ReflectionTypeDoesNotPointToAClassAlikeType::class);
+
+        $type->targetReflectionClass();
+    }
+
+    public function testWillDisallowRetrievingIncompatibleReflectionTypesForClassTypes() : void
+    {
+        $type = ReflectionType::createFromTypeAndReflector(
+            '\Foo\Bar',
+            true,
+            $this->reflector
+        );
+
+        $reflection = $this->createMock(Reflection::class);
+
+        $this
+            ->reflector
+            ->expects(self::once())
+            ->method('reflect')
+            ->with('Foo\Bar')
+            ->willReturn($reflection);
+
+        $this->expectException(ClassDoesNotExist::class);
+
+        $type->targetReflectionClass();
+    }
+
+    public function testWillRetrieveTargetClass() : void
+    {
+        $type = ReflectionType::createFromTypeAndReflector(
+            'Foo\Bar',
+            true,
+            $this->reflector
+        );
+
+        $reflection = $this->createMock(ReflectionClass::class);
+
+        $this
+            ->reflector
+            ->expects(self::any())
+            ->method('reflect')
+            ->with('Foo\Bar')
+            ->willReturn($reflection);
+
+        self::assertSame($reflection, $type->targetReflectionClass());
     }
 }


### PR DESCRIPTION
Required for https://github.com/Roave/ApiCompare/pull/38