### PR TITLE
Better exception messages and assertions for unrecognized class constant fetch expressions

### DIFF
--- a/src/NodeCompiler/CompileNodeToValue.php
+++ b/src/NodeCompiler/CompileNodeToValue.php
@@ -74,7 +74,7 @@ class CompileNodeToValue
                 return true;
             default:
                 if (! defined($firstName)) {
-                    throw Exception\UnableToCompileNode::becauseOfOfNotFoundConstantReference($context, $constNode);
+                    throw Exception\UnableToCompileNode::becauseOfNotFoundConstantReference($context, $constNode);
                 }
 
                 return constant($firstName);

--- a/src/NodeCompiler/CompileNodeToValue.php
+++ b/src/NodeCompiler/CompileNodeToValue.php
@@ -112,7 +112,6 @@ class CompileNodeToValue
             $classInfo = $context->getReflector()->reflect($className);
         }
 
-        /** @var ReflectionClassConstant $reflectionConstant */
         $reflectionConstant = $classInfo->getReflectionConstant($nodeName);
 
         if (! $reflectionConstant instanceof ReflectionClassConstant) {

--- a/src/NodeCompiler/CompileNodeToValue.php
+++ b/src/NodeCompiler/CompileNodeToValue.php
@@ -87,7 +87,7 @@ class CompileNodeToValue
      * @return string|int|float|bool|mixed[]|null
      *
      * @throws IdentifierNotFound
-     * @throws Exception\UnableToCompileNode if a referenced constant could not be located on the expected referenced class
+     * @throws Exception\UnableToCompileNode If a referenced constant could not be located on the expected referenced class.
      */
     private function compileClassConstFetch(Node\Expr\ClassConstFetch $node, CompilerContext $context)
     {

--- a/src/NodeCompiler/CompileNodeToValue.php
+++ b/src/NodeCompiler/CompileNodeToValue.php
@@ -13,10 +13,8 @@ use Roave\BetterReflection\Util\FileHelper;
 use function constant;
 use function defined;
 use function dirname;
-use function get_class;
 use function realpath;
 use function reset;
-use function sprintf;
 
 class CompileNodeToValue
 {
@@ -37,7 +35,7 @@ class CompileNodeToValue
 
         $constExprEvaluator = new ConstExprEvaluator(function (Node\Expr $node) use ($context) {
             if ($node instanceof Node\Expr\ConstFetch) {
-                return $this->compileConstFetch($node);
+                return $this->compileConstFetch($node, $context);
             }
 
             if ($node instanceof Node\Expr\ClassConstFetch) {
@@ -52,7 +50,7 @@ class CompileNodeToValue
                 return $this->compileClassConstant($context);
             }
 
-            throw new Exception\UnableToCompileNode('Unable to compile expression: ' . get_class($node));
+            throw Exception\UnableToCompileNode::forUnRecognizedExpressionInContext($node, $context);
         });
 
         return $constExprEvaluator->evaluateDirectly($node);
@@ -62,9 +60,9 @@ class CompileNodeToValue
      * Compile constant expressions
      *
      * @return bool|mixed|null
-     * @throws UnableToCompileNode
+     * @throws Exception\UnableToCompileNode
      */
-    private function compileConstFetch(Node\Expr\ConstFetch $constNode)
+    private function compileConstFetch(Node\Expr\ConstFetch $constNode, CompilerContext $context)
     {
         $firstName = reset($constNode->name->parts);
         switch ($firstName) {
@@ -76,9 +74,7 @@ class CompileNodeToValue
                 return true;
             default:
                 if (! defined($firstName)) {
-                    throw new Exception\UnableToCompileNode(
-                        sprintf('Constant "%s" has not been defined', $firstName)
-                    );
+                    throw Exception\UnableToCompileNode::becauseOfOfNotFoundConstantReference($context, $constNode);
                 }
 
                 return constant($firstName);
@@ -89,7 +85,9 @@ class CompileNodeToValue
      * Compile class constants
      *
      * @return string|int|float|bool|mixed[]|null
+     *
      * @throws IdentifierNotFound
+     * @throws Exception\UnableToCompileNode if a referenced constant could not be located on the expected referenced class
      */
     private function compileClassConstFetch(Node\Expr\ClassConstFetch $node, CompilerContext $context)
     {
@@ -116,6 +114,10 @@ class CompileNodeToValue
 
         /** @var ReflectionClassConstant $reflectionConstant */
         $reflectionConstant = $classInfo->getReflectionConstant($nodeName);
+
+        if (! $reflectionConstant instanceof ReflectionClassConstant) {
+            throw Exception\UnableToCompileNode::becauseOfNotFoundClassConstantReference($context, $classInfo, $node);
+        }
 
         return $this->__invoke(
             $reflectionConstant->getAst()->consts[$reflectionConstant->getPositionInAst()]->value,

--- a/src/NodeCompiler/Exception/UnableToCompileNode.php
+++ b/src/NodeCompiler/Exception/UnableToCompileNode.php
@@ -9,6 +9,7 @@ use PhpParser\Node;
 use Roave\BetterReflection\NodeCompiler\CompilerContext;
 use Roave\BetterReflection\Reflection\ReflectionClass;
 use function get_class;
+use function reset;
 use function sprintf;
 
 class UnableToCompileNode extends LogicException

--- a/src/NodeCompiler/Exception/UnableToCompileNode.php
+++ b/src/NodeCompiler/Exception/UnableToCompileNode.php
@@ -29,7 +29,7 @@ class UnableToCompileNode extends LogicException
         ReflectionClass $targetClass,
         Node\Expr\ClassConstFetch $constantFetch
     ) : self {
-        /** @var Node\Identifier $constantFetch ->name */
+        /** @var Node\Identifier $constantFetch->name */
         return new self(sprintf(
             'Could not locate constant %s::%s while trying to evaluate constant expression in %s at line %s',
             $targetClass->getName(),
@@ -43,7 +43,7 @@ class UnableToCompileNode extends LogicException
         CompilerContext $fetchContext,
         Node\Expr\ConstFetch $constantFetch
     ) : self {
-        /** @var Node\Identifier $constantFetch ->name */
+        /** @var Node\Name $constantFetch->name */
         return new self(sprintf(
             'Could not locate constant "%s" while evaluating expression in %s at line %s',
             reset($constantFetch->name->parts),

--- a/src/NodeCompiler/Exception/UnableToCompileNode.php
+++ b/src/NodeCompiler/Exception/UnableToCompileNode.php
@@ -5,7 +5,56 @@ declare(strict_types=1);
 namespace Roave\BetterReflection\NodeCompiler\Exception;
 
 use LogicException;
+use PhpParser\Node;
+use Roave\BetterReflection\NodeCompiler\CompilerContext;
+use Roave\BetterReflection\Reflection\ReflectionClass;
+use function get_class;
+use function sprintf;
 
 class UnableToCompileNode extends LogicException
 {
+    public static function forUnRecognizedExpressionInContext(Node\Expr $expression, CompilerContext $context) : self
+    {
+        return new self(sprintf(
+            'Unable to compile expression in %s: unrecognized node type %s at line %d',
+            self::compilerContextToContextDescription($context),
+            get_class($expression),
+            $expression->getLine()
+        ));
+    }
+
+    public static function becauseOfNotFoundClassConstantReference(
+        CompilerContext $fetchContext,
+        ReflectionClass $targetClass,
+        Node\Expr\ClassConstFetch $constantFetch
+    ) : self {
+        /** @var Node\Identifier $constantFetch ->name */
+        return new self(sprintf(
+            'Could not locate constant %s::%s while trying to evaluate constant expression in %s at line %s',
+            $targetClass->getName(),
+            $constantFetch->name->name,
+            self::compilerContextToContextDescription($fetchContext),
+            $constantFetch->getLine()
+        ));
+    }
+
+    public static function becauseOfOfNotFoundConstantReference(
+        CompilerContext $fetchContext,
+        Node\Expr\ConstFetch $constantFetch
+    ) : self {
+        /** @var Node\Identifier $constantFetch ->name */
+        return new self(sprintf(
+            'Could not locate constant "%s" while evaluating expression in %s at line %s',
+            reset($constantFetch->name->parts),
+            self::compilerContextToContextDescription($fetchContext),
+            $constantFetch->getLine()
+        ));
+    }
+
+    private static function compilerContextToContextDescription(CompilerContext $fetchContext) : string
+    {
+        return $fetchContext->hasSelf()
+            ? $fetchContext->getSelf()->getName()
+            : 'unknown context'; // @TODO review feedback here, plox!
+    }
 }

--- a/src/NodeCompiler/Exception/UnableToCompileNode.php
+++ b/src/NodeCompiler/Exception/UnableToCompileNode.php
@@ -54,8 +54,9 @@ class UnableToCompileNode extends LogicException
 
     private static function compilerContextToContextDescription(CompilerContext $fetchContext) : string
     {
+        // @todo improve in https://github.com/Roave/BetterReflection/issues/434
         return $fetchContext->hasSelf()
             ? $fetchContext->getSelf()->getName()
-            : 'unknown context'; // @TODO review feedback here, plox!
+            : 'unknown context (probably a function)';
     }
 }

--- a/src/NodeCompiler/Exception/UnableToCompileNode.php
+++ b/src/NodeCompiler/Exception/UnableToCompileNode.php
@@ -39,7 +39,7 @@ class UnableToCompileNode extends LogicException
         ));
     }
 
-    public static function becauseOfOfNotFoundConstantReference(
+    public static function becauseOfNotFoundConstantReference(
         CompilerContext $fetchContext,
         Node\Expr\ConstFetch $constantFetch
     ) : self {

--- a/src/Reflection/ReflectionFunctionAbstract.php
+++ b/src/Reflection/ReflectionFunctionAbstract.php
@@ -557,6 +557,10 @@ abstract class ReflectionFunctionAbstract implements CoreReflector
         $lowerName = strtolower($parameterName);
 
         foreach ($this->node->params as $key => $paramNode) {
+            if ($paramNode->var instanceof Node\Expr\Error) {
+                throw new \LogicException('PhpParser left an "Error" node in the parameters AST, this should NOT happen');
+            }
+
             if (! is_string($paramNode->var->name) || strtolower($paramNode->var->name) !== $lowerName) {
                 continue;
             }

--- a/src/TypesFinder/FindParameterType.php
+++ b/src/TypesFinder/FindParameterType.php
@@ -7,6 +7,7 @@ namespace Roave\BetterReflection\TypesFinder;
 use phpDocumentor\Reflection\DocBlock\Tags\Param;
 use phpDocumentor\Reflection\DocBlockFactory;
 use phpDocumentor\Reflection\Type;
+use PhpParser\Node\Expr\Error;
 use PhpParser\Node\Param as ParamNode;
 use PhpParser\Node\Stmt\Namespace_;
 use Roave\BetterReflection\Reflection\ReflectionFunctionAbstract;
@@ -53,6 +54,9 @@ class FindParameterType
             ->getTagsByName('param');
 
         foreach ($paramTags as $paramTag) {
+            if ($node->var instanceof Error) {
+                throw new \LogicException('PhpParser left an "Error" node in the parameters AST, this should NOT happen');
+            }
             if ($paramTag->getVariableName() === $node->var->name) {
                 return $this->resolveTypes->__invoke(explode('|', (string) $paramTag->getType()), $context);
             }

--- a/test/unit/NodeCompiler/CompileNodeToValueTest.php
+++ b/test/unit/NodeCompiler/CompileNodeToValueTest.php
@@ -20,6 +20,7 @@ use Roave\BetterReflectionTest\BetterReflectionSingleton;
 use const PHP_EOL;
 use const PHP_INT_MAX;
 use function define;
+use function sprintf;
 use function uniqid;
 
 /**

--- a/test/unit/NodeCompiler/CompileNodeToValueTest.php
+++ b/test/unit/NodeCompiler/CompileNodeToValueTest.php
@@ -178,7 +178,7 @@ class CompileNodeToValueTest extends TestCase
     {
         $this->expectException(UnableToCompileNode::class);
         $this->expectExceptionMessage(sprintf(
-            'Unable to compile expression in unknown context: unrecognized node type %s at line -1',
+            'Unable to compile expression in unknown context (probably a function): unrecognized node type %s at line -1',
             Yield_::class
         ));
 
@@ -188,7 +188,7 @@ class CompileNodeToValueTest extends TestCase
     public function testExceptionThrownWhenUndefinedConstUsed() : void
     {
         $this->expectException(UnableToCompileNode::class);
-        $this->expectExceptionMessage('Could not locate constant "FOO" while evaluating expression in unknown context at line -1');
+        $this->expectExceptionMessage('Could not locate constant "FOO" while evaluating expression in unknown context (probably a function) at line -1');
 
         (new CompileNodeToValue())->__invoke(new ConstFetch(new Name('FOO')), $this->getDummyContext());
     }
@@ -196,7 +196,7 @@ class CompileNodeToValueTest extends TestCase
     public function testExceptionThrownWhenUndefinedClassConstUsed() : void
     {
         $this->expectException(UnableToCompileNode::class);
-        $this->expectExceptionMessage('Could not locate constant EmptyClass::FOO while trying to evaluate constant expression in unknown context at line -1');
+        $this->expectExceptionMessage('Could not locate constant EmptyClass::FOO while trying to evaluate constant expression in unknown context (probably a function) at line -1');
 
         (new CompileNodeToValue())
             ->__invoke(

--- a/test/unit/NodeCompiler/Exception/UnableToCompileNodeTest.php
+++ b/test/unit/NodeCompiler/Exception/UnableToCompileNodeTest.php
@@ -27,7 +27,7 @@ final class UnableToCompileNodeTest extends TestCase
     /** @dataProvider supportedContextTypes */
     public function testBecauseOfNotFoundConstantReference(CompilerContext $context) : void
     {
-        $contextName = $context->hasSelf() ? 'EmptyClass' : 'unknown context';
+        $contextName = $context->hasSelf() ? 'EmptyClass' : 'unknown context (probably a function)';
 
         self::assertSame(
             'Could not locate constant "FOO" while evaluating expression in ' . $contextName . ' at line -1',
@@ -41,7 +41,7 @@ final class UnableToCompileNodeTest extends TestCase
     /** @dataProvider supportedContextTypes */
     public function testBecauseOfNotFoundClassConstantReference(CompilerContext $context) : void
     {
-        $contextName = $context->hasSelf() ? 'EmptyClass' : 'unknown context';
+        $contextName = $context->hasSelf() ? 'EmptyClass' : 'unknown context (probably a function)';
 
         /** @var ReflectionClass|MockObject $targetClass */
         $targetClass = $this->createMock(ReflectionClass::class);
@@ -68,7 +68,7 @@ final class UnableToCompileNodeTest extends TestCase
     /** @dataProvider supportedContextTypes */
     public function testForUnRecognizedExpressionInContext(CompilerContext $context) : void
     {
-        $contextName = $context->hasSelf() ? 'EmptyClass' : 'unknown context';
+        $contextName = $context->hasSelf() ? 'EmptyClass' : 'unknown context (probably a function)';
 
         self::assertSame(
             'Unable to compile expression in ' . $contextName

--- a/test/unit/NodeCompiler/Exception/UnableToCompileNodeTest.php
+++ b/test/unit/NodeCompiler/Exception/UnableToCompileNodeTest.php
@@ -25,13 +25,13 @@ use Roave\BetterReflectionTest\BetterReflectionSingleton;
 final class UnableToCompileNodeTest extends TestCase
 {
     /** @dataProvider supportedContextTypes */
-    public function testBecauseOfOfNotFoundConstantReference(CompilerContext $context) : void
+    public function testBecauseOfNotFoundConstantReference(CompilerContext $context) : void
     {
         $contextName = $context->hasSelf() ? 'EmptyClass' : 'unknown context';
 
         self::assertSame(
             'Could not locate constant "FOO" while evaluating expression in ' . $contextName . ' at line -1',
-            UnableToCompileNode::becauseOfOfNotFoundConstantReference(
+            UnableToCompileNode::becauseOfNotFoundConstantReference(
                 $context,
                 new ConstFetch(new Name('FOO'))
             )->getMessage()

--- a/test/unit/NodeCompiler/Exception/UnableToCompileNodeTest.php
+++ b/test/unit/NodeCompiler/Exception/UnableToCompileNodeTest.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Roave\BetterReflectionTest\NodeCompiler\Exception;
+
+use PhpParser\Node\Expr\ClassConstFetch;
+use PhpParser\Node\Expr\ConstFetch;
+use PhpParser\Node\Expr\Yield_;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
+use PhpParser\Node\Scalar\String_;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Roave\BetterReflection\NodeCompiler\CompilerContext;
+use Roave\BetterReflection\NodeCompiler\Exception\UnableToCompileNode;
+use Roave\BetterReflection\Reflection\ReflectionClass;
+use Roave\BetterReflection\Reflector\ClassReflector;
+use Roave\BetterReflection\SourceLocator\Type\StringSourceLocator;
+use Roave\BetterReflectionTest\BetterReflectionSingleton;
+
+/**
+ * @covers \Roave\BetterReflection\NodeCompiler\Exception\UnableToCompileNode
+ */
+final class UnableToCompileNodeTest extends TestCase
+{
+    /** @dataProvider supportedContextTypes */
+    public function testBecauseOfOfNotFoundConstantReference(CompilerContext $context) : void
+    {
+        $contextName = $context->hasSelf() ? 'EmptyClass' : 'unknown context';
+
+        self::assertSame(
+            'Could not locate constant "FOO" while evaluating expression in ' . $contextName . ' at line -1',
+            UnableToCompileNode::becauseOfOfNotFoundConstantReference(
+                $context,
+                new ConstFetch(new Name('FOO'))
+            )->getMessage()
+        );
+    }
+
+    /** @dataProvider supportedContextTypes */
+    public function testBecauseOfNotFoundClassConstantReference(CompilerContext $context) : void
+    {
+        $contextName = $context->hasSelf() ? 'EmptyClass' : 'unknown context';
+
+        /** @var ReflectionClass|MockObject $targetClass */
+        $targetClass = $this->createMock(ReflectionClass::class);
+
+        $targetClass
+            ->expects(self::any())
+            ->method('getName')
+            ->willReturn('An\\Example');
+
+        self::assertSame(
+            'Could not locate constant An\Example::SOME_CONSTANT while trying to evaluate constant expression in '
+            . $contextName . ' at line -1',
+            UnableToCompileNode::becauseOfNotFoundClassConstantReference(
+                $context,
+                $targetClass,
+                new ClassConstFetch(
+                    new Name\FullyQualified('A'),
+                    new Identifier('SOME_CONSTANT')
+                )
+            )->getMessage()
+        );
+    }
+
+    /** @dataProvider supportedContextTypes */
+    public function testForUnRecognizedExpressionInContext(CompilerContext $context) : void
+    {
+        $contextName = $context->hasSelf() ? 'EmptyClass' : 'unknown context';
+
+        self::assertSame(
+            'Unable to compile expression in ' . $contextName
+            . ': unrecognized node type ' . Yield_::class
+            . ' at line -1',
+            UnableToCompileNode::forUnRecognizedExpressionInContext(
+                new Yield_(new String_('')),
+                $context
+            )->getMessage()
+        );
+    }
+
+    /** @return CompilerContext[] */
+    public function supportedContextTypes() : array
+    {
+        $reflector = new ClassReflector(new StringSourceLocator(
+            '<?php class EmptyClass {}',
+            BetterReflectionSingleton::instance()->astLocator()
+        ));
+
+        return [
+            [new CompilerContext($reflector, null)],
+            [new CompilerContext($reflector, $reflector->reflect('EmptyClass'))],
+        ];
+    }
+}


### PR DESCRIPTION
This basically replaces a null pointer error with a nicer exception with some
minimal context/description around it.