### PR TITLE
[RFC] Pass ClassIdentifier to StubClassSourceLocator

### DIFF
--- a/src/Identifier/ClassIdentifier.php
+++ b/src/Identifier/ClassIdentifier.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Roave\BetterReflection\Identifier;
+
+class ClassIdentifier extends Identifier
+{
+}

--- a/src/Reflection/ReflectionClass.php
+++ b/src/Reflection/ReflectionClass.php
@@ -21,6 +21,8 @@ use ReflectionClass as CoreReflectionClass;
 use ReflectionProperty as CoreReflectionProperty;
 use Reflector as CoreReflector;
 use Roave\BetterReflection\BetterReflection;
+use Roave\BetterReflection\Identifier\ClassIdentifier;
+use Roave\BetterReflection\Identifier\IdentifierType;
 use Roave\BetterReflection\Reflection\Exception\ClassDoesNotExist;
 use Roave\BetterReflection\Reflection\Exception\NoObjectProvided;
 use Roave\BetterReflection\Reflection\Exception\NotAClassReflection;
@@ -784,8 +786,12 @@ class ReflectionClass implements Reflection, CoreReflector
         }
 
         // @TODO use actual `ClassReflector` or `FunctionReflector`?
+        $identifier = new ClassIdentifier(
+            $this->node->extends->toString(),
+            new IdentifierType(IdentifierType::IDENTIFIER_CLASS)
+        );
         /** @var self $parent */
-        $parent = $this->reflector->reflect($this->node->extends->toString());
+        $parent = $this->reflector->reflectIdentifier($identifier);
 
         if ($parent->isInterface() || $parent->isTrait()) {
             throw NotAClassReflection::fromReflectionClass($parent);

--- a/src/Reflection/ReflectionClass.php
+++ b/src/Reflection/ReflectionClass.php
@@ -32,6 +32,7 @@ use Roave\BetterReflection\Reflection\Exception\ObjectNotInstanceOfClass;
 use Roave\BetterReflection\Reflection\Exception\PropertyDoesNotExist;
 use Roave\BetterReflection\Reflection\Exception\Uncloneable;
 use Roave\BetterReflection\Reflection\StringCast\ReflectionClassStringCast;
+use Roave\BetterReflection\Reflector\ClassReflector;
 use Roave\BetterReflection\Reflector\Exception\IdentifierNotFound;
 use Roave\BetterReflection\Reflector\Reflector;
 use Roave\BetterReflection\SourceLocator\Located\LocatedSource;
@@ -58,7 +59,7 @@ class ReflectionClass implements Reflection, CoreReflector
 {
     public const ANONYMOUS_CLASS_NAME_PREFIX = 'class@anonymous';
 
-    /** @var Reflector */
+    /** @var ClassReflector */
     private $reflector;
 
     /** @var NamespaceNode|null */

--- a/src/Reflector/ClassReflector.php
+++ b/src/Reflector/ClassReflector.php
@@ -29,8 +29,19 @@ class ClassReflector implements Reflector
      */
     public function reflect(string $className) : Reflection
     {
-        $identifier = new Identifier($className, new IdentifierType(IdentifierType::IDENTIFIER_CLASS));
+        return $this->reflectIdentifier(
+            new Identifier($className, new IdentifierType(IdentifierType::IDENTIFIER_CLASS))
+        );
+    }
 
+    /**
+     * Create a ReflectionClass for the specified $identifier.
+     *
+     * @return ReflectionClass
+     * @throws IdentifierNotFound
+     */
+    public function reflectIdentifier(Identifier $identifier) : Reflection
+    {
         /** @var ReflectionClass|null $classInfo */
         $classInfo = $this->sourceLocator->locateIdentifier($this, $identifier);
 


### PR DESCRIPTION
When i tested `roave/backward-compatibility-check` tool, i found that it cannot check a class, that extends some other class from `require-dev` deps of composer.json

This job https://travis-ci.com/covex-nn/test-bc-check/builds/74891794, for example, was failed with a wierd message `Provided node "Symfony\Component\Filesystem\Filesystem" is not class, but "interface"`

~~~With this PR that message would be not so confusing~~~

This PR will let `StubClassSourceLocator` know what `Identifier` it must "locate"

* If it will be instanceof `ClassIdentifier`, them it will be `class`
* Otherwise - it will be interface
