### PR TITLE
Fixing AutoloadSourceLocator when multiple PSR-0/4 directories are possible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -76,7 +76,7 @@ jobs:
       php: 7.1
       env: DEPENDENCIES=""
       before_script:
-        - travis_retry composer require --dev --prefer-dist --prefer-stable phpstan/phpstan:^0.10.0
+        - travis_retry composer require --dev --prefer-dist --prefer-stable phpstan/phpstan:^0.10.2
       script: vendor/bin/phpstan analyse -l 5 -c phpstan.neon src
 
     - stage: Static Analysis

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -3,5 +3,3 @@ parameters:
         # Some parent constructors are explicitly to be ignored
         - '#does not call parent constructor#'
         - '#Access to an undefined property PhpParser\\Node\\Param::\$isOptional#'
-        # PHPStan bug reported to author privatly
-        - '#Parameter \#1 \.\.\.\$(sourceLocator|node) of closure expects#'

--- a/src/SourceLocator/Type/AutoloadSourceLocator.php
+++ b/src/SourceLocator/Type/AutoloadSourceLocator.php
@@ -186,7 +186,7 @@ class AutoloadSourceLocator extends AbstractSourceLocator
      *
      * @param string $path
      * @param int    $flags
-     * @return mixed[]|false
+     * @return mixed[]|bool
      * @see https://php.net/manual/en/class.streamwrapper.php
      * @see https://php.net/manual/en/streamwrapper.url-stat.php
      * @phpcsSuppress SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingParameterTypeHint

--- a/src/SourceLocator/Type/AutoloadSourceLocator.php
+++ b/src/SourceLocator/Type/AutoloadSourceLocator.php
@@ -180,7 +180,9 @@ class AutoloadSourceLocator extends AbstractSourceLocator
     }
 
     /**
-     * Must be implemented to return some data so that calls like is_file will work.
+     * url_stat is triggered by calls like "file_exists". The call to "file_exists" must not be overloaded.
+     * This function restores the original "file" stream, issues a call to "stat" to get the real results,
+     * and then re-registers the AutoloadSourceLocator stream wrapper.
      *
      * @param string $path
      * @param int    $flags

--- a/src/SourceLocator/Type/AutoloadSourceLocator.php
+++ b/src/SourceLocator/Type/AutoloadSourceLocator.php
@@ -11,19 +11,19 @@ use Roave\BetterReflection\Identifier\Identifier;
 use Roave\BetterReflection\SourceLocator\Ast\Locator as AstLocator;
 use Roave\BetterReflection\SourceLocator\Exception\InvalidFileLocation;
 use Roave\BetterReflection\SourceLocator\Located\LocatedSource;
-use function array_merge;
-use function array_values;
+use const STREAM_URL_STAT_QUIET;
 use function class_exists;
 use function file_exists;
 use function file_get_contents;
 use function function_exists;
 use function interface_exists;
 use function is_string;
+use function restore_error_handler;
 use function set_error_handler;
+use function stat;
 use function stream_wrapper_register;
 use function stream_wrapper_restore;
 use function stream_wrapper_unregister;
-use function time;
 use function trait_exists;
 
 /**
@@ -183,8 +183,8 @@ class AutoloadSourceLocator extends AbstractSourceLocator
      * Must be implemented to return some data so that calls like is_file will work.
      *
      * @param string $path
-     * @param int    $flags|false
-     * @return mixed[]
+     * @param int    $flags
+     * @return mixed[]|false
      * @see https://php.net/manual/en/class.streamwrapper.php
      * @see https://php.net/manual/en/streamwrapper.url-stat.php
      * @phpcsSuppress SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingParameterTypeHint

--- a/test/unit/Fixture/AutoloadableClassWithTwoDirectories.php
+++ b/test/unit/Fixture/AutoloadableClassWithTwoDirectories.php
@@ -1,0 +1,10 @@
+<?php
+
+
+namespace Foo\Bar;
+
+
+class AutoloadableClassWithTwoDirectories
+{
+
+}

--- a/test/unit/SourceLocator/Type/AutoloadSourceLocatorTest.php
+++ b/test/unit/SourceLocator/Type/AutoloadSourceLocatorTest.php
@@ -228,6 +228,8 @@ class AutoloadSourceLocatorTest extends TestCase
         );
 
         spl_autoload_unregister([$this, 'autoload']);
+
+        self::assertFalse(class_exists(AutoloadableClassWithTwoDirectories::class, false));
     }
 
     /**

--- a/test/unit/SourceLocator/Type/AutoloadSourceLocatorTest.php
+++ b/test/unit/SourceLocator/Type/AutoloadSourceLocatorTest.php
@@ -22,7 +22,10 @@ use Roave\BetterReflectionTest\Fixture\AutoloadableTrait;
 use Roave\BetterReflectionTest\Fixture\ClassForHinting;
 use Roave\BetterReflectionTest\Fixture\ExampleClass;
 use function class_exists;
+use function file_exists;
 use function interface_exists;
+use function spl_autoload_register;
+use function spl_autoload_unregister;
 use function trait_exists;
 use function uniqid;
 
@@ -235,15 +238,16 @@ class AutoloadSourceLocatorTest extends TestCase
     /**
      * A test autoloader that simulates Composer PSR-4 autoloader with 2 possible directories for the same namespace.
      */
-    public function autoload(string $className) : bool {
+    public function autoload(string $className) : bool
+    {
         if ($className !== AutoloadableClassWithTwoDirectories::class) {
             return false;
         }
 
-        self::assertFalse(file_exists(__DIR__.'/AutoloadableClassWithTwoDirectories.php'));
-        self::assertTrue(file_exists(__DIR__.'/../../Fixture/AutoloadableClassWithTwoDirectories.php'));
+        self::assertFalse(file_exists(__DIR__ . '/AutoloadableClassWithTwoDirectories.php'));
+        self::assertTrue(file_exists(__DIR__ . '/../../Fixture/AutoloadableClassWithTwoDirectories.php'));
 
-        include __DIR__.'/../../Fixture/AutoloadableClassWithTwoDirectories.php';
+        include __DIR__ . '/../../Fixture/AutoloadableClassWithTwoDirectories.php';
         return true;
     }
 }

--- a/test/unit/SourceLocator/Type/AutoloadSourceLocatorTest.php
+++ b/test/unit/SourceLocator/Type/AutoloadSourceLocatorTest.php
@@ -215,7 +215,7 @@ class AutoloadSourceLocatorTest extends TestCase
         );
     }
 
-    public function testCanAutoloadPsr4ClassesInpotentiallyMultipleDirectories() : void
+    public function testCanAutoloadPsr4ClassesInPotentiallyMultipleDirectories() : void
     {
         self::assertNotNull(
             (new AutoloadSourceLocator($this->astLocator))

--- a/test/unit/SourceLocator/Type/AutoloadSourceLocatorTest.php
+++ b/test/unit/SourceLocator/Type/AutoloadSourceLocatorTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Roave\BetterReflectionTest\SourceLocator\Type;
 
+use phpDocumentor\Reflection\DocBlock\ExampleFinder;
 use PHPUnit\Framework\TestCase;
 use ReflectionObject;
 use Roave\BetterReflection\Identifier\Identifier;
@@ -210,6 +211,17 @@ class AutoloadSourceLocatorTest extends TestCase
                 ->locateIdentifier(
                     $this->getMockReflector(),
                     new Identifier('strlen', new IdentifierType(IdentifierType::IDENTIFIER_FUNCTION))
+                )
+        );
+    }
+
+    public function testCanAutoloadPsr4ClassesInpotentiallyMultipleDirectories() : void
+    {
+        self::assertNotNull(
+            (new AutoloadSourceLocator($this->astLocator))
+                ->locateIdentifier(
+                    $this->getMockReflector(),
+                    new Identifier(ExampleFinder::class, new IdentifierType(IdentifierType::IDENTIFIER_CLASS))
                 )
         );
     }


### PR DESCRIPTION
This PR fixes #384.

The issue was that Composer autoloader is scanning the PSR-4 directories that may contain the file.

**Composer's ClassLoader.php excerpt**:
```php
    foreach ($this->prefixDirsPsr4[$search] as $dir) {
        if (file_exists($file = $dir . $pathEnd)) {
            return $file;
        }
    }
```

The call to `file_exists` was always returning `true`, because of the way the `AutoloadSourceLocator::url_stat` was written.

I reimplemented the `url_stat` to actually unregister the stream wrapper, fall back to the real stream wrapper, do the real "stat" call and then re-register the stream wrapper.

The code is strongly inspired from PHP-VCR so thanks to PHP-VCR folks for the idea :)

Note: The first commit is a failing test to demonstrate #384 issue.