### PR TITLE
Adapter's ReflectionClass::getConstructor() returns null when no constructor exists

### DIFF
--- a/src/Reflection/Adapter/ReflectionClass.php
+++ b/src/Reflection/Adapter/ReflectionClass.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Roave\BetterReflection\Reflection\Adapter;
 
+use OutOfBoundsException;
 use ReflectionClass as CoreReflectionClass;
 use ReflectionException as CoreReflectionException;
 use Roave\BetterReflection\Reflection\ReflectionClass as BetterReflectionClass;
@@ -127,7 +128,11 @@ class ReflectionClass extends CoreReflectionClass
      */
     public function getConstructor()
     {
-        return new ReflectionMethod($this->betterReflectionClass->getConstructor());
+        try {
+            return new ReflectionMethod($this->betterReflectionClass->getConstructor());
+        } catch (OutOfBoundsException $e) {
+            return null;
+        }
     }
 
     /**

--- a/test/unit/Reflection/Adapter/ReflectionClassTest.php
+++ b/test/unit/Reflection/Adapter/ReflectionClassTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Roave\BetterReflectionTest\Reflection\Adapter;
 
+use OutOfBoundsException;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass as CoreReflectionClass;
 use ReflectionException as CoreReflectionException;
@@ -424,5 +425,17 @@ class ReflectionClassTest extends TestCase
         $reflectionClassAdapter = new ReflectionClassAdapter($betterReflectionClass);
 
         self::assertFalse($reflectionClassAdapter->getExtensionName());
+    }
+
+    public function testGetConstructorReturnsNullWhenNoConstructorExists() : void
+    {
+        $betterReflectionClass = $this->createMock(BetterReflectionClass::class);
+        $betterReflectionClass
+            ->method('getConstructor')
+            ->willThrowException(new OutOfBoundsException());
+
+        $reflectionClassAdapter = new ReflectionClassAdapter($betterReflectionClass);
+
+        self::assertNull($reflectionClassAdapter->getConstructor());
     }
 }


### PR DESCRIPTION
As per https://secure.php.net/manual/en/reflectionclass.getconstructor.php. If someone can guide me on how to write a test for this, I'll be happy to do it.