### PR TITLE
Allow installing with php 7.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Better Reflection - an improved code reflection API",
     "license": "MIT",
     "require": {
-        "php": ">=7.1.0,<7.3.0",
+        "php": ">=7.1.0,<7.4.0",
         "nikic/php-parser": "^4.0.0",
         "phpdocumentor/reflection-docblock": "^4.1.1",
         "phpdocumentor/type-resolver": "^0.4.0",


### PR DESCRIPTION
TravisCI now supports php 7.3 RC, but testing projects that require BetterReflection against 7.3 is not possible with the current version requirement in composer.json. If you would like to consider a change it would be much appreciated.