### PR TITLE
getInterfaceNames + SingleFileSourceLocator exception on native interfaces

### DIFF
--- a/test/unit/Fixture/CustomException.php
+++ b/test/unit/Fixture/CustomException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Roave\BetterReflectionTest\Fixture;
+
+class CustomException extends Exception
+{
+  
+}

--- a/test/unit/Reflection/ReflectionClassTest.php
+++ b/test/unit/Reflection/ReflectionClassTest.php
@@ -395,7 +395,7 @@ class Foo
     protected $c = 'c',
               $d = 'd';
     private $e = bool,
-            $f = false;                
+            $f = false;
 }
 PHP;
 
@@ -993,6 +993,16 @@ PHP;
                 ->getInterfaceNames(),
             'Interfaces are retrieved in the correct numeric order (indexed by number)'
         );
+    }
+
+    public function testGetInterfaceNamesFromCustomExceptionClassThatExtendsNativeExceptionClass() : void
+    {
+        $reflector = new ClassReflector(new SingleFileSourceLocator(
+            __DIR__ . '/../Fixture/CustomException.php',
+            $this->astLocator
+        ));
+
+        $this->assertContains(\Throwable::class, $reflector->reflect($reflector->getAllClasses()[0]->getName())->getInterfaceNames());
     }
 
     public function testGetInterfaces() : void


### PR DESCRIPTION
Reference to issue #456 

Run:
```
./vendor/bin/phpunit --filter testGetInterfaceNamesFromCustomExceptionClassThatExtendsNativeExceptionClass ReflectionClassTest test/unit/Reflection/ReflectionClassTest.php
```

Result:
```
PHPUnit 7.4.1 by Sebastian Bergmann and contributors.

E                                                                   1 / 1 (100%)

Time: 413 ms, Memory: 10.00MB

There was 1 error:

1) Roave\BetterReflectionTest\Reflection\ReflectionClassTest::testGetInterfaceNamesFromCustomExceptionClassThatExtendsNativeExceptionClass
Roave\BetterReflection\Reflector\Exception\IdentifierNotFound: Roave\BetterReflection\Reflection\ReflectionClass "Roave\BetterReflectionTest\Fixture\Exception" could not be found in the located source

/***/BetterReflection2/src/Reflector/Exception/IdentifierNotFound.php:30
/***/BetterReflection2/src/Reflector/ClassReflector.php:39
/***/BetterReflection2/src/Reflection/ReflectionClass.php:791
/***/BetterReflection2/src/Reflection/ReflectionClass.php:1187
/***/BetterReflection2/src/Reflection/ReflectionClass.php:1014
/***/BetterReflection2/src/Reflection/ReflectionClass.php:1042
/***/BetterReflection2/test/unit/Reflection/ReflectionClassTest.php:1005

ERRORS!
Tests: 1, Assertions: 0, Errors: 1.
```

Thanks!