### PR TITLE
Fix `.gitignore` format for Windows environments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 /.phpcs-cache
 /.phpunit.result.cache
 /phpcs.xml
-./vendor
+/vendor

--- a/test/unit/SourceLocator/SourceStubber/ReflectionSourceStubberTest.php
+++ b/test/unit/SourceLocator/SourceStubber/ReflectionSourceStubberTest.php
@@ -191,7 +191,8 @@ class ReflectionSourceStubberTest extends TestCase
         }
 
         if ($original->getName() === RecursiveArrayIterator::class
-            && (PHP_VERSION_ID < 70114 || (PHP_VERSION_ID >= 70200 && PHP_VERSION_ID < 70202))
+            && PHP_VERSION_ID >= 70200
+            && PHP_VERSION_ID < 70202
         ) {
             // https://bugs.php.net/bug.php?id=75242
             self::markTestIncomplete(sprintf(


### PR DESCRIPTION
The previous version of `.gitignore` does not work on Windows.