### PR TITLE
Correct PHPUnit MockObject class names as per PHPUnit 8+

### DIFF
--- a/test/unit/Reflection/Adapter/ReflectionClassConstantTest.php
+++ b/test/unit/Reflection/Adapter/ReflectionClassConstantTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Roave\BetterReflectionTest\Reflection\Adapter;
 
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use PHPUnit_Framework_MockObject_MockObject;
 use ReflectionClass as CoreReflectionClass;
 use ReflectionClassConstant as CoreReflectionClassConstant;
 use Roave\BetterReflection\Reflection\Adapter\ReflectionClassConstant as ReflectionClassConstantAdapter;
@@ -61,7 +61,7 @@ class ReflectionClassConstantTest extends TestCase
      */
     public function testAdapterMethods(string $methodName, $returnValue, array $args) : void
     {
-        /** @var BetterReflectionClassConstant|PHPUnit_Framework_MockObject_MockObject $reflectionStub */
+        /** @var BetterReflectionClassConstant|MockObject $reflectionStub */
         $reflectionStub = $this->createMock(BetterReflectionClassConstant::class);
 
         $reflectionStub->expects($this->once())

--- a/test/unit/Reflection/Adapter/ReflectionClassTest.php
+++ b/test/unit/Reflection/Adapter/ReflectionClassTest.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Roave\BetterReflectionTest\Reflection\Adapter;
 
 use OutOfBoundsException;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use PHPUnit_Framework_MockObject_MockObject;
 use ReflectionClass as CoreReflectionClass;
 use ReflectionException as CoreReflectionException;
 use Roave\BetterReflection\Reflection\Adapter\Exception\NotImplemented;
@@ -113,7 +113,7 @@ class ReflectionClassTest extends TestCase
      */
     public function testAdapterMethods(string $methodName, ?string $expectedException, $returnValue, array $args) : void
     {
-        /** @var BetterReflectionClass|PHPUnit_Framework_MockObject_MockObject $reflectionStub */
+        /** @var BetterReflectionClass|MockObject $reflectionStub */
         $reflectionStub = $this->createMock(BetterReflectionClass::class);
 
         if ($expectedException === null) {

--- a/test/unit/Reflection/Adapter/ReflectionFunctionTest.php
+++ b/test/unit/Reflection/Adapter/ReflectionFunctionTest.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Roave\BetterReflectionTest\Reflection\Adapter;
 
 use Exception;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use PHPUnit_Framework_MockObject_MockObject;
 use ReflectionClass as CoreReflectionClass;
 use ReflectionException as CoreReflectionException;
 use ReflectionFunction as CoreReflectionFunction;
@@ -96,7 +96,7 @@ class ReflectionFunctionTest extends TestCase
      */
     public function testAdapterMethods(string $methodName, ?string $expectedException, $returnValue, array $args) : void
     {
-        /** @var BetterReflectionFunction|PHPUnit_Framework_MockObject_MockObject $reflectionStub */
+        /** @var BetterReflectionFunction|MockObject $reflectionStub */
         $reflectionStub = $this->createMock(BetterReflectionFunction::class);
 
         if ($expectedException === null) {

--- a/test/unit/Reflection/Adapter/ReflectionMethodTest.php
+++ b/test/unit/Reflection/Adapter/ReflectionMethodTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Roave\BetterReflectionTest\Reflection\Adapter;
 
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use PHPUnit_Framework_MockObject_MockObject;
 use ReflectionClass as CoreReflectionClass;
 use ReflectionException as CoreReflectionException;
 use ReflectionMethod as CoreReflectionMethod;
@@ -112,7 +112,7 @@ class ReflectionMethodTest extends TestCase
      */
     public function testAdapterMethods(string $methodName, ?string $expectedException, $returnValue, array $args) : void
     {
-        /** @var BetterReflectionMethod|PHPUnit_Framework_MockObject_MockObject $reflectionStub */
+        /** @var BetterReflectionMethod|MockObject $reflectionStub */
         $reflectionStub = $this->createMock(BetterReflectionMethod::class);
 
         if ($expectedException === null) {

--- a/test/unit/Reflection/Adapter/ReflectionObjectTest.php
+++ b/test/unit/Reflection/Adapter/ReflectionObjectTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Roave\BetterReflectionTest\Reflection\Adapter;
 
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use PHPUnit_Framework_MockObject_MockObject;
 use ReflectionClass as CoreReflectionClass;
 use ReflectionException as CoreReflectionException;
 use ReflectionObject as CoreReflectionObject;
@@ -108,7 +108,7 @@ class ReflectionObjectTest extends TestCase
      */
     public function testAdapterMethods(string $methodName, ?string $expectedException, $returnValue, array $args) : void
     {
-        /** @var BetterReflectionObject|PHPUnit_Framework_MockObject_MockObject $reflectionStub */
+        /** @var BetterReflectionObject|MockObject $reflectionStub */
         $reflectionStub = $this->createMock(BetterReflectionObject::class);
 
         if ($expectedException === null) {

--- a/test/unit/Reflection/Adapter/ReflectionParameterTest.php
+++ b/test/unit/Reflection/Adapter/ReflectionParameterTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Roave\BetterReflectionTest\Reflection\Adapter;
 
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use PHPUnit_Framework_MockObject_MockObject;
 use ReflectionClass as CoreReflectionClass;
 use ReflectionParameter as CoreReflectionParameter;
 use Roave\BetterReflection\Reflection\Adapter\ReflectionParameter as ReflectionParameterAdapter;
@@ -86,7 +86,7 @@ class ReflectionParameterTest extends TestCase
      */
     public function testAdapterMethods(string $methodName, ?string $expectedException, $returnValue, array $args) : void
     {
-        /** @var BetterReflectionParameter|PHPUnit_Framework_MockObject_MockObject $reflectionStub */
+        /** @var BetterReflectionParameter|MockObject $reflectionStub */
         $reflectionStub = $this->createMock(BetterReflectionParameter::class);
 
         if ($expectedException === null) {

--- a/test/unit/Reflection/Adapter/ReflectionPropertyTest.php
+++ b/test/unit/Reflection/Adapter/ReflectionPropertyTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Roave\BetterReflectionTest\Reflection\Adapter;
 
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use PHPUnit_Framework_MockObject_MockObject;
 use ReflectionClass as CoreReflectionClass;
 use ReflectionException as CoreReflectionException;
 use ReflectionProperty as CoreReflectionProperty;
@@ -68,7 +68,7 @@ class ReflectionPropertyTest extends TestCase
      */
     public function testAdapterMethods(string $methodName, $returnValue, array $args) : void
     {
-        /** @var BetterReflectionProperty|PHPUnit_Framework_MockObject_MockObject $reflectionStub */
+        /** @var BetterReflectionProperty|MockObject $reflectionStub */
         $reflectionStub = $this->createMock(BetterReflectionProperty::class);
 
         $reflectionStub->expects($this->once())

--- a/test/unit/Reflection/Adapter/ReflectionTypeTest.php
+++ b/test/unit/Reflection/Adapter/ReflectionTypeTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Roave\BetterReflectionTest\Reflection\Adapter;
 
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use PHPUnit_Framework_MockObject_MockObject;
 use ReflectionClass as CoreReflectionClass;
 use ReflectionType as CoreReflectionType;
 use Roave\BetterReflection\Reflection\Adapter\ReflectionType;
@@ -56,7 +56,7 @@ class ReflectionTypeTest extends TestCase
      */
     public function testAdapterMethods(string $methodName, ?string $expectedException, $returnValue, array $args) : void
     {
-        /** @var BetterReflectionType|PHPUnit_Framework_MockObject_MockObject $reflectionStub */
+        /** @var BetterReflectionType|MockObject $reflectionStub */
         $reflectionStub = $this->createMock(BetterReflectionType::class);
 
         if ($expectedException === null) {

--- a/test/unit/Reflector/ClassReflectorTest.php
+++ b/test/unit/Reflector/ClassReflectorTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Roave\BetterReflectionTest\Reflector;
 
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use PHPUnit_Framework_MockObject_MockObject;
 use Roave\BetterReflection\Reflection\ReflectionClass;
 use Roave\BetterReflection\Reflector\ClassReflector;
 use Roave\BetterReflection\Reflector\Exception\IdentifierNotFound;
@@ -32,7 +32,7 @@ class ClassReflectorTest extends TestCase
     {
         $reflection = $this->createMock(ReflectionClass::class);
 
-        /** @var StringSourceLocator|PHPUnit_Framework_MockObject_MockObject $sourceLocator */
+        /** @var StringSourceLocator|MockObject $sourceLocator */
         $sourceLocator = $this
             ->getMockBuilder(StringSourceLocator::class)
             ->disableOriginalConstructor()

--- a/test/unit/Reflector/FunctionReflectorTest.php
+++ b/test/unit/Reflector/FunctionReflectorTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Roave\BetterReflectionTest\Reflector;
 
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use PHPUnit_Framework_MockObject_MockObject;
 use Roave\BetterReflection\Reflection\ReflectionFunction;
 use Roave\BetterReflection\Reflector\ClassReflector;
 use Roave\BetterReflection\Reflector\FunctionReflector;
@@ -32,7 +32,7 @@ class FunctionReflectorTest extends TestCase
     {
         $reflection = $this->createMock(ReflectionFunction::class);
 
-        /** @var StringSourceLocator|PHPUnit_Framework_MockObject_MockObject $sourceLocator */
+        /** @var StringSourceLocator|MockObject $sourceLocator */
         $sourceLocator = $this
             ->getMockBuilder(StringSourceLocator::class)
             ->disableOriginalConstructor()

--- a/test/unit/SourceLocator/Ast/FindReflectionsInTreeTest.php
+++ b/test/unit/SourceLocator/Ast/FindReflectionsInTreeTest.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Roave\BetterReflectionTest\Reflector;
 
 use PhpParser\Node;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use PHPUnit_Framework_MockObject_MockObject;
 use Roave\BetterReflection\Identifier\IdentifierType;
 use Roave\BetterReflection\Reflection\ReflectionClass;
 use Roave\BetterReflection\Reflection\ReflectionFunction;
@@ -31,13 +31,13 @@ class FindReflectionsInTreeTest extends TestCase
 
     public function testInvokeDoesNotCallReflectNodesWhenNoNodesFoundInEmptyAst() : void
     {
-        /** @var NodeToReflection|PHPUnit_Framework_MockObject_MockObject $strategy */
+        /** @var NodeToReflection|MockObject $strategy */
         $strategy = $this->createMock(NodeToReflection::class);
 
         $strategy->expects($this->never())
             ->method('__invoke');
 
-        /** @var Reflector|PHPUnit_Framework_MockObject_MockObject $reflector */
+        /** @var Reflector|MockObject $reflector */
         $reflector     = $this->createMock(Reflector::class);
         $locatedSource = new LocatedSource('<?php', null);
 
@@ -54,13 +54,13 @@ class FindReflectionsInTreeTest extends TestCase
 
     public function testInvokeDoesNotCallReflectNodesWhenNoNodesFoundInPopulatedAst() : void
     {
-        /** @var NodeToReflection|PHPUnit_Framework_MockObject_MockObject $strategy */
+        /** @var NodeToReflection|MockObject $strategy */
         $strategy = $this->createMock(NodeToReflection::class);
 
         $strategy->expects($this->never())
             ->method('__invoke');
 
-        /** @var Reflector|PHPUnit_Framework_MockObject_MockObject $reflector */
+        /** @var Reflector|MockObject $reflector */
         $reflector     = $this->createMock(Reflector::class);
         $locatedSource = new LocatedSource('<?php echo "Hello world";', null);
 
@@ -77,7 +77,7 @@ class FindReflectionsInTreeTest extends TestCase
 
     public function testInvokeCallsReflectNodesForClassWithoutNamespace() : void
     {
-        /** @var NodeToReflection|PHPUnit_Framework_MockObject_MockObject $strategy */
+        /** @var NodeToReflection|MockObject $strategy */
         $strategy = $this->createMock(NodeToReflection::class);
 
         $mockReflection = $this->createMock(ReflectionClass::class);
@@ -86,7 +86,7 @@ class FindReflectionsInTreeTest extends TestCase
             ->method('__invoke')
             ->will($this->returnValue($mockReflection));
 
-        /** @var Reflector|PHPUnit_Framework_MockObject_MockObject $reflector */
+        /** @var Reflector|MockObject $reflector */
         $reflector     = $this->createMock(Reflector::class);
         $locatedSource = new LocatedSource('<?php class Foo {}', null);
 
@@ -103,7 +103,7 @@ class FindReflectionsInTreeTest extends TestCase
 
     public function testInvokeCallsReflectNodesForNamespacedClass() : void
     {
-        /** @var NodeToReflection|PHPUnit_Framework_MockObject_MockObject $strategy */
+        /** @var NodeToReflection|MockObject $strategy */
         $strategy = $this->createMock(NodeToReflection::class);
 
         $mockReflection = $this->createMock(ReflectionClass::class);
@@ -112,7 +112,7 @@ class FindReflectionsInTreeTest extends TestCase
             ->method('__invoke')
             ->will($this->returnValue($mockReflection));
 
-        /** @var Reflector|PHPUnit_Framework_MockObject_MockObject $reflector */
+        /** @var Reflector|MockObject $reflector */
         $reflector     = $this->createMock(Reflector::class);
         $locatedSource = new LocatedSource('<?php namespace Foo { class Bar {} }', null);
 
@@ -129,7 +129,7 @@ class FindReflectionsInTreeTest extends TestCase
 
     public function testInvokeCallsReflectNodesForFunction() : void
     {
-        /** @var NodeToReflection|PHPUnit_Framework_MockObject_MockObject $strategy */
+        /** @var NodeToReflection|MockObject $strategy */
         $strategy = $this->createMock(NodeToReflection::class);
 
         $mockReflection = $this->createMock(ReflectionFunction::class);
@@ -138,7 +138,7 @@ class FindReflectionsInTreeTest extends TestCase
             ->method('__invoke')
             ->will($this->returnValue($mockReflection));
 
-        /** @var Reflector|PHPUnit_Framework_MockObject_MockObject $reflector */
+        /** @var Reflector|MockObject $reflector */
         $reflector     = $this->createMock(Reflector::class);
         $locatedSource = new LocatedSource('<?php function foo() {}', null);
 
@@ -155,7 +155,7 @@ class FindReflectionsInTreeTest extends TestCase
 
     public function testAnonymousClassCreatedInFunction() : void
     {
-        /** @var NodeToReflection|PHPUnit_Framework_MockObject_MockObject $strategy */
+        /** @var NodeToReflection|MockObject $strategy */
         $strategy = $this->createMock(NodeToReflection::class);
 
         $mockReflectionFunction = $this->createMock(ReflectionFunction::class);
@@ -165,7 +165,7 @@ class FindReflectionsInTreeTest extends TestCase
             ->method('__invoke')
             ->willReturnOnConsecutiveCalls($mockReflectionFunction, $mockReflectionClass);
 
-        /** @var Reflector|PHPUnit_Framework_MockObject_MockObject $reflector */
+        /** @var Reflector|MockObject $reflector */
         $reflector     = $this->createMock(Reflector::class);
         $locatedSource = new LocatedSource('<?php function foo() {return new class {};}', null);
 

--- a/test/unit/SourceLocator/Ast/Parser/MemoizingParserTest.php
+++ b/test/unit/SourceLocator/Ast/Parser/MemoizingParserTest.php
@@ -6,8 +6,8 @@ namespace Roave\BetterReflectionTest\Reflector;
 
 use PhpParser\Node;
 use PhpParser\Parser;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use PHPUnit_Framework_MockObject_MockObject;
 use Roave\BetterReflection\SourceLocator\Ast\Parser\MemoizingParser;
 use function array_map;
 use function array_unique;
@@ -23,7 +23,7 @@ class MemoizingParserTest extends TestCase
 {
     public function testParse() : void
     {
-        /** @var Parser|PHPUnit_Framework_MockObject_MockObject $wrappedParser */
+        /** @var Parser|MockObject $wrappedParser */
         $wrappedParser = $this->createMock(Parser::class);
 
         $randomCodeStrings = array_unique(array_map(

--- a/test/unit/SourceLocator/Ast/Strategy/NodeToReflectionTest.php
+++ b/test/unit/SourceLocator/Ast/Strategy/NodeToReflectionTest.php
@@ -7,8 +7,8 @@ namespace Roave\BetterReflectionTest\Reflector;
 use PhpParser\Lexer;
 use PhpParser\Node;
 use PhpParser\Parser;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use PHPUnit_Framework_MockObject_MockObject;
 use Roave\BetterReflection\Reflection\ReflectionClass;
 use Roave\BetterReflection\Reflection\ReflectionFunction;
 use Roave\BetterReflection\Reflector\Reflector;
@@ -33,7 +33,7 @@ class NodeToReflectionTest extends TestCase
 
     public function testReturnsReflectionForClassNode() : void
     {
-        /** @var Reflector|PHPUnit_Framework_MockObject_MockObject $reflector */
+        /** @var Reflector|MockObject $reflector */
         $reflector = $this->createMock(Reflector::class);
 
         $locatedSource = new LocatedSource('<?php class Foo {}', null);
@@ -51,7 +51,7 @@ class NodeToReflectionTest extends TestCase
 
     public function testReturnsReflectionForTraitNode() : void
     {
-        /** @var Reflector|PHPUnit_Framework_MockObject_MockObject $reflector */
+        /** @var Reflector|MockObject $reflector */
         $reflector = $this->createMock(Reflector::class);
 
         $locatedSource = new LocatedSource('<?php trait Foo {}', null);
@@ -70,7 +70,7 @@ class NodeToReflectionTest extends TestCase
 
     public function testReturnsReflectionForInterfaceNode() : void
     {
-        /** @var Reflector|PHPUnit_Framework_MockObject_MockObject $reflector */
+        /** @var Reflector|MockObject $reflector */
         $reflector = $this->createMock(Reflector::class);
 
         $locatedSource = new LocatedSource('<?php interface Foo {}', null);
@@ -89,7 +89,7 @@ class NodeToReflectionTest extends TestCase
 
     public function testReturnsReflectionForFunctionNode() : void
     {
-        /** @var Reflector|PHPUnit_Framework_MockObject_MockObject $reflector */
+        /** @var Reflector|MockObject $reflector */
         $reflector = $this->createMock(Reflector::class);
 
         $locatedSource = new LocatedSource('<?php function foo(){}', null);
@@ -107,7 +107,7 @@ class NodeToReflectionTest extends TestCase
 
     public function testReturnsNullWhenIncompatibleNodeFound() : void
     {
-        /** @var Reflector|PHPUnit_Framework_MockObject_MockObject $reflector */
+        /** @var Reflector|MockObject $reflector */
         $reflector = $this->createMock(Reflector::class);
 
         $locatedSource = new LocatedSource('<?php echo "Hello world";', null);

--- a/test/unit/SourceLocator/Type/AbstractSourceLocatorTest.php
+++ b/test/unit/SourceLocator/Type/AbstractSourceLocatorTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Roave\BetterReflectionTest\SourceLocator\Type;
 
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use PHPUnit_Framework_MockObject_MockObject;
 use Roave\BetterReflection\Identifier\Identifier;
 use Roave\BetterReflection\Identifier\IdentifierType;
 use Roave\BetterReflection\Reflection\ReflectionClass;
@@ -22,7 +22,7 @@ class AbstractSourceLocatorTest extends TestCase
 {
     public function testLocateIdentifierCallsFindReflection() : void
     {
-        /** @var Reflector|PHPUnit_Framework_MockObject_MockObject $mockReflector */
+        /** @var Reflector|MockObject $mockReflector */
         $mockReflector = $this->createMock(Reflector::class);
 
         $locatedSource = new LocatedSource('<?php class Foo{}', null);
@@ -31,7 +31,7 @@ class AbstractSourceLocatorTest extends TestCase
 
         $mockReflection = $this->createMock(ReflectionClass::class);
 
-        /** @var AstLocator|PHPUnit_Framework_MockObject_MockObject $astLocator */
+        /** @var AstLocator|MockObject $astLocator */
         $astLocator = $this->createMock(AstLocator::class);
 
         $astLocator->expects($this->once())
@@ -39,7 +39,7 @@ class AbstractSourceLocatorTest extends TestCase
             ->with($mockReflector, $locatedSource, $identifier)
             ->will($this->returnValue($mockReflection));
 
-        /** @var AbstractSourceLocator|PHPUnit_Framework_MockObject_MockObject $sourceLocator */
+        /** @var AbstractSourceLocator|MockObject $sourceLocator */
         $sourceLocator = $this->getMockBuilder(AbstractSourceLocator::class)
             ->setConstructorArgs([$astLocator])
             ->setMethods(['createLocatedSource'])
@@ -55,18 +55,18 @@ class AbstractSourceLocatorTest extends TestCase
 
     public function testLocateIdentifierReturnsNullWithoutTryingToFindReflectionWhenUnableToLocateSource() : void
     {
-        /** @var Reflector|PHPUnit_Framework_MockObject_MockObject $mockReflector */
+        /** @var Reflector|MockObject $mockReflector */
         $mockReflector = $this->createMock(Reflector::class);
 
         $identifier = new Identifier('Foo', new IdentifierType(IdentifierType::IDENTIFIER_CLASS));
 
-        /** @var AstLocator|PHPUnit_Framework_MockObject_MockObject $astLocator */
+        /** @var AstLocator|MockObject $astLocator */
         $astLocator = $this->createMock(AstLocator::class);
 
         $astLocator->expects($this->never())
             ->method('findReflection');
 
-        /** @var AbstractSourceLocator|PHPUnit_Framework_MockObject_MockObject $sourceLocator */
+        /** @var AbstractSourceLocator|MockObject $sourceLocator */
         $sourceLocator = $this->getMockBuilder(AbstractSourceLocator::class)
             ->setConstructorArgs([$astLocator])
             ->setMethods(['createLocatedSource'])
@@ -82,14 +82,14 @@ class AbstractSourceLocatorTest extends TestCase
 
     public function testLocateIdentifierReturnsNullWhenFindLocatorThrowsException() : void
     {
-        /** @var Reflector|PHPUnit_Framework_MockObject_MockObject $mockReflector */
+        /** @var Reflector|MockObject $mockReflector */
         $mockReflector = $this->createMock(Reflector::class);
 
         $locatedSource = new LocatedSource('<?php class Foo{}', null);
 
         $identifier = new Identifier('Foo', new IdentifierType(IdentifierType::IDENTIFIER_CLASS));
 
-        /** @var AstLocator|PHPUnit_Framework_MockObject_MockObject $astLocator */
+        /** @var AstLocator|MockObject $astLocator */
         $astLocator = $this->createMock(AstLocator::class);
 
         $astLocator->expects($this->once())
@@ -97,7 +97,7 @@ class AbstractSourceLocatorTest extends TestCase
             ->with($mockReflector, $locatedSource, $identifier)
             ->will($this->throwException(new IdentifierNotFound('Foo', $identifier)));
 
-        /** @var AbstractSourceLocator|PHPUnit_Framework_MockObject_MockObject $sourceLocator */
+        /** @var AbstractSourceLocator|MockObject $sourceLocator */
         $sourceLocator = $this->getMockBuilder(AbstractSourceLocator::class)
             ->setConstructorArgs([$astLocator])
             ->setMethods(['createLocatedSource'])
@@ -113,7 +113,7 @@ class AbstractSourceLocatorTest extends TestCase
 
     public function testLocateIdentifiersByTypeCallsFindReflectionsOfType() : void
     {
-        /** @var Reflector|PHPUnit_Framework_MockObject_MockObject $mockReflector */
+        /** @var Reflector|MockObject $mockReflector */
         $mockReflector = $this->createMock(Reflector::class);
 
         $locatedSource = new LocatedSource('<?php class Foo{}', null);
@@ -122,7 +122,7 @@ class AbstractSourceLocatorTest extends TestCase
 
         $mockReflection = $this->createMock(ReflectionClass::class);
 
-        /** @var AstLocator|PHPUnit_Framework_MockObject_MockObject $astLocator */
+        /** @var AstLocator|MockObject $astLocator */
         $astLocator = $this->createMock(AstLocator::class);
 
         $astLocator->expects($this->once())
@@ -130,7 +130,7 @@ class AbstractSourceLocatorTest extends TestCase
             ->with($mockReflector, $locatedSource, $identifierType)
             ->will($this->returnValue([$mockReflection]));
 
-        /** @var AbstractSourceLocator|PHPUnit_Framework_MockObject_MockObject $sourceLocator */
+        /** @var AbstractSourceLocator|MockObject $sourceLocator */
         $sourceLocator = $this->getMockBuilder(AbstractSourceLocator::class)
             ->setConstructorArgs([$astLocator])
             ->setMethods(['createLocatedSource'])
@@ -145,18 +145,18 @@ class AbstractSourceLocatorTest extends TestCase
 
     public function testLocateIdentifiersByTypeReturnsEmptyArrayWithoutTryingToFindReflectionsWhenUnableToLocateSource() : void
     {
-        /** @var Reflector|PHPUnit_Framework_MockObject_MockObject $mockReflector */
+        /** @var Reflector|MockObject $mockReflector */
         $mockReflector = $this->createMock(Reflector::class);
 
         $identifierType = new IdentifierType(IdentifierType::IDENTIFIER_CLASS);
 
-        /** @var AstLocator|PHPUnit_Framework_MockObject_MockObject $astLocator */
+        /** @var AstLocator|MockObject $astLocator */
         $astLocator = $this->createMock(AstLocator::class);
 
         $astLocator->expects($this->never())
             ->method('findReflectionsOfType');
 
-        /** @var AbstractSourceLocator|PHPUnit_Framework_MockObject_MockObject $sourceLocator */
+        /** @var AbstractSourceLocator|MockObject $sourceLocator */
         $sourceLocator = $this->getMockBuilder(AbstractSourceLocator::class)
             ->setConstructorArgs([$astLocator])
             ->setMethods(['createLocatedSource'])

--- a/test/unit/SourceLocator/Type/AggregateSourceLocatorTest.php
+++ b/test/unit/SourceLocator/Type/AggregateSourceLocatorTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Roave\BetterReflectionTest\SourceLocator\Type;
 
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use PHPUnit_Framework_MockObject_MockObject;
 use Roave\BetterReflection\Identifier\Identifier;
 use Roave\BetterReflection\Identifier\IdentifierType;
 use Roave\BetterReflection\Reflection\ReflectionClass;
@@ -32,7 +32,7 @@ class AggregateSourceLocatorTest extends TestCase
     }
 
     /**
-     * @return Reflector|PHPUnit_Framework_MockObject_MockObject
+     * @return Reflector|MockObject
      */
     private function getMockReflector()
     {

--- a/test/unit/SourceLocator/Type/AutoloadSourceLocatorTest.php
+++ b/test/unit/SourceLocator/Type/AutoloadSourceLocatorTest.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Roave\BetterReflectionTest\SourceLocator\Type;
 
 use Foo\Bar\AutoloadableClassWithTwoDirectories;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use PHPUnit_Framework_MockObject_MockObject;
 use ReflectionObject;
 use Roave\BetterReflection\Identifier\Identifier;
 use Roave\BetterReflection\Identifier\IdentifierType;
@@ -51,7 +51,7 @@ class AutoloadSourceLocatorTest extends TestCase
     }
 
     /**
-     * @return Reflector|PHPUnit_Framework_MockObject_MockObject
+     * @return Reflector|MockObject
      */
     private function getMockReflector()
     {

--- a/test/unit/SourceLocator/Type/ComposerSourceLocatorTest.php
+++ b/test/unit/SourceLocator/Type/ComposerSourceLocatorTest.php
@@ -6,8 +6,8 @@ namespace Roave\BetterReflectionTest\SourceLocator\Type;
 
 use ClassWithNoNamespace;
 use Composer\Autoload\ClassLoader;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use PHPUnit_Framework_MockObject_MockObject;
 use Roave\BetterReflection\Identifier\Identifier;
 use Roave\BetterReflection\Identifier\IdentifierType;
 use Roave\BetterReflection\Reflector\Reflector;
@@ -31,7 +31,7 @@ class ComposerSourceLocatorTest extends TestCase
     }
 
     /**
-     * @return Reflector|PHPUnit_Framework_MockObject_MockObject
+     * @return Reflector|MockObject
      */
     private function getMockReflector()
     {

--- a/test/unit/SourceLocator/Type/EvaledCodeSourceLocatorTest.php
+++ b/test/unit/SourceLocator/Type/EvaledCodeSourceLocatorTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Roave\BetterReflectionTest\SourceLocator\Type;
 
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use PHPUnit_Framework_MockObject_MockObject;
 use Roave\BetterReflection\Identifier\Identifier;
 use Roave\BetterReflection\Identifier\IdentifierType;
 use Roave\BetterReflection\Reflection\ReflectionClass;
@@ -40,7 +40,7 @@ class EvaledCodeSourceLocatorTest extends TestCase
     }
 
     /**
-     * @return Reflector|PHPUnit_Framework_MockObject_MockObject
+     * @return Reflector|MockObject
      */
     private function getMockReflector()
     {

--- a/test/unit/SourceLocator/Type/MemoizingSourceLocatorTest.php
+++ b/test/unit/SourceLocator/Type/MemoizingSourceLocatorTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Roave\BetterReflectionTest\SourceLocator\Type;
 
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use PHPUnit_Framework_MockObject_MockObject;
 use Roave\BetterReflection\Identifier\Identifier;
 use Roave\BetterReflection\Identifier\IdentifierType;
 use Roave\BetterReflection\Reflection\Reflection;
@@ -28,13 +28,13 @@ use function uniqid;
  */
 class MemoizingSourceLocatorTest extends TestCase
 {
-    /** @var Reflector|PHPUnit_Framework_MockObject_MockObject */
+    /** @var Reflector|MockObject */
     private $reflector1;
 
-    /** @var Reflector|PHPUnit_Framework_MockObject_MockObject */
+    /** @var Reflector|MockObject */
     private $reflector2;
 
-    /** @var SourceLocator|PHPUnit_Framework_MockObject_MockObject */
+    /** @var SourceLocator|MockObject */
     private $wrappedLocator;
 
     /** @var MemoizingSourceLocator */

--- a/test/unit/SourceLocator/Type/PhpInternalSourceLocatorTest.php
+++ b/test/unit/SourceLocator/Type/PhpInternalSourceLocatorTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Roave\BetterReflectionTest\SourceLocator\Type;
 
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use PHPUnit_Framework_MockObject_MockObject;
 use ReflectionClass as CoreReflectionClass;
 use ReflectionException;
 use Roave\BetterReflection\Identifier\Identifier;
@@ -44,7 +44,7 @@ class PhpInternalSourceLocatorTest extends TestCase
     }
 
     /**
-     * @return Reflector|PHPUnit_Framework_MockObject_MockObject
+     * @return Reflector|MockObject
      */
     private function getMockReflector()
     {

--- a/test/unit/SourceLocator/Type/SingleFileSourceLocatorTest.php
+++ b/test/unit/SourceLocator/Type/SingleFileSourceLocatorTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Roave\BetterReflectionTest\SourceLocator\Type;
 
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use PHPUnit_Framework_MockObject_MockObject;
 use Roave\BetterReflection\Identifier\Identifier;
 use Roave\BetterReflection\Identifier\IdentifierType;
 use Roave\BetterReflection\Reflector\Reflector;
@@ -29,7 +29,7 @@ class SingleFileSourceLocatorTest extends TestCase
     }
 
     /**
-     * @return Reflector|PHPUnit_Framework_MockObject_MockObject
+     * @return Reflector|MockObject
      */
     private function getMockReflector()
     {

--- a/test/unit/SourceLocator/Type/StringSourceLocatorTest.php
+++ b/test/unit/SourceLocator/Type/StringSourceLocatorTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Roave\BetterReflectionTest\SourceLocator\Type;
 
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use PHPUnit_Framework_MockObject_MockObject;
 use Roave\BetterReflection\Identifier\Identifier;
 use Roave\BetterReflection\Identifier\IdentifierType;
 use Roave\BetterReflection\Reflector\Reflector;
@@ -30,7 +30,7 @@ class StringSourceLocatorTest extends TestCase
     }
 
     /**
-     * @return Reflector|PHPUnit_Framework_MockObject_MockObject
+     * @return Reflector|MockObject
      */
     private function getMockReflector()
     {

--- a/test/unit/TypesFinder/FindParameterTypeTest.php
+++ b/test/unit/TypesFinder/FindParameterTypeTest.php
@@ -13,8 +13,8 @@ use PhpParser\Node\Name;
 use PhpParser\Node\Param as ParamNode;
 use PhpParser\Node\Stmt\Namespace_;
 use PhpParser\Node\Stmt\Use_ as UseStatement;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use PHPUnit_Framework_MockObject_MockObject;
 use Roave\BetterReflection\Reflection\ReflectionFunction;
 use Roave\BetterReflection\Reflection\ReflectionFunctionAbstract;
 use Roave\BetterReflection\Reflector\ClassReflector;
@@ -82,7 +82,7 @@ class FindParameterTypeTest extends TestCase
         $node     = new ParamNode(new Variable($nodeName));
         $docBlock = sprintf("/**\n * %s\n */", $docBlock);
 
-        /** @var ReflectionFunctionAbstract|PHPUnit_Framework_MockObject_MockObject $function */
+        /** @var ReflectionFunctionAbstract|MockObject $function */
         $function = $this->createMock(ReflectionFunction::class);
 
         $function
@@ -109,7 +109,7 @@ class FindParameterTypeTest extends TestCase
         $node     = new ParamNode(new Variable($nodeName));
         $docBlock = sprintf("/**\n * %s\n */", $docBlock);
 
-        /** @var ReflectionFunctionAbstract|PHPUnit_Framework_MockObject_MockObject $method */
+        /** @var ReflectionFunctionAbstract|MockObject $method */
         $method = $this->createMock(ReflectionFunctionAbstract::class);
 
         $method
@@ -130,7 +130,7 @@ class FindParameterTypeTest extends TestCase
     {
         $node = new ParamNode(new Variable('foo'));
 
-        /** @var ReflectionFunctionAbstract|PHPUnit_Framework_MockObject_MockObject $function */
+        /** @var ReflectionFunctionAbstract|MockObject $function */
         $function = $this->createMock(ReflectionFunctionAbstract::class);
 
         $function
@@ -157,7 +157,7 @@ class FindParameterTypeTest extends TestCase
 
         $parameterNode = new ParamNode(new Variable('foo'));
 
-        /** @var ReflectionFunctionAbstract|PHPUnit_Framework_MockObject_MockObject $function */
+        /** @var ReflectionFunctionAbstract|MockObject $function */
         $function = $this->createMock(ReflectionFunctionAbstract::class);
 
         $function

--- a/test/unit/TypesFinder/FindPropertyTypeTest.php
+++ b/test/unit/TypesFinder/FindPropertyTypeTest.php
@@ -11,8 +11,8 @@ use PhpParser\Builder\Use_;
 use PhpParser\Node\Name;
 use PhpParser\Node\Stmt\Namespace_;
 use PhpParser\Node\Stmt\Use_ as UseStatement;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use PHPUnit_Framework_MockObject_MockObject;
 use Roave\BetterReflection\Reflection\ReflectionProperty;
 use Roave\BetterReflection\Reflector\ClassReflector;
 use Roave\BetterReflection\SourceLocator\Type\StringSourceLocator;
@@ -47,7 +47,7 @@ class FindPropertyTypeTest extends TestCase
      */
     public function testFindPropertyType(string $docBlock, array $expectedInstances) : void
     {
-        /** @var ReflectionProperty|PHPUnit_Framework_MockObject_MockObject $property */
+        /** @var ReflectionProperty|MockObject $property */
         $property = $this->createMock(ReflectionProperty::class);
 
         $property->expects($this->any())->method('getDocComment')
@@ -87,7 +87,7 @@ class FindPropertyTypeTest extends TestCase
 
     public function testFindPropertyTypeReturnsEmptyArrayWhenNoCommentsNodesFound() : void
     {
-        /** @var ReflectionProperty|PHPUnit_Framework_MockObject_MockObject $property */
+        /** @var ReflectionProperty|MockObject $property */
         $property = $this->createMock(ReflectionProperty::class);
 
         $property->expects($this->any())->method('getDocComment')
@@ -100,7 +100,7 @@ class FindPropertyTypeTest extends TestCase
 
     public function testFindPropertyTypeReturnsEmptyArrayWhenNoDocBlockIsPresent() : void
     {
-        /** @var ReflectionProperty|PHPUnit_Framework_MockObject_MockObject $property */
+        /** @var ReflectionProperty|MockObject $property */
         $property = $this->createMock(ReflectionProperty::class);
 
         $property->expects(self::once())->method('getDocComment')
@@ -125,7 +125,7 @@ class FindPropertyTypeTest extends TestCase
     ) : void {
         $docBlock = sprintf("/**\n * @var %s\n */", $docBlockType);
 
-        /** @var ReflectionProperty|PHPUnit_Framework_MockObject_MockObject $property */
+        /** @var ReflectionProperty|MockObject $property */
         $property = $this->createMock(ReflectionProperty::class);
 
         $property

--- a/test/unit/TypesFinder/FindReturnTypeTest.php
+++ b/test/unit/TypesFinder/FindReturnTypeTest.php
@@ -11,8 +11,8 @@ use PhpParser\Builder\Use_;
 use PhpParser\Node\Name;
 use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\Namespace_;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use PHPUnit_Framework_MockObject_MockObject;
 use Roave\BetterReflection\Reflection\ReflectionFunction;
 use Roave\BetterReflection\Reflection\ReflectionFunctionAbstract;
 use Roave\BetterReflection\Reflection\ReflectionMethod;
@@ -49,7 +49,7 @@ class FindReturnTypeTest extends TestCase
     {
         $docBlock = sprintf("/**\n * %s\n */", $docBlock);
 
-        /** @var ReflectionMethod|PHPUnit_Framework_MockObject_MockObject $function */
+        /** @var ReflectionMethod|MockObject $function */
         $function = $this->createMock(ReflectionFunction::class);
 
         $function
@@ -75,7 +75,7 @@ class FindReturnTypeTest extends TestCase
     {
         $docBlock = sprintf("/**\n * %s\n */", $docBlock);
 
-        /** @var ReflectionMethod|PHPUnit_Framework_MockObject_MockObject $method */
+        /** @var ReflectionMethod|MockObject $method */
         $method = $this->createMock(ReflectionMethod::class);
 
         $method
@@ -94,7 +94,7 @@ class FindReturnTypeTest extends TestCase
 
     public function testFindReturnTypeForFunctionWithNoDocBlock() : void
     {
-        /** @var ReflectionFunction|PHPUnit_Framework_MockObject_MockObject $function */
+        /** @var ReflectionFunction|MockObject $function */
         $function = $this->createMock(ReflectionFunction::class);
 
         $function
@@ -119,7 +119,7 @@ class FindReturnTypeTest extends TestCase
     ) : void {
         $docBlock = sprintf("/**\n * @return %s\n */", $returnType);
 
-        /** @var ReflectionFunctionAbstract|PHPUnit_Framework_MockObject_MockObject $function */
+        /** @var ReflectionFunctionAbstract|MockObject $function */
         $function = $this->createMock(ReflectionFunctionAbstract::class);
 
         $function

--- a/test/unit/Util/Autoload/ClassLoaderMethod/FileCacheLoaderTest.php
+++ b/test/unit/Util/Autoload/ClassLoaderMethod/FileCacheLoaderTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Roave\BetterReflectionTest\Util\Autoload\ClassLoaderMethod;
 
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use PHPUnit_Framework_MockObject_MockObject;
 use Roave\BetterReflection\Reflection\ReflectionClass;
 use Roave\BetterReflection\Util\Autoload\ClassLoaderMethod\Exception\SignatureCheckFailed;
 use Roave\BetterReflection\Util\Autoload\ClassLoaderMethod\FileCacheLoader;
@@ -27,7 +27,7 @@ final class FileCacheLoaderTest extends TestCase
         $className         = uniqid(__METHOD__, true);
         $generatedFilename = __DIR__ . '/' . sha1($className);
 
-        /** @var ReflectionClass|PHPUnit_Framework_MockObject_MockObject $classInfo */
+        /** @var ReflectionClass|MockObject $classInfo */
         $classInfo = $this->createMock(ReflectionClass::class);
         $classInfo->expects(self::exactly(2))->method('getName')->willReturn($className);
 
@@ -35,15 +35,15 @@ final class FileCacheLoaderTest extends TestCase
         $signature     = uniqid('Roave/Signature: ', true);
         $signedCode    = "<?php\n// " . $signature . "\n" . $generatedCode;
 
-        /** @var ClassPrinterInterface|PHPUnit_Framework_MockObject_MockObject $printer */
+        /** @var ClassPrinterInterface|MockObject $printer */
         $printer = $this->createMock(ClassPrinterInterface::class);
         $printer->expects(self::once())->method('__invoke')->with($classInfo)->willReturn($generatedCode);
 
-        /** @var SignerInterface|PHPUnit_Framework_MockObject_MockObject $signer */
+        /** @var SignerInterface|MockObject $signer */
         $signer = $this->createMock(SignerInterface::class);
         $signer->expects(self::once())->method('sign')->with("<?php\n" . $generatedCode)->willReturn($signature);
 
-        /** @var CheckerInterface|PHPUnit_Framework_MockObject_MockObject $checker */
+        /** @var CheckerInterface|MockObject $checker */
         $checker = $this->createMock(CheckerInterface::class);
         $checker->expects(self::exactly(2))->method('check')->with($signedCode)->willReturn(true);
 
@@ -61,7 +61,7 @@ final class FileCacheLoaderTest extends TestCase
         $className         = uniqid(__METHOD__, true);
         $generatedFilename = __DIR__ . '/' . sha1($className);
 
-        /** @var ReflectionClass|PHPUnit_Framework_MockObject_MockObject $classInfo */
+        /** @var ReflectionClass|MockObject $classInfo */
         $classInfo = $this->createMock(ReflectionClass::class);
         $classInfo->expects(self::exactly(2))->method('getName')->willReturn($className);
 
@@ -69,15 +69,15 @@ final class FileCacheLoaderTest extends TestCase
         $signature     = uniqid('Roave/Signature: ', true);
         $signedCode    = "<?php\n// " . $signature . "\n" . $generatedCode;
 
-        /** @var ClassPrinterInterface|PHPUnit_Framework_MockObject_MockObject $printer */
+        /** @var ClassPrinterInterface|MockObject $printer */
         $printer = $this->createMock(ClassPrinterInterface::class);
         $printer->expects(self::once())->method('__invoke')->with($classInfo)->willReturn($generatedCode);
 
-        /** @var SignerInterface|PHPUnit_Framework_MockObject_MockObject $signer */
+        /** @var SignerInterface|MockObject $signer */
         $signer = $this->createMock(SignerInterface::class);
         $signer->expects(self::once())->method('sign')->with("<?php\n" . $generatedCode)->willReturn($signature);
 
-        /** @var CheckerInterface|PHPUnit_Framework_MockObject_MockObject $checker */
+        /** @var CheckerInterface|MockObject $checker */
         $checker = $this->createMock(CheckerInterface::class);
         $checker->expects(self::once())->method('check')->with($signedCode)->willReturn(false);
 

--- a/test/unit/Util/Autoload/ClassLoaderTest.php
+++ b/test/unit/Util/Autoload/ClassLoaderTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Roave\BetterReflectionTest\Util\Autoload;
 
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use PHPUnit_Framework_MockObject_MockObject;
 use Roave\BetterReflection\Reflection\ReflectionClass;
 use Roave\BetterReflection\Util\Autoload\ClassLoader;
 use Roave\BetterReflection\Util\Autoload\ClassLoaderMethod\LoaderMethodInterface;
@@ -30,7 +30,7 @@ final class ClassLoaderTest extends TestCase
     {
         $initialAutoloaderCount = count(spl_autoload_functions());
 
-        /** @var LoaderMethodInterface|PHPUnit_Framework_MockObject_MockObject $loaderMethod */
+        /** @var LoaderMethodInterface|MockObject $loaderMethod */
         $loaderMethod = $this->createMock(LoaderMethodInterface::class);
         $loader       = new ClassLoader($loaderMethod);
 
@@ -46,7 +46,7 @@ final class ClassLoaderTest extends TestCase
         $reflection = ReflectionClass::createFromName(TestClassForAutoloader::class);
         self::assertFalse(class_exists(TestClassForAutoloader::class, false));
 
-        /** @var LoaderMethodInterface|PHPUnit_Framework_MockObject_MockObject $loaderMethod */
+        /** @var LoaderMethodInterface|MockObject $loaderMethod */
         $loaderMethod = $this->createMock(LoaderMethodInterface::class);
         $loaderMethod->expects(self::once())
             ->method('__invoke')
@@ -67,7 +67,7 @@ final class ClassLoaderTest extends TestCase
     {
         $reflection = ReflectionClass::createFromName(AnotherTestClassForAutoloader::class);
 
-        /** @var LoaderMethodInterface|PHPUnit_Framework_MockObject_MockObject $loaderMethod */
+        /** @var LoaderMethodInterface|MockObject $loaderMethod */
         $loaderMethod = $this->createMock(LoaderMethodInterface::class);
         $loader       = new ClassLoader($loaderMethod);
 
@@ -81,7 +81,7 @@ final class ClassLoaderTest extends TestCase
 
     public function testAddClassThrowsExceptionWhenClassAlreadyLoaded() : void
     {
-        /** @var LoaderMethodInterface|PHPUnit_Framework_MockObject_MockObject $loaderMethod */
+        /** @var LoaderMethodInterface|MockObject $loaderMethod */
         $loaderMethod = $this->createMock(LoaderMethodInterface::class);
         $loader       = new ClassLoader($loaderMethod);
 
@@ -100,7 +100,7 @@ final class ClassLoaderTest extends TestCase
         $reflection = ReflectionClass::createFromName(AnotherTestClassForAutoloader::class);
         self::assertFalse(class_exists(AnotherTestClassForAutoloader::class, false));
 
-        /** @var LoaderMethodInterface|PHPUnit_Framework_MockObject_MockObject $loaderMethod */
+        /** @var LoaderMethodInterface|MockObject $loaderMethod */
         $loaderMethod = $this->createMock(LoaderMethodInterface::class);
         $loaderMethod->expects(self::once())
             ->method('__invoke')

--- a/test/unit/Util/Autoload/Exception/ClassAlreadyLoadedTest.php
+++ b/test/unit/Util/Autoload/Exception/ClassAlreadyLoadedTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Roave\BetterReflectionTest\Util\Autoload\Exception;
 
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use PHPUnit_Framework_MockObject_MockObject;
 use Roave\BetterReflection\Reflection\ReflectionClass;
 use Roave\BetterReflection\Util\Autoload\Exception\ClassAlreadyLoaded;
 use function sprintf;
@@ -20,7 +20,7 @@ final class ClassAlreadyLoadedTest extends TestCase
     {
         $className = uniqid('class name', true);
 
-        /** @var ReflectionClass|PHPUnit_Framework_MockObject_MockObject $reflection */
+        /** @var ReflectionClass|MockObject $reflection */
         $reflection = $this->createMock(ReflectionClass::class);
         $reflection->expects(self::any())->method('getName')->willReturn($className);
 

--- a/test/unit/Util/Autoload/Exception/ClassAlreadyRegisteredTest.php
+++ b/test/unit/Util/Autoload/Exception/ClassAlreadyRegisteredTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Roave\BetterReflectionTest\Util\Autoload\Exception;
 
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use PHPUnit_Framework_MockObject_MockObject;
 use Roave\BetterReflection\Reflection\ReflectionClass;
 use Roave\BetterReflection\Util\Autoload\Exception\ClassAlreadyRegistered;
 use function sprintf;
@@ -20,7 +20,7 @@ final class ClassAlreadyRegisteredTest extends TestCase
     {
         $className = uniqid('class name', true);
 
-        /** @var ReflectionClass|PHPUnit_Framework_MockObject_MockObject $reflection */
+        /** @var ReflectionClass|MockObject $reflection */
         $reflection = $this->createMock(ReflectionClass::class);
         $reflection->expects(self::any())->method('getName')->willReturn($className);
 


### PR DESCRIPTION
Broken since https://github.com/Roave/BetterReflection/commit/b9a4c135809d1295325e3e819b18414f42ac793e