### PR TITLE
Fix behaviour of ReflectionClass::export/ReflectionObject::export to match behaviour of core classes

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -3,6 +3,22 @@
 This document serves as a reference to upgrade your current BetterReflection installation if improvements, deprecations
 or backwards compatibility (BC) breakages occur.
 
+## 4.0.0
+
+### BC Breaks
+
+* The following classes no longer implement `\Reflector`. If you need something that implements `\Reflector`, you should
+  wrap the BetterReflection in the appropriate `\Roave\BetterReflection\Reflection\Adapter\*` class.
+  * `\Roave\BetterReflection\Reflection\ReflectionClass`
+  * `\Roave\BetterReflection\Reflection\ReflectionClassConstant`
+  * `\Roave\BetterReflection\Reflection\ReflectionConstant`
+  * `\Roave\BetterReflection\Reflection\ReflectionFunctionAbstract`
+  * `\Roave\BetterReflection\Reflection\ReflectionFunction`
+  * `\Roave\BetterReflection\Reflection\ReflectionMethod`
+  * `\Roave\BetterReflection\Reflection\ReflectionObject`
+  * `\Roave\BetterReflection\Reflection\ReflectionParameter`
+  * `\Roave\BetterReflection\Reflection\ReflectionProperty`
+
 ## 3.0.0
 
 ### BC breaks

--- a/src/Reflection/Adapter/ReflectionClass.php
+++ b/src/Reflection/Adapter/ReflectionClass.php
@@ -4,16 +4,18 @@ declare(strict_types=1);
 
 namespace Roave\BetterReflection\Reflection\Adapter;
 
+use InvalidArgumentException;
 use OutOfBoundsException;
 use ReflectionClass as CoreReflectionClass;
 use ReflectionException as CoreReflectionException;
 use Roave\BetterReflection\Reflection\ReflectionClass as BetterReflectionClass;
 use Roave\BetterReflection\Reflection\ReflectionClassConstant as BetterReflectionClassConstant;
 use Roave\BetterReflection\Reflection\ReflectionMethod as BetterReflectionMethod;
+use Roave\BetterReflection\Reflection\ReflectionObject as BetterReflectionObject;
 use function array_combine;
 use function array_map;
-use function func_get_args;
 use function func_num_args;
+use Roave\BetterReflection\Reflection\ReflectionObject;
 use function sprintf;
 use function strtolower;
 
@@ -29,10 +31,26 @@ class ReflectionClass extends CoreReflectionClass
 
     /**
      * {@inheritDoc}
+     * @throws CoreReflectionException
      */
     public static function export($argument, $return = false)
     {
-        return BetterReflectionClass::export(...func_get_args());
+        if (is_string($argument) || is_object($argument)) {
+            if (is_string($argument)) {
+                $output = BetterReflectionClass::createFromName($argument)->__toString();
+            } else {
+                $output = BetterReflectionObject::createFromInstance($argument)->__toString();
+            }
+
+            if ($return) {
+                return $output;
+            }
+
+            echo $output;
+            return null;
+        }
+
+        throw new InvalidArgumentException('Class name must be provided');
     }
 
     /**

--- a/src/Reflection/Adapter/ReflectionClass.php
+++ b/src/Reflection/Adapter/ReflectionClass.php
@@ -15,7 +15,8 @@ use Roave\BetterReflection\Reflection\ReflectionObject as BetterReflectionObject
 use function array_combine;
 use function array_map;
 use function func_num_args;
-use Roave\BetterReflection\Reflection\ReflectionObject;
+use function is_object;
+use function is_string;
 use function sprintf;
 use function strtolower;
 
@@ -31,6 +32,7 @@ class ReflectionClass extends CoreReflectionClass
 
     /**
      * {@inheritDoc}
+     *
      * @throws CoreReflectionException
      */
     public static function export($argument, $return = false)
@@ -47,6 +49,7 @@ class ReflectionClass extends CoreReflectionClass
             }
 
             echo $output;
+
             return null;
         }
 

--- a/src/Reflection/Adapter/ReflectionFunction.php
+++ b/src/Reflection/Adapter/ReflectionFunction.php
@@ -24,6 +24,7 @@ class ReflectionFunction extends CoreReflectionFunction
 
     /**
      * {@inheritDoc}
+     *
      * @throws Exception
      */
     public static function export($name, $return = null)

--- a/src/Reflection/Adapter/ReflectionFunction.php
+++ b/src/Reflection/Adapter/ReflectionFunction.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace Roave\BetterReflection\Reflection\Adapter;
 
+use Exception;
 use ReflectionException as CoreReflectionException;
 use ReflectionFunction as CoreReflectionFunction;
+use Roave\BetterReflection\Reflection\Adapter\Exception\NotImplemented;
 use Roave\BetterReflection\Reflection\ReflectionFunction as BetterReflectionFunction;
 use Throwable;
 use function func_get_args;
@@ -22,10 +24,11 @@ class ReflectionFunction extends CoreReflectionFunction
 
     /**
      * {@inheritDoc}
+     * @throws Exception
      */
     public static function export($name, $return = null)
     {
-        BetterReflectionFunction::export(...func_get_args());
+        throw new Exception('Unable to export statically');
     }
 
     /**
@@ -81,7 +84,7 @@ class ReflectionFunction extends CoreReflectionFunction
      */
     public function getClosureThis()
     {
-        throw new Exception\NotImplemented('Not implemented');
+        throw new NotImplemented('Not implemented');
     }
 
     /**
@@ -89,7 +92,7 @@ class ReflectionFunction extends CoreReflectionFunction
      */
     public function getClosureScopeClass()
     {
-        throw new Exception\NotImplemented('Not implemented');
+        throw new NotImplemented('Not implemented');
     }
 
     /**
@@ -113,7 +116,7 @@ class ReflectionFunction extends CoreReflectionFunction
      */
     public function getExtension()
     {
-        throw new Exception\NotImplemented('Not implemented');
+        throw new NotImplemented('Not implemented');
     }
 
     /**
@@ -208,7 +211,7 @@ class ReflectionFunction extends CoreReflectionFunction
      */
     public function getStaticVariables()
     {
-        throw new Exception\NotImplemented('Not implemented');
+        throw new NotImplemented('Not implemented');
     }
 
     /**

--- a/src/Reflection/Adapter/ReflectionMethod.php
+++ b/src/Reflection/Adapter/ReflectionMethod.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace Roave\BetterReflection\Reflection\Adapter;
 
+use Exception;
 use ReflectionException as CoreReflectionException;
 use ReflectionMethod as CoreReflectionMethod;
+use Roave\BetterReflection\Reflection\Adapter\Exception\NotImplemented;
 use Roave\BetterReflection\Reflection\Exception\NoObjectProvided;
 use Roave\BetterReflection\Reflection\Exception\NotAnObject;
 use Roave\BetterReflection\Reflection\ReflectionMethod as BetterReflectionMethod;
@@ -27,10 +29,11 @@ class ReflectionMethod extends CoreReflectionMethod
 
     /**
      * {@inheritDoc}
+     * @throws Exception
      */
     public static function export($class, $name, $return = null)
     {
-        BetterReflectionMethod::export(...func_get_args());
+        throw new Exception('Unable to export statically');
     }
 
     /**
@@ -86,7 +89,7 @@ class ReflectionMethod extends CoreReflectionMethod
      */
     public function getClosureThis()
     {
-        throw new Exception\NotImplemented('Not implemented');
+        throw new NotImplemented('Not implemented');
     }
 
     /**
@@ -94,7 +97,7 @@ class ReflectionMethod extends CoreReflectionMethod
      */
     public function getClosureScopeClass()
     {
-        throw new Exception\NotImplemented('Not implemented');
+        throw new NotImplemented('Not implemented');
     }
 
     /**
@@ -118,7 +121,7 @@ class ReflectionMethod extends CoreReflectionMethod
      */
     public function getExtension()
     {
-        throw new Exception\NotImplemented('Not implemented');
+        throw new NotImplemented('Not implemented');
     }
 
     /**
@@ -213,7 +216,7 @@ class ReflectionMethod extends CoreReflectionMethod
      */
     public function getStaticVariables()
     {
-        throw new Exception\NotImplemented('Not implemented');
+        throw new NotImplemented('Not implemented');
     }
 
     /**

--- a/src/Reflection/Adapter/ReflectionMethod.php
+++ b/src/Reflection/Adapter/ReflectionMethod.php
@@ -29,6 +29,7 @@ class ReflectionMethod extends CoreReflectionMethod
 
     /**
      * {@inheritDoc}
+     *
      * @throws Exception
      */
     public static function export($class, $name, $return = null)

--- a/src/Reflection/Adapter/ReflectionObject.php
+++ b/src/Reflection/Adapter/ReflectionObject.php
@@ -10,7 +10,6 @@ use Roave\BetterReflection\Reflection\ReflectionMethod as BetterReflectionMethod
 use Roave\BetterReflection\Reflection\ReflectionObject as BetterReflectionObject;
 use function array_combine;
 use function array_map;
-use function func_get_args;
 use function func_num_args;
 use function sprintf;
 use function strtolower;
@@ -27,10 +26,18 @@ class ReflectionObject extends CoreReflectionObject
 
     /**
      * {@inheritDoc}
+     * @throws CoreReflectionException
      */
     public static function export($argument, $return = null)
     {
-        return BetterReflectionObject::export(...func_get_args());
+        $output = BetterReflectionObject::createFromInstance($argument)->__toString();
+
+        if ($return) {
+            return $output;
+        }
+
+        echo $output;
+        return null;
     }
 
     /**

--- a/src/Reflection/Adapter/ReflectionObject.php
+++ b/src/Reflection/Adapter/ReflectionObject.php
@@ -26,6 +26,7 @@ class ReflectionObject extends CoreReflectionObject
 
     /**
      * {@inheritDoc}
+     *
      * @throws CoreReflectionException
      */
     public static function export($argument, $return = null)
@@ -37,6 +38,7 @@ class ReflectionObject extends CoreReflectionObject
         }
 
         echo $output;
+
         return null;
     }
 

--- a/src/Reflection/Adapter/ReflectionParameter.php
+++ b/src/Reflection/Adapter/ReflectionParameter.php
@@ -8,7 +8,6 @@ use Exception;
 use ReflectionParameter as CoreReflectionParameter;
 use Roave\BetterReflection\Reflection\ReflectionMethod as BetterReflectionMethod;
 use Roave\BetterReflection\Reflection\ReflectionParameter as BetterReflectionParameter;
-use function func_get_args;
 
 class ReflectionParameter extends CoreReflectionParameter
 {
@@ -22,6 +21,7 @@ class ReflectionParameter extends CoreReflectionParameter
 
     /**
      * {@inheritDoc}
+     *
      * @throws Exception
      */
     public static function export($function, $parameter, $return = null)

--- a/src/Reflection/Adapter/ReflectionParameter.php
+++ b/src/Reflection/Adapter/ReflectionParameter.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Roave\BetterReflection\Reflection\Adapter;
 
+use Exception;
 use ReflectionParameter as CoreReflectionParameter;
 use Roave\BetterReflection\Reflection\ReflectionMethod as BetterReflectionMethod;
 use Roave\BetterReflection\Reflection\ReflectionParameter as BetterReflectionParameter;
@@ -21,10 +22,11 @@ class ReflectionParameter extends CoreReflectionParameter
 
     /**
      * {@inheritDoc}
+     * @throws Exception
      */
     public static function export($function, $parameter, $return = null)
     {
-        BetterReflectionParameter::export(...func_get_args());
+        throw new Exception('Unable to export statically');
     }
 
     /**

--- a/src/Reflection/Adapter/ReflectionProperty.php
+++ b/src/Reflection/Adapter/ReflectionProperty.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Roave\BetterReflection\Reflection\Adapter;
 
+use Exception;
 use ReflectionException as CoreReflectionException;
 use ReflectionProperty as CoreReflectionProperty;
 use Roave\BetterReflection\Reflection\Exception\NoObjectProvided;
@@ -27,10 +28,11 @@ class ReflectionProperty extends CoreReflectionProperty
 
     /**
      * {@inheritDoc}
+     * @throws Exception
      */
     public static function export($class, $name, $return = null)
     {
-        BetterReflectionProperty::export(...func_get_args());
+        throw new Exception('Unable to export statically');
     }
 
     /**

--- a/src/Reflection/Adapter/ReflectionProperty.php
+++ b/src/Reflection/Adapter/ReflectionProperty.php
@@ -11,7 +11,6 @@ use Roave\BetterReflection\Reflection\Exception\NoObjectProvided;
 use Roave\BetterReflection\Reflection\Exception\NotAnObject;
 use Roave\BetterReflection\Reflection\ReflectionProperty as BetterReflectionProperty;
 use Throwable;
-use function func_get_args;
 
 class ReflectionProperty extends CoreReflectionProperty
 {
@@ -28,6 +27,7 @@ class ReflectionProperty extends CoreReflectionProperty
 
     /**
      * {@inheritDoc}
+     *
      * @throws Exception
      */
     public static function export($class, $name, $return = null)

--- a/src/Reflection/ReflectionClass.php
+++ b/src/Reflection/ReflectionClass.php
@@ -20,7 +20,6 @@ use PhpParser\Node\Stmt\TraitUse;
 use ReflectionClass as CoreReflectionClass;
 use ReflectionException;
 use ReflectionProperty as CoreReflectionProperty;
-use Reflector as CoreReflector;
 use Roave\BetterReflection\BetterReflection;
 use Roave\BetterReflection\Reflection\Exception\ClassDoesNotExist;
 use Roave\BetterReflection\Reflection\Exception\NoObjectProvided;
@@ -47,13 +46,12 @@ use function array_values;
 use function implode;
 use function in_array;
 use function is_object;
-use function is_string;
 use function ltrim;
 use function sha1;
 use function sprintf;
 use function strtolower;
 
-class ReflectionClass implements Reflection, CoreReflector
+class ReflectionClass implements Reflection
 {
     public const ANONYMOUS_CLASS_NAME_PREFIX = 'class@anonymous';
 
@@ -83,31 +81,6 @@ class ReflectionClass implements Reflection, CoreReflector
 
     private function __construct()
     {
-    }
-
-    /**
-     * Create a reflection and return the string representation of a named class
-     *
-     * @param string|object $argument
-     */
-    public static function export($argument, bool $return = false) : ?string
-    {
-        if (is_string($argument) || is_object($argument)) {
-            if (is_string($argument)) {
-                $output = self::createFromName($argument)->__toString();
-            } else {
-                $output = ReflectionObject::createFromInstance($argument)->__toString();
-            }
-
-            if ($return) {
-                return $output;
-            }
-
-            echo $output;
-            return null;
-        }
-
-        throw new InvalidArgumentException('Class name must be provided');
     }
 
     public function __toString() : string

--- a/src/Reflection/ReflectionClass.php
+++ b/src/Reflection/ReflectionClass.php
@@ -47,6 +47,7 @@ use function array_values;
 use function implode;
 use function in_array;
 use function is_object;
+use function is_string;
 use function ltrim;
 use function sha1;
 use function sprintf;
@@ -86,6 +87,8 @@ class ReflectionClass implements Reflection, CoreReflector
 
     /**
      * Create a reflection and return the string representation of a named class
+     *
+     * @param string|object $argument
      */
     public static function export($argument, bool $return = false) : ?string
     {

--- a/src/Reflection/ReflectionClass.php
+++ b/src/Reflection/ReflectionClass.php
@@ -87,13 +87,24 @@ class ReflectionClass implements Reflection, CoreReflector
     /**
      * Create a reflection and return the string representation of a named class
      */
-    public static function export(?string $className) : string
+    public static function export($argument, bool $return = false) : ?string
     {
-        if ($className === null) {
-            throw new InvalidArgumentException('Class name must be provided');
+        if (is_string($argument) || is_object($argument)) {
+            if (is_string($argument)) {
+                $output = self::createFromName($argument)->__toString();
+            } else {
+                $output = ReflectionObject::createFromInstance($argument)->__toString();
+            }
+
+            if ($return) {
+                return $output;
+            }
+
+            echo $output;
+            return null;
         }
 
-        return self::createFromName($className)->__toString();
+        throw new InvalidArgumentException('Class name must be provided');
     }
 
     public function __toString() : string

--- a/src/Reflection/ReflectionClassConstant.php
+++ b/src/Reflection/ReflectionClassConstant.php
@@ -4,10 +4,8 @@ declare(strict_types=1);
 
 namespace Roave\BetterReflection\Reflection;
 
-use Exception;
 use PhpParser\Node\Stmt\ClassConst;
 use ReflectionProperty;
-use Reflector as CoreReflector;
 use Roave\BetterReflection\NodeCompiler\CompileNodeToValue;
 use Roave\BetterReflection\NodeCompiler\CompilerContext;
 use Roave\BetterReflection\Reflection\StringCast\ReflectionClassConstantStringCast;
@@ -15,7 +13,7 @@ use Roave\BetterReflection\Reflector\Reflector;
 use Roave\BetterReflection\Util\CalculateReflectionColum;
 use Roave\BetterReflection\Util\GetFirstDocComment;
 
-class ReflectionClassConstant implements CoreReflector
+class ReflectionClassConstant
 {
     /** @var bool */
     private $valueWasCached = false;
@@ -175,11 +173,6 @@ class ReflectionClassConstant implements CoreReflector
     public function __toString() : string
     {
         return ReflectionClassConstantStringCast::toString($this);
-    }
-
-    public static function export() : void
-    {
-        throw new Exception('Unable to export statically');
     }
 
     public function getAst() : ClassConst

--- a/src/Reflection/ReflectionConstant.php
+++ b/src/Reflection/ReflectionConstant.php
@@ -4,10 +4,8 @@ declare(strict_types=1);
 
 namespace Roave\BetterReflection\Reflection;
 
-use Exception;
 use PhpParser\Node;
 use PhpParser\Node\Stmt\Namespace_ as NamespaceNode;
-use Reflector as CoreReflector;
 use Roave\BetterReflection\BetterReflection;
 use Roave\BetterReflection\NodeCompiler\CompileNodeToValue;
 use Roave\BetterReflection\NodeCompiler\CompilerContext;
@@ -25,7 +23,7 @@ use function explode;
 use function implode;
 use function substr_count;
 
-class ReflectionConstant implements Reflection, CoreReflector
+class ReflectionConstant implements Reflection
 {
     /** @var Reflector */
     private $reflector;
@@ -284,11 +282,6 @@ class ReflectionConstant implements Reflection, CoreReflector
     public function __toString() : string
     {
         return ReflectionConstantStringCast::toString($this);
-    }
-
-    public static function export() : void
-    {
-        throw new Exception('Unable to export statically');
     }
 
     /**

--- a/src/Reflection/ReflectionFunctionAbstract.php
+++ b/src/Reflection/ReflectionFunctionAbstract.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Roave\BetterReflection\Reflection;
 
 use Closure;
-use Exception;
 use LogicException;
 use phpDocumentor\Reflection\Type;
 use PhpParser\Comment\Doc;
@@ -18,7 +17,6 @@ use PhpParser\NodeTraverser;
 use PhpParser\Parser;
 use PhpParser\PrettyPrinter\Standard as StandardPrettyPrinter;
 use PhpParser\PrettyPrinterAbstract;
-use Reflector as CoreReflector;
 use Roave\BetterReflection\BetterReflection;
 use Roave\BetterReflection\Identifier\Exception\InvalidIdentifierName;
 use Roave\BetterReflection\Identifier\Identifier;
@@ -40,7 +38,7 @@ use function is_array;
 use function is_string;
 use function strtolower;
 
-abstract class ReflectionFunctionAbstract implements CoreReflector
+abstract class ReflectionFunctionAbstract
 {
     public const CLOSURE_NAME = '{closure}';
 
@@ -61,11 +59,6 @@ abstract class ReflectionFunctionAbstract implements CoreReflector
 
     protected function __construct()
     {
-    }
-
-    public static function export() : void
-    {
-        throw new Exception('Unable to export statically');
     }
 
     /**

--- a/src/Reflection/ReflectionObject.php
+++ b/src/Reflection/ReflectionObject.php
@@ -45,27 +45,6 @@ class ReflectionObject extends ReflectionClass
     }
 
     /**
-     * Create a reflection and return the string representation of a class instance
-     *
-     * @param object $instance
-     *
-     * @throws IdentifierNotFound
-     * @throws ReflectionException
-     * @throws InvalidArgumentException
-     */
-    public static function export($instance, bool $return = false) : ?string
-    {
-        $output = self::createFromInstance($instance)->__toString();
-
-        if ($return) {
-            return $output;
-        }
-
-        echo $output;
-        return null;
-    }
-
-    /**
      * Pass an instance of an object to this method to reflect it
      *
      * @param object $object

--- a/src/Reflection/ReflectionObject.php
+++ b/src/Reflection/ReflectionObject.php
@@ -53,13 +53,16 @@ class ReflectionObject extends ReflectionClass
      * @throws ReflectionException
      * @throws InvalidArgumentException
      */
-    public static function export($instance = null) : string
+    public static function export($instance, bool $return = false) : ?string
     {
-        if ($instance === null) {
-            throw new InvalidArgumentException('Class instance must be provided');
+        $output = self::createFromInstance($instance)->__toString();
+
+        if ($return) {
+            return $output;
         }
 
-        return self::createFromInstance($instance)->__toString();
+        echo $output;
+        return null;
     }
 
     /**

--- a/src/Reflection/ReflectionParameter.php
+++ b/src/Reflection/ReflectionParameter.php
@@ -14,7 +14,6 @@ use PhpParser\Node;
 use PhpParser\Node\NullableType;
 use PhpParser\Node\Param as ParamNode;
 use PhpParser\Node\Stmt\Namespace_;
-use Reflector as CoreReflector;
 use Roave\BetterReflection\NodeCompiler\CompileNodeToValue;
 use Roave\BetterReflection\NodeCompiler\CompilerContext;
 use Roave\BetterReflection\Reflection\Exception\Uncloneable;
@@ -33,7 +32,7 @@ use function is_string;
 use function sprintf;
 use function strtolower;
 
-class ReflectionParameter implements CoreReflector
+class ReflectionParameter
 {
     /** @var ParamNode */
     private $node;
@@ -61,11 +60,6 @@ class ReflectionParameter implements CoreReflector
 
     private function __construct()
     {
-    }
-
-    public static function export() : void
-    {
-        throw new Exception('Unable to export statically');
     }
 
     /**

--- a/src/Reflection/ReflectionProperty.php
+++ b/src/Reflection/ReflectionProperty.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Roave\BetterReflection\Reflection;
 
 use Closure;
-use Exception;
 use InvalidArgumentException;
 use phpDocumentor\Reflection\Type;
 use PhpParser\Node;
@@ -15,7 +14,6 @@ use PhpParser\Node\Stmt\Namespace_;
 use PhpParser\Node\Stmt\Property as PropertyNode;
 use ReflectionException;
 use ReflectionProperty as CoreReflectionProperty;
-use Reflector as CoreReflector;
 use Roave\BetterReflection\NodeCompiler\CompileNodeToValue;
 use Roave\BetterReflection\NodeCompiler\CompilerContext;
 use Roave\BetterReflection\Reflection\Exception\ClassDoesNotExist;
@@ -34,7 +32,7 @@ use function func_num_args;
 use function get_class;
 use function is_object;
 
-class ReflectionProperty implements CoreReflector
+class ReflectionProperty
 {
     /** @var ReflectionClass */
     private $declaringClass;
@@ -59,11 +57,6 @@ class ReflectionProperty implements CoreReflector
 
     private function __construct()
     {
-    }
-
-    public static function export() : void
-    {
-        throw new Exception('Unable to export statically');
     }
 
     /**

--- a/test/unit/Reflection/Adapter/ReflectionClassTest.php
+++ b/test/unit/Reflection/Adapter/ReflectionClassTest.php
@@ -133,7 +133,7 @@ class ReflectionClassTest extends TestCase
 
     public function testExport() : void
     {
-        $exported = ReflectionClassAdapter::export('\stdClass');
+        $exported = ReflectionClassAdapter::export('\stdClass', true);
 
         self::assertIsString($exported);
         self::assertStringContainsString('stdClass', $exported);

--- a/test/unit/Reflection/Adapter/ReflectionObjectTest.php
+++ b/test/unit/Reflection/Adapter/ReflectionObjectTest.php
@@ -128,7 +128,7 @@ class ReflectionObjectTest extends TestCase
 
     public function testExport() : void
     {
-        $exported = ReflectionObjectAdapter::export(new stdClass());
+        $exported = ReflectionObjectAdapter::export(new stdClass(), true);
 
         self::assertIsString($exported);
         self::assertStringContainsString('stdClass', $exported);

--- a/test/unit/Reflection/ReflectionClassTest.php
+++ b/test/unit/Reflection/ReflectionClassTest.php
@@ -1398,30 +1398,12 @@ PHP;
         self::assertSame([], $traitReflection->getInterfaces());
     }
 
-    public function testImplementsReflector() : void
-    {
-        $php = '<?php class Foo {}';
-
-        $reflector = new ClassReflector(new StringSourceLocator($php, $this->astLocator));
-        $classInfo = $reflector->reflect('Foo');
-
-        self::assertInstanceOf(CoreReflector::class, $classInfo);
-    }
-
     public function testToString() : void
     {
         $reflection = ReflectionClass::createFromName(ExampleClass::class);
         self::assertStringMatchesFormat(
             file_get_contents(__DIR__ . '/../Fixture/ExampleClassExport.txt'),
             $reflection->__toString()
-        );
-    }
-
-    public function testExport() : void
-    {
-        self::assertStringMatchesFormat(
-            file_get_contents(__DIR__ . '/../Fixture/ExampleClassExport.txt'),
-            ReflectionClass::export(ExampleClass::class, true)
         );
     }
 

--- a/test/unit/Reflection/ReflectionClassTest.php
+++ b/test/unit/Reflection/ReflectionClassTest.php
@@ -1421,7 +1421,7 @@ PHP;
     {
         self::assertStringMatchesFormat(
             file_get_contents(__DIR__ . '/../Fixture/ExampleClassExport.txt'),
-            ReflectionClass::export(ExampleClass::class)
+            ReflectionClass::export(ExampleClass::class, true)
         );
     }
 

--- a/test/unit/Reflection/ReflectionClassTest.php
+++ b/test/unit/Reflection/ReflectionClassTest.php
@@ -19,7 +19,6 @@ use Reflection as CoreReflection;
 use ReflectionClass as CoreReflectionClass;
 use ReflectionMethod as CoreReflectionMethod;
 use ReflectionProperty as CoreReflectionProperty;
-use Reflector as CoreReflector;
 use Roave\BetterReflection\Reflection\Exception\NotAClassReflection;
 use Roave\BetterReflection\Reflection\Exception\NotAnInterfaceReflection;
 use Roave\BetterReflection\Reflection\Exception\NotAnObject;

--- a/test/unit/Reflection/ReflectionConstantTest.php
+++ b/test/unit/Reflection/ReflectionConstantTest.php
@@ -45,16 +45,6 @@ class ReflectionConstantTest extends TestCase
         $this->sourceStubber  = $configuration->sourceStubber();
     }
 
-    public function testImplementsReflector() : void
-    {
-        $php = '<?php const FOO = 1;';
-
-        $reflector  = new ConstantReflector(new StringSourceLocator($php, $this->astLocator), $this->classReflector);
-        $reflection = $reflector->reflect('FOO');
-
-        self::assertInstanceOf(Reflector::class, $reflection);
-    }
-
     public function testNameMethodsWithNoNamespaceByConst() : void
     {
         $php = '<?php const FOO = 1;';
@@ -308,11 +298,5 @@ class ReflectionConstantTest extends TestCase
 
         self::assertInstanceOf(Node\Expr\FuncCall::class, $ast);
         self::assertSame('FOO', $ast->args[0]->value->value);
-    }
-
-    public function testExportThrowsException() : void
-    {
-        $this->expectException(Throwable::class);
-        ReflectionConstant::export();
     }
 }

--- a/test/unit/Reflection/ReflectionConstantTest.php
+++ b/test/unit/Reflection/ReflectionConstantTest.php
@@ -7,7 +7,6 @@ namespace Roave\BetterReflectionTest\Reflection;
 use PhpParser\BuilderHelpers;
 use PhpParser\Node;
 use PHPUnit\Framework\TestCase;
-use Reflector;
 use Roave\BetterReflection\Reflection\ReflectionConstant;
 use Roave\BetterReflection\Reflector\ClassReflector;
 use Roave\BetterReflection\Reflector\ConstantReflector;
@@ -18,7 +17,6 @@ use Roave\BetterReflection\SourceLocator\Type\PhpInternalSourceLocator;
 use Roave\BetterReflection\SourceLocator\Type\SingleFileSourceLocator;
 use Roave\BetterReflection\SourceLocator\Type\StringSourceLocator;
 use Roave\BetterReflectionTest\BetterReflectionSingleton;
-use Throwable;
 use const E_ALL;
 
 /**

--- a/test/unit/Reflection/ReflectionFunctionAbstractTest.php
+++ b/test/unit/Reflection/ReflectionFunctionAbstractTest.php
@@ -60,12 +60,6 @@ class ReflectionFunctionAbstractTest extends TestCase
         $this->astLocator     = $configuration->astLocator();
     }
 
-    public function testExportThrowsException() : void
-    {
-        $this->expectException(Throwable::class);
-        ReflectionFunctionAbstract::export();
-    }
-
     public function testNameMethodsWithNamespace() : void
     {
         $php = '<?php namespace Foo { function bar() {}}';

--- a/test/unit/Reflection/ReflectionFunctionAbstractTest.php
+++ b/test/unit/Reflection/ReflectionFunctionAbstractTest.php
@@ -30,7 +30,6 @@ use Roave\BetterReflection\SourceLocator\Type\SingleFileSourceLocator;
 use Roave\BetterReflection\SourceLocator\Type\StringSourceLocator;
 use Roave\BetterReflectionTest\BetterReflectionSingleton;
 use stdClass;
-use Throwable;
 use TypeError;
 use function current;
 use function next;

--- a/test/unit/Reflection/ReflectionFunctionTest.php
+++ b/test/unit/Reflection/ReflectionFunctionTest.php
@@ -7,7 +7,6 @@ namespace Roave\BetterReflectionTest\Reflection;
 use Closure;
 use phpDocumentor\Reflection\Types\Boolean;
 use PHPUnit\Framework\TestCase;
-use Reflector;
 use Roave\BetterReflection\Reflection\Adapter\Exception\NotImplemented;
 use Roave\BetterReflection\Reflection\Exception\FunctionDoesNotExist;
 use Roave\BetterReflection\Reflection\ReflectionFunction;

--- a/test/unit/Reflection/ReflectionFunctionTest.php
+++ b/test/unit/Reflection/ReflectionFunctionTest.php
@@ -43,16 +43,6 @@ class ReflectionFunctionTest extends TestCase
         $this->sourceStubber  = $configuration->sourceStubber();
     }
 
-    public function testImplementsReflector() : void
-    {
-        $php = '<?php function foo() {}';
-
-        $reflector    = new FunctionReflector(new StringSourceLocator($php, $this->astLocator), $this->classReflector);
-        $functionInfo = $reflector->reflect('foo');
-
-        self::assertInstanceOf(Reflector::class, $functionInfo);
-    }
-
     public function testNameMethodsWithNoNamespace() : void
     {
         $php = '<?php function foo() {}';

--- a/test/unit/Reflection/ReflectionMethodTest.php
+++ b/test/unit/Reflection/ReflectionMethodTest.php
@@ -15,7 +15,6 @@ use PHPUnit\Framework\TestCase;
 use Reflection;
 use ReflectionClass;
 use ReflectionMethod as CoreReflectionMethod;
-use Reflector;
 use Roave\BetterReflection\Reflection\Exception\ClassDoesNotExist;
 use Roave\BetterReflection\Reflection\Exception\MethodPrototypeNotFound;
 use Roave\BetterReflection\Reflection\Exception\NoObjectProvided;

--- a/test/unit/Reflection/ReflectionMethodTest.php
+++ b/test/unit/Reflection/ReflectionMethodTest.php
@@ -85,14 +85,6 @@ class ReflectionMethodTest extends TestCase
         self::assertSame('add', $method->getName());
     }
 
-    public function testImplementsReflector() : void
-    {
-        $classInfo  = $this->reflector->reflect(Methods::class);
-        $methodInfo = $classInfo->getMethod('publicMethod');
-
-        self::assertInstanceOf(Reflector::class, $methodInfo);
-    }
-
     /**
      * @return array
      */

--- a/test/unit/Reflection/ReflectionObjectTest.php
+++ b/test/unit/Reflection/ReflectionObjectTest.php
@@ -307,7 +307,7 @@ Object of class [ <user> class Roave\BetterReflectionTest\Fixture\ClassForHintin
   }
 }
 BLAH;
-        $actualExport   = ReflectionObject::export($foo);
+        $actualExport   = ReflectionObject::export($foo, true);
 
         self::assertStringMatchesFormat($expectedExport, $actualExport);
     }

--- a/test/unit/Reflection/ReflectionObjectTest.php
+++ b/test/unit/Reflection/ReflectionObjectTest.php
@@ -277,41 +277,6 @@ class ReflectionObjectTest extends TestCase
         $reflectionObject->{$methodName}(...$fakeParams);
     }
 
-    public function testReflectionObjectExportMatchesExpectation() : void
-    {
-        $foo      = new ClassForHinting();
-        $foo->bar = 'huzzah';
-
-        $expectedExport = <<<'BLAH'
-Object of class [ <user> class Roave\BetterReflectionTest\Fixture\ClassForHinting ] {
-  @@ %s
-
-  - Constants [0] {
-  }
-
-  - Static properties [0] {
-  }
-
-  - Static methods [0] {
-  }
-
-  - Properties [1] {
-    Property [ <default> public $someProperty ]
-  }
-
-  - Dynamic properties [1] {
-    Property [ <dynamic> public $bar ]
-  }
-
-  - Methods [0] {
-  }
-}
-BLAH;
-        $actualExport   = ReflectionObject::export($foo, true);
-
-        self::assertStringMatchesFormat($expectedExport, $actualExport);
-    }
-
     public function testCannotClone() : void
     {
         $classInfo = ReflectionObject::createFromInstance(new stdClass());

--- a/test/unit/Reflection/ReflectionParameterTest.php
+++ b/test/unit/Reflection/ReflectionParameterTest.php
@@ -129,21 +129,6 @@ class ReflectionParameterTest extends TestCase
         ReflectionParameter::createFromSpec(123, 'a');
     }
 
-    public function testImplementsReflector() : void
-    {
-        $classInfo  = $this->reflector->reflect(Methods::class);
-        $methodInfo = $classInfo->getMethod('methodWithParameters');
-        $paramInfo  = $methodInfo->getParameter('parameter1');
-
-        self::assertInstanceOf(Reflector::class, $paramInfo);
-    }
-
-    public function testExportThrowsException() : void
-    {
-        $this->expectException(Throwable::class);
-        ReflectionParameter::export();
-    }
-
     /**
      * @return array
      */

--- a/test/unit/Reflection/ReflectionParameterTest.php
+++ b/test/unit/Reflection/ReflectionParameterTest.php
@@ -11,7 +11,6 @@ use phpDocumentor\Reflection\Types;
 use PhpParser\Node\Param;
 use PhpParser\PrettyPrinter\Standard as StandardPrettyPrinter;
 use PHPUnit\Framework\TestCase;
-use Reflector;
 use Roave\BetterReflection\Reflection\Exception\Uncloneable;
 use Roave\BetterReflection\Reflection\ReflectionClass;
 use Roave\BetterReflection\Reflection\ReflectionParameter;
@@ -34,7 +33,6 @@ use Roave\BetterReflectionTest\Fixture\Php7ParameterTypeDeclarations;
 use Roave\BetterReflectionTest\FixtureOther\OtherClass;
 use SplDoublyLinkedList;
 use stdClass;
-use Throwable;
 use function sprintf;
 
 /**

--- a/test/unit/Reflection/ReflectionPropertyTest.php
+++ b/test/unit/Reflection/ReflectionPropertyTest.php
@@ -16,7 +16,6 @@ use PHPUnit\Framework\TestCase;
 use Reflection;
 use ReflectionFunctionAbstract;
 use ReflectionProperty as CoreReflectionProperty;
-use Reflector;
 use Roave\BetterReflection\Reflection\Exception\ClassDoesNotExist;
 use Roave\BetterReflection\Reflection\Exception\NoObjectProvided;
 use Roave\BetterReflection\Reflection\Exception\NotAnObject;
@@ -35,7 +34,6 @@ use Roave\BetterReflectionTest\Fixture\Php74PropertyTypeDeclarations;
 use Roave\BetterReflectionTest\Fixture\PropertyGetSet;
 use Roave\BetterReflectionTest\Fixture\StaticPropertyGetSet;
 use stdClass;
-use Throwable;
 use TraitWithProperty;
 use function count;
 

--- a/test/unit/Reflection/ReflectionPropertyTest.php
+++ b/test/unit/Reflection/ReflectionPropertyTest.php
@@ -74,14 +74,6 @@ class ReflectionPropertyTest extends TestCase
         self::assertSame('someProperty', $property->getName());
     }
 
-    public function testImplementsReflector() : void
-    {
-        $classInfo  = $this->reflector->reflect(ExampleClass::class);
-        $publicProp = $classInfo->getProperty('publicProperty');
-
-        self::assertInstanceOf(Reflector::class, $publicProp);
-    }
-
     public function testVisibilityMethods() : void
     {
         $classInfo = $this->reflector->reflect(ExampleClass::class);
@@ -195,12 +187,6 @@ class ReflectionPropertyTest extends TestCase
         $property  = $classInfo->getProperty('publicStaticProperty');
 
         self::assertSame('', $property->getDocComment());
-    }
-
-    public function testExportThrowsException() : void
-    {
-        $this->expectException(Throwable::class);
-        ReflectionProperty::export();
     }
 
     public function modifierProvider() : array


### PR DESCRIPTION
Replaces #397 from @muglug - I've rebased onto latest `master`, and implemented the proposal.

Note: introduces a BC break, so definitely targeting 4.0.0 for this.