### PR TITLE
Make getDocComment in adapter test return a string

### DIFF
--- a/test/unit/Reflection/Adapter/ReflectionMethodTest.php
+++ b/test/unit/Reflection/Adapter/ReflectionMethodTest.php
@@ -71,7 +71,7 @@ class ReflectionMethodTest extends TestCase
             ['isUserDefined', null, true, []],
             ['getClosureThis', NotImplemented::class, null, []],
             ['getClosureScopeClass', NotImplemented::class, null, []],
-            ['getDocComment', null, false, []],
+            ['getDocComment', null, '', []],
             ['getStartLine', null, 123, []],
             ['getEndLine', null, 123, []],
             ['getExtension', NotImplemented::class, null, []],


### PR DESCRIPTION
It was returning a `bool(false)` previously, which technically is fine (returns `false` if no comment exists), but I guess it makes more sense to return a string anyway because that's the usual case if a doc does exist anyway.