### PR TITLE
Replaced the string cast with a getName() call

### DIFF
--- a/src/SourceLocator/SourceStubber/ReflectionSourceStubber.php
+++ b/src/SourceLocator/SourceStubber/ReflectionSourceStubber.php
@@ -33,6 +33,7 @@ use ReflectionClassConstant;
 use ReflectionFunction as CoreReflectionFunction;
 use ReflectionFunctionAbstract as CoreReflectionFunctionAbstract;
 use ReflectionMethod as CoreReflectionMethod;
+use ReflectionNamedType as CoreReflectionNamedType;
 use ReflectionParameter;
 use ReflectionProperty as CoreReflectionProperty;
 use ReflectionType as CoreReflectionType;
@@ -475,7 +476,7 @@ final class ReflectionSourceStubber implements SourceStubber
      */
     private function formatType(CoreReflectionType $type) : NodeAbstract
     {
-        $name     = (string) $type;
+        $name     = $type instanceof CoreReflectionNamedType ? $type->getName() : (string) $type;
         $nameNode = $type->isBuiltin() || in_array($name, ['self', 'parent'], true) ? new Name($name) : new FullyQualified($name);
 
         return $type->allowsNull() ? new NullableType($nameNode) : $nameNode;


### PR DESCRIPTION
The `__toString()` method has been deprecated since 7.1, it's started to raise an error in 7.4 so this PR switches to use `getName()` instead.

`getName()` operates as this code expects (eg returns the type name without the nullable indicator `?`), and in PHP 8.0 `__toString()` will start to return the nullable indicator.

I don't think it's possible for `CoreReflectionType` to be passed to this method anymore, but the stubs suggest it is and I've not dug further into that yet, so this PR attempts to retain support for that scenario as well