### PR TITLE
ReflectionClass::getConstructor() should work event if the constructor isn't the first method in the class

### DIFF
--- a/src/Reflection/ReflectionClass.php
+++ b/src/Reflection/ReflectionClass.php
@@ -569,9 +569,9 @@ class ReflectionClass implements Reflection
      */
     public function getConstructor() : ReflectionMethod
     {
-        $constructors = array_filter($this->getMethods(), static function (ReflectionMethod $method) : bool {
+        $constructors = array_values(array_filter($this->getMethods(), static function (ReflectionMethod $method) : bool {
             return $method->isConstructor();
-        });
+        }));
 
         if (! isset($constructors[0])) {
             throw new OutOfBoundsException('Could not find method: __construct');

--- a/test/unit/Fixture/ExampleClass.php
+++ b/test/unit/Fixture/ExampleClass.php
@@ -65,6 +65,17 @@ namespace Roave\BetterReflectionTest\Fixture {
     interface ExampleInterface
     {
     }
+
+    class ExampleClassWhereConstructorIsNotFirstMethod
+    {
+        public function someMethod()
+        {
+        }
+
+        public function __construct()
+        {
+        }
+    }
 }
 
 namespace Roave\BetterReflectionTest\FixtureOther {

--- a/test/unit/Reflection/ReflectionClassTest.php
+++ b/test/unit/Reflection/ReflectionClassTest.php
@@ -48,6 +48,7 @@ use Roave\BetterReflectionTest\Fixture;
 use Roave\BetterReflectionTest\Fixture\AbstractClass;
 use Roave\BetterReflectionTest\Fixture\ClassForHinting;
 use Roave\BetterReflectionTest\Fixture\ExampleClass;
+use Roave\BetterReflectionTest\Fixture\ExampleClassWhereConstructorIsNotFirstMethod;
 use Roave\BetterReflectionTest\Fixture\ExampleInterface;
 use Roave\BetterReflectionTest\Fixture\ExampleTrait;
 use Roave\BetterReflectionTest\Fixture\FinalClass;
@@ -318,6 +319,19 @@ class ReflectionClassTest extends TestCase
     {
         $reflector   = new ClassReflector($this->getComposerLocator());
         $classInfo   = $reflector->reflect(ExampleClass::class);
+        $constructor = $classInfo->getConstructor();
+
+        self::assertInstanceOf(ReflectionMethod::class, $constructor);
+        self::assertTrue($constructor->isConstructor());
+    }
+
+    public function testGetConstructorThatIsNotFirstMethod() : void
+    {
+        $reflector   = (new ClassReflector(new SingleFileSourceLocator(
+            __DIR__ . '/../Fixture/ExampleClass.php',
+            $this->astLocator
+        )));
+        $classInfo   = $reflector->reflect(ExampleClassWhereConstructorIsNotFirstMethod::class);
         $constructor = $classInfo->getConstructor();
 
         self::assertInstanceOf(ReflectionMethod::class, $constructor);

--- a/test/unit/Reflector/ClassReflectorTest.php
+++ b/test/unit/Reflector/ClassReflectorTest.php
@@ -26,7 +26,7 @@ class ClassReflectorTest extends TestCase
         ))->getAllClasses();
 
         self::assertContainsOnlyInstancesOf(ReflectionClass::class, $classes);
-        self::assertCount(9, $classes);
+        self::assertCount(10, $classes);
     }
 
     public function testReflectProxiesToSourceLocator() : void


### PR DESCRIPTION
It looks @ondrejmirtes is too lazy to send PR 😛