### PR TITLE
Improve Psalm coverage for decoded datas from json files

### DIFF
--- a/src/SourceLocator/Type/Composer/Factory/MakeLocatorForComposerJson.php
+++ b/src/SourceLocator/Type/Composer/Factory/MakeLocatorForComposerJson.php
@@ -41,6 +41,7 @@ final class MakeLocatorForComposerJson
             throw MissingComposerJson::inProjectPath($installationPath);
         }
 
+        /** @var array{autoload: array{classmap: array<int, string>, files: array<int, string>, psr-4: array<string, array<int, string>>, psr-0: array<string, array<int, string>>}}|null $composer */
         $composer = json_decode((string) file_get_contents($composerJsonPath), true);
 
         if (! is_array($composer)) {
@@ -76,7 +77,7 @@ final class MakeLocatorForComposerJson
     }
 
     /**
-     * @param mixed[] $package
+     * @param array{autoload: array{classmap: array<int, string>, files: array<int, string>, psr-4: array<string, array<int, string>>, psr-0: array<string, array<int, string>>}} $package
      *
      * @return array<string, array<int, string>>
      */
@@ -88,7 +89,7 @@ final class MakeLocatorForComposerJson
     }
 
     /**
-     * @param mixed[] $package
+     * @param array{autoload: array{classmap: array<int, string>, files: array<int, string>, psr-4: array<string, array<int, string>>, psr-0: array<string, array<int, string>>}} $package
      *
      * @return array<string, array<int, string>>
      */
@@ -100,7 +101,7 @@ final class MakeLocatorForComposerJson
     }
 
     /**
-     * @param mixed[] $package
+     * @param array{autoload: array{classmap: array<int, string>, files: array<int, string>, psr-4: array<string, array<int, string>>, psr-0: array<string, array<int, string>>}} $package
      *
      * @return array<int, string>
      */
@@ -110,7 +111,7 @@ final class MakeLocatorForComposerJson
     }
 
     /**
-     * @param mixed[] $package
+     * @param array{autoload: array{classmap: array<int, string>, files: array<int, string>, psr-4: array<string, array<int, string>>, psr-0: array<string, array<int, string>>}} $package
      *
      * @return array<int, string>
      */

--- a/src/SourceLocator/Type/Composer/Factory/MakeLocatorForComposerJsonAndInstalledJson.php
+++ b/src/SourceLocator/Type/Composer/Factory/MakeLocatorForComposerJsonAndInstalledJson.php
@@ -48,7 +48,9 @@ final class MakeLocatorForComposerJsonAndInstalledJson
             throw MissingInstalledJson::inProjectPath($installationPath);
         }
 
+        /** @var array{autoload: array{classmap: array<int, string>, files: array<int, string>, psr-4: array<string, array<int, string>>, psr-0: array<string, array<int, string>>}}|null $composer */
         $composer  = json_decode((string) file_get_contents($composerJsonPath), true);
+        /** @var list<array{name: string, autoload: array{classmap: array<int, string>, files: array<int, string>, psr-4: array<string, array<int, string>>, psr-0: array<string, array<int, string>>}}>|null $installed*/
         $installed = json_decode((string) file_get_contents($installedJsonPath), true);
 
         if (! is_array($composer)) {
@@ -117,7 +119,7 @@ final class MakeLocatorForComposerJsonAndInstalledJson
     }
 
     /**
-     * @param mixed[] $package
+     * @param array{autoload: array{classmap: array<int, string>, files: array<int, string>, psr-4: array<string, array<int, string>>, psr-0: array<string, array<int, string>>}} $package
      *
      * @return array<string, array<int, string>>
      */
@@ -129,7 +131,7 @@ final class MakeLocatorForComposerJsonAndInstalledJson
     }
 
     /**
-     * @param mixed[] $package
+     * @param array{autoload: array{classmap: array<int, string>, files: array<int, string>, psr-4: array<string, array<int, string>>, psr-0: array<string, array<int, string>>}} $package
      *
      * @return array<string, array<int, string>>
      */
@@ -141,7 +143,7 @@ final class MakeLocatorForComposerJsonAndInstalledJson
     }
 
     /**
-     * @param mixed[] $package
+     * @param array{autoload: array{classmap: array<int, string>, files: array<int, string>, psr-4: array<string, array<int, string>>, psr-0: array<string, array<int, string>>}} $package
      *
      * @return array<int, string>
      */
@@ -151,7 +153,7 @@ final class MakeLocatorForComposerJsonAndInstalledJson
     }
 
     /**
-     * @param mixed[] $package
+     * @param array{autoload: array{classmap: array<int, string>, files: array<int, string>, psr-4: array<string, array<int, string>>, psr-0: array<string, array<int, string>>}} $package
      *
      * @return array<int, string>
      */

--- a/src/SourceLocator/Type/Composer/Factory/MakeLocatorForInstalledJson.php
+++ b/src/SourceLocator/Type/Composer/Factory/MakeLocatorForInstalledJson.php
@@ -42,6 +42,7 @@ final class MakeLocatorForInstalledJson
             throw MissingInstalledJson::inProjectPath($installationPath);
         }
 
+        /** @var list<array{name: string, autoload: array{classmap: array<int, string>, files: array<int, string>, psr-4: array<string, array<int, string>>, psr-0: array<string, array<int, string>>}}>|null $installed */
         $installed = json_decode((string) file_get_contents($installedJsonPath), true);
 
         if (! is_array($installed)) {
@@ -106,7 +107,7 @@ final class MakeLocatorForInstalledJson
     }
 
     /**
-     * @param mixed[] $package
+     * @param array{autoload: array{classmap: array<int, string>, files: array<int, string>, psr-4: array<string, array<int, string>>, psr-0: array<string, array<int, string>>}} $package
      *
      * @return array<string, array<int, string>>
      */
@@ -118,7 +119,7 @@ final class MakeLocatorForInstalledJson
     }
 
     /**
-     * @param mixed[] $package
+     * @param array{autoload: array{classmap: array<int, string>, files: array<int, string>, psr-4: array<string, array<int, string>>, psr-0: array<string, array<int, string>>}} $package
      *
      * @return array<string, array<int, string>>
      */
@@ -130,7 +131,7 @@ final class MakeLocatorForInstalledJson
     }
 
     /**
-     * @param mixed[] $package
+     * @param array{autoload: array{classmap: array<int, string>, files: array<int, string>, psr-4: array<string, array<int, string>>, psr-0: array<string, array<int, string>>}} $package
      *
      * @return array<int, string>
      */
@@ -140,7 +141,7 @@ final class MakeLocatorForInstalledJson
     }
 
     /**
-     * @param mixed[] $package
+     * @param array{autoload: array{classmap: array<int, string>, files: array<int, string>, psr-4: array<string, array<int, string>>, psr-0: array<string, array<int, string>>}} $package
      *
      * @return array<int, string>
      */
@@ -150,7 +151,7 @@ final class MakeLocatorForInstalledJson
     }
 
     /**
-     * @param mixed[] $package
+     * @param array{name: string, autoload: array{classmap: array<int, string>, files: array<int, string>, psr-4: array<string, array<int, string>>, psr-0: array<string, array<int, string>>}} $package
      *
      * @psalm-param array{name: string} $package
      */


### PR DESCRIPTION
As discussed here  #525 I described some types to improve Psalm coverage from 98.9751% to 99.2148%

This is not very elegant but I don't see a better way without refactoring the code just to pass smaller chunks of the whole file.