### PR TITLE
Provide path to PHP Storm stubs directory

### DIFF
--- a/src/SourceLocator/SourceStubber/PhpStormStubsSourceStubber.php
+++ b/src/SourceLocator/SourceStubber/PhpStormStubsSourceStubber.php
@@ -80,8 +80,11 @@ final class PhpStormStubsSourceStubber implements SourceStubber
 
     public static function fromStubsDirectory(Parser $phpParser, string $stubsDirectory)
     {
-        $instance = new self($phpParser);
+        if (is_dir($stubsDirectory) === false) {
+            throw CouldNotFindPhpStormStubs::create();
+        }
 
+        $instance = new self($phpParser);
         $instance->stubsDirectory = $stubsDirectory;
 
         return $instance;

--- a/src/SourceLocator/SourceStubber/PhpStormStubsSourceStubber.php
+++ b/src/SourceLocator/SourceStubber/PhpStormStubsSourceStubber.php
@@ -66,10 +66,11 @@ final class PhpStormStubsSourceStubber implements SourceStubber
     /** @var array<string, Node\Const_|Node\Expr\FuncCall> */
     private $constantNodes = [];
 
-    public function __construct(Parser $phpParser)
+    public function __construct(Parser $phpParser, ?string $stubsDirectory = null)
     {
-        $this->phpParser     = $phpParser;
-        $this->prettyPrinter = new Standard(self::BUILDER_OPTIONS);
+        $this->phpParser      = $phpParser;
+        $this->stubsDirectory = $stubsDirectory;
+        $this->prettyPrinter  = new Standard(self::BUILDER_OPTIONS);
 
         $this->cachingVisitor = $this->createCachingVisitor();
 

--- a/src/SourceLocator/SourceStubber/PhpStormStubsSourceStubber.php
+++ b/src/SourceLocator/SourceStubber/PhpStormStubsSourceStubber.php
@@ -66,17 +66,25 @@ final class PhpStormStubsSourceStubber implements SourceStubber
     /** @var array<string, Node\Const_|Node\Expr\FuncCall> */
     private $constantNodes = [];
 
-    public function __construct(Parser $phpParser, ?string $stubsDirectory = null)
+    public function __construct(Parser $phpParser)
     {
-        $this->phpParser      = $phpParser;
-        $this->stubsDirectory = $stubsDirectory;
-        $this->prettyPrinter  = new Standard(self::BUILDER_OPTIONS);
+        $this->phpParser     = $phpParser;
+        $this->prettyPrinter = new Standard(self::BUILDER_OPTIONS);
 
         $this->cachingVisitor = $this->createCachingVisitor();
 
         $this->nodeTraverser = new NodeTraverser();
         $this->nodeTraverser->addVisitor(new NameResolver());
         $this->nodeTraverser->addVisitor($this->cachingVisitor);
+    }
+
+    public static function fromStubsDirectory(Parser $phpParser, string $stubsDirectory)
+    {
+        $instance = new self($phpParser);
+
+        $instance->stubsDirectory = $stubsDirectory;
+
+        return $instance;
     }
 
     public function generateClassStub(string $className) : ?StubData

--- a/test/unit/SourceLocator/SourceStubber/PhpStormStubsSourceStubberTest.php
+++ b/test/unit/SourceLocator/SourceStubber/PhpStormStubsSourceStubberTest.php
@@ -17,6 +17,7 @@ use Roave\BetterReflection\Reflector\ClassReflector;
 use Roave\BetterReflection\Reflector\ConstantReflector;
 use Roave\BetterReflection\Reflector\FunctionReflector;
 use Roave\BetterReflection\SourceLocator\Exception\InvalidFileLocation;
+use Roave\BetterReflection\SourceLocator\SourceStubber\Exception\CouldNotFindPhpStormStubs;
 use Roave\BetterReflection\SourceLocator\SourceStubber\PhpStormStubsSourceStubber;
 use Roave\BetterReflection\SourceLocator\SourceStubber\StubData;
 use Roave\BetterReflection\SourceLocator\Type\PhpInternalSourceLocator;
@@ -517,11 +518,9 @@ class PhpStormStubsSourceStubberTest extends TestCase
 
     public function testStubberThrowsExceptionWhenInvalidStubsDirectoryIsSpecified() : void
     {
+        self::expectException(CouldNotFindPhpStormStubs::class);
+
         $parser = BetterReflectionSingleton::instance()->phpParser();
         $stubber = PhpStormStubsSourceStubber::fromStubsDirectory($parser, '/tmp/invalid_directory');
-
-        self::expectException(InvalidFileLocation::class);
-
-        $stubber->generateFunctionStub('array_filter');
     }
 }

--- a/test/unit/SourceLocator/SourceStubber/PhpStormStubsSourceStubberTest.php
+++ b/test/unit/SourceLocator/SourceStubber/PhpStormStubsSourceStubberTest.php
@@ -16,7 +16,9 @@ use Roave\BetterReflection\Reflection\ReflectionParameter;
 use Roave\BetterReflection\Reflector\ClassReflector;
 use Roave\BetterReflection\Reflector\ConstantReflector;
 use Roave\BetterReflection\Reflector\FunctionReflector;
+use Roave\BetterReflection\SourceLocator\Exception\InvalidFileLocation;
 use Roave\BetterReflection\SourceLocator\SourceStubber\PhpStormStubsSourceStubber;
+use Roave\BetterReflection\SourceLocator\SourceStubber\StubData;
 use Roave\BetterReflection\SourceLocator\Type\PhpInternalSourceLocator;
 use Roave\BetterReflectionTest\BetterReflectionSingleton;
 use function array_filter;
@@ -501,5 +503,25 @@ class PhpStormStubsSourceStubberTest extends TestCase
     public function testNoStubForUnknownConstant() : void
     {
         self::assertNull($this->sourceStubber->generateConstantStub('SOME_CONSTANT'));
+    }
+
+    public function testStubberWithStubsDirectory(): void
+    {
+        $parser = BetterReflectionSingleton::instance()->phpParser();
+        $stubber = PhpStormStubsSourceStubber::fromStubsDirectory($parser, __DIR__.'/../../../../vendor/jetbrains/phpstorm-stubs');
+
+        $stub = $stubber->generateFunctionStub('array_filter');
+
+        self::assertInstanceOf(StubData::class, $stub);
+    }
+
+    public function testStubberThrowsExceptionWhenInvalidStubsDirectoryIsSpecified() : void
+    {
+        $parser = BetterReflectionSingleton::instance()->phpParser();
+        $stubber = PhpStormStubsSourceStubber::fromStubsDirectory($parser, '/tmp/invalid_directory');
+
+        self::expectException(InvalidFileLocation::class);
+
+        $stubber->generateFunctionStub('array_filter');
     }
 }


### PR DESCRIPTION
Allows for the `stubsDirectory` to be optionally specified during the construction of `PhpStormStubsSourceStubber`, so as to avoid calls to `is_dir` in stream contexts where `is_dir` is not implemented by a stream wrapper.

This resolves a use case where BR is packaged in a phar, but the stubs directory (i.e. `phar:///tmp/app.phar/vendor/jetbrains/phpstorm-stubs`) cannot be located due to `is_dir` returning `false` behind the phar stream wrapper.  Because the stubs directory path is known, the path can be provided to the constructor instead of having to be resolved at runtime.