### PR TITLE
bump psalm, fix errors, add usePhpDocPropertiesWithoutMagicCall

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "doctrine/coding-standard": "^7.0.2",
         "phpstan/phpstan": "^0.12.8",
         "phpunit/phpunit": "^8.5.2",
-        "vimeo/psalm": "^3.8.3"
+        "vimeo/psalm": "3.9.2"
     },
     "autoload": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e4ca5654db48fa2b4a0b13e9cecbf196",
+    "content-hash": "8f5f4353470bb7193814eb120605eaa8",
     "packages": [
         {
             "name": "jetbrains/phpstorm-stubs",
@@ -2785,16 +2785,16 @@
         },
         {
             "name": "vimeo/psalm",
-            "version": "3.8.5",
+            "version": "3.9.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vimeo/psalm.git",
-                "reference": "e6ec5fa22a7b9e61670a24d07b3119aff80dcd89"
+                "reference": "87d8947ff36d8b71f54b7e46b93384cf010681a0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vimeo/psalm/zipball/e6ec5fa22a7b9e61670a24d07b3119aff80dcd89",
-                "reference": "e6ec5fa22a7b9e61670a24d07b3119aff80dcd89",
+                "url": "https://api.github.com/repos/vimeo/psalm/zipball/87d8947ff36d8b71f54b7e46b93384cf010681a0",
+                "reference": "87d8947ff36d8b71f54b7e46b93384cf010681a0",
                 "shasum": ""
             },
             "require": {
@@ -2825,10 +2825,10 @@
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.2",
                 "ext-curl": "*",
-                "phpmyadmin/sql-parser": "^5.0",
+                "phpmyadmin/sql-parser": "5.1.0",
                 "phpspec/prophecy": ">=1.9.0",
                 "phpunit/phpunit": "^7.5.16 || ^8.0",
-                "psalm/plugin-phpunit": "^0.6",
+                "psalm/plugin-phpunit": "^0.9",
                 "slevomat/coding-standard": "^5.0",
                 "squizlabs/php_codesniffer": "^3.5",
                 "symfony/process": "^4.3"
@@ -2876,7 +2876,7 @@
                 "inspection",
                 "php"
             ],
-            "time": "2020-02-07T17:15:50+00:00"
+            "time": "2020-02-18T20:08:32+00:00"
         },
         {
             "name": "webmozart/glob",

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,11 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="3.8.3@389af1bfc739bfdff3f9e3dc7bd6499aee51a831">
+<files psalm-version="3.9.2@87d8947ff36d8b71f54b7e46b93384cf010681a0">
   <file src="src/BetterReflection.php">
     <DocblockTypeContradiction occurrences="1">
       <code>$this-&gt;sourceStubber</code>
     </DocblockTypeContradiction>
   </file>
   <file src="src/Reflection/Adapter/ReflectionClass.php">
+    <InvalidReturnType occurrences="1">
+      <code>getProperties</code>
+    </InvalidReturnType>
     <MethodSignatureMismatch occurrences="5">
       <code>public function getName()</code>
       <code>public function getTraitNames()</code>
@@ -19,12 +22,14 @@
       <code>$interface</code>
       <code>$realInterfaceName</code>
     </PossiblyInvalidArgument>
-    <RedundantCondition occurrences="2">
+    <RedundantCondition occurrences="1">
       <code>is_object($argument)</code>
-      <code>is_string($argument) || is_object($argument)</code>
     </RedundantCondition>
   </file>
   <file src="src/Reflection/Adapter/ReflectionObject.php">
+    <InvalidReturnType occurrences="1">
+      <code>getProperties</code>
+    </InvalidReturnType>
     <MethodSignatureMismatch occurrences="5">
       <code>public function getName()</code>
       <code>public function getTraitNames()</code>
@@ -43,6 +48,10 @@
     <PossiblyInvalidCast occurrences="1">
       <code>$returnType</code>
     </PossiblyInvalidCast>
+    <PossiblyNullPropertyAssignmentValue occurrences="2">
+      <code>$functionNode-&gt;getStmts()</code>
+      <code>$this-&gt;loadStaticParser()-&gt;parse('&lt;?php ' . $newBody)</code>
+    </PossiblyNullPropertyAssignmentValue>
   </file>
   <file src="src/Reflection/ReflectionMethod.php">
     <InvalidStringClass occurrences="1">

--- a/psalm.xml
+++ b/psalm.xml
@@ -6,6 +6,7 @@
     errorBaseline="psalm-baseline.xml"
     useDocblockTypes="true"
     totallyTyped="false"
+    usePhpDocPropertiesWithoutMagicCall="true"
     allowPhpStormGenerics="true"
 >
     <projectFiles>
@@ -66,26 +67,16 @@
 
         <UndefinedPropertyAssignment>
             <errorLevel type="suppress">
-                <referencedProperty name="PhpParser\Node\Stmt\ClassLike::$namespacedName" />
                 <referencedProperty name="PhpParser\Node\Param::$isOptional" />
             </errorLevel>
         </UndefinedPropertyAssignment>
 
         <UndefinedPropertyFetch>
             <errorLevel type="suppress">
-                <referencedProperty name="PhpParser\Node\Stmt\ClassLike::$namespacedName" />
                 <referencedProperty name="PhpParser\Node\Param::$isOptional" />
             </errorLevel>
         </UndefinedPropertyFetch>
 
-        <PossiblyNullPropertyAssignmentValue>
-            <errorLevel type="suppress">
-                <referencedProperty name="PhpParser\Node\Expr\Closure::$stmts" />
-                <referencedProperty name="PhpParser\Node\Stmt\Function_::$stmts" />
-                <referencedProperty name="PhpParser\Node\Stmt\ClassMethod::$stmts" />
-            </errorLevel>
-        </PossiblyNullPropertyAssignmentValue>
-        
         <InvalidScalarArgument>
             <!-- Not actually an issue, we send scalar where the called method wait for bool|float|int|string. See vimeo/psalm/issues/2622 -->
             <errorLevel type="suppress">

--- a/src/NodeCompiler/Exception/UnableToCompileNode.php
+++ b/src/NodeCompiler/Exception/UnableToCompileNode.php
@@ -45,8 +45,6 @@ class UnableToCompileNode extends LogicException
         CompilerContext $fetchContext,
         Node\Expr\ConstFetch $constantFetch
     ) : self {
-        assert($constantFetch->name instanceof Node\Name);
-
         return new self(sprintf(
             'Could not locate constant "%s" while evaluating expression in %s at line %s',
             reset($constantFetch->name->parts),

--- a/src/Reflection/ReflectionClass.php
+++ b/src/Reflection/ReflectionClass.php
@@ -936,7 +936,6 @@ class ReflectionClass implements Reflection
         // @TODO use actual `ClassReflector` or `FunctionReflector`?
         if ($this->isAnonymous()) {
             $class = (new BetterReflection())->classReflector()->reflect($node->toString());
-            assert($class instanceof self);
         } else {
             $class = $this->reflector->reflect($node->toString());
             assert($class instanceof self);
@@ -1225,6 +1224,8 @@ class ReflectionClass implements Reflection
      * This method allows us to retrieve all interfaces parent of the this interface. Do not use on class nodes!
      *
      * @return ReflectionClass[] parent interfaces of this interface
+     *
+     * @psalm-return array<string, ReflectionClass>
      *
      * @throws NotAnInterfaceReflection
      */

--- a/src/Reflection/ReflectionFunction.php
+++ b/src/Reflection/ReflectionFunction.php
@@ -97,8 +97,6 @@ class ReflectionFunction extends ReflectionFunctionAbstract implements Reflectio
         $this->assertFunctionExist($functionName);
 
         return static function (...$args) use ($functionName) {
-            assert(is_callable($functionName));
-
             return $functionName(...$args);
         };
     }
@@ -131,9 +129,7 @@ class ReflectionFunction extends ReflectionFunctionAbstract implements Reflectio
         $functionName = $this->getName();
 
         $this->assertFunctionExist($functionName);
-
-        assert(is_callable($functionName));
-
+        
         return $functionName(...$args);
     }
 
@@ -149,6 +145,8 @@ class ReflectionFunction extends ReflectionFunctionAbstract implements Reflectio
 
     /**
      * @throws FunctionDoesNotExist
+     *
+     * @psalm-assert callable-string $functionName
      */
     private function assertFunctionExist(string $functionName) : void
     {

--- a/src/Reflection/ReflectionProperty.php
+++ b/src/Reflection/ReflectionProperty.php
@@ -338,7 +338,7 @@ class ReflectionProperty
 
         $instance = $this->assertObject($object);
 
-        return Closure::bind(function ($instance, string $propertyName) {
+        return Closure::bind(function (object $instance, string $propertyName) {
             return $instance->{$propertyName};
         }, $instance, $declaringClassName)->__invoke($instance, $this->getName());
     }

--- a/src/Reflector/ClassReflector.php
+++ b/src/Reflector/ClassReflector.php
@@ -34,7 +34,6 @@ class ClassReflector implements Reflector
         $identifier = new Identifier($className, new IdentifierType(IdentifierType::IDENTIFIER_CLASS));
 
         $classInfo = $this->sourceLocator->locateIdentifier($this, $identifier);
-        assert($classInfo instanceof ReflectionClass || $classInfo === null);
 
         if ($classInfo === null) {
             throw Exception\IdentifierNotFound::fromIdentifier($identifier);

--- a/src/TypesFinder/ResolveTypes.php
+++ b/src/TypesFinder/ResolveTypes.php
@@ -29,9 +29,7 @@ class ResolveTypes
         $resolvedTypes = [];
 
         foreach ($stringTypes as $stringType) {
-            $resolvedType = $this->typeResolver->resolve($stringType, $context);
-            assert($resolvedType instanceof Type);
-            $resolvedTypes[] = $resolvedType;
+            $resolvedTypes[] = $this->typeResolver->resolve($stringType, $context);
         }
 
         return $resolvedTypes;

--- a/src/Util/GetFirstDocComment.php
+++ b/src/Util/GetFirstDocComment.php
@@ -6,6 +6,7 @@ namespace Roave\BetterReflection\Util;
 
 use PhpParser\Comment\Doc;
 use PhpParser\NodeAbstract;
+use Webmozart\Assert\Assert;
 
 /**
  * @internal
@@ -16,7 +17,10 @@ final class GetFirstDocComment
     {
         foreach ($node->getComments() as $comment) {
             if ($comment instanceof Doc) {
-                return $comment->getReformattedText();
+                $text = $comment->getReformattedText();
+                Assert::string($text);
+                
+                return $text;
             }
         }
 


### PR DESCRIPTION
Bumping psalm on last version to use usePhpDocPropertiesWithoutMagicCall.

This allows to drop some ignored errors and gain some type coverage.

Also fixed some errors