### PR TITLE
bump phpbench and phpstan

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -253,7 +253,7 @@ jobs:
       php: 7.4
       env: DEPENDENCIES=""
       before_script:
-        - travis_retry composer require --dev --prefer-dist --prefer-stable phpbench/phpbench:^0.16.9
+        - travis_retry composer require --dev --prefer-dist --prefer-stable phpbench/phpbench:^0.17.0
       script: ./vendor/bin/phpbench run --progress=dots --iterations=1
 
     - stage: Upload Coverage

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
     ],
     "require-dev": {
         "doctrine/coding-standard": "^7.0.2",
-        "phpstan/phpstan": "^0.12.8",
+        "phpstan/phpstan": "^0.12.11",
         "phpunit/phpunit": "^8.5.2",
         "vimeo/psalm": "3.9.2"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8f5f4353470bb7193814eb120605eaa8",
+    "content-hash": "229146722b7ee60f056e85a235b1af96",
     "packages": [
         {
             "name": "jetbrains/phpstorm-stubs",
@@ -1317,16 +1317,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "0.12.10",
+            "version": "0.12.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "39004edc7fc308752f625b89b70ad1710708f45e"
+                "reference": "ca5f2b7cf81c6d8fba74f9576970399c5817e03b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/39004edc7fc308752f625b89b70ad1710708f45e",
-                "reference": "39004edc7fc308752f625b89b70ad1710708f45e",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/ca5f2b7cf81c6d8fba74f9576970399c5817e03b",
+                "reference": "ca5f2b7cf81c6d8fba74f9576970399c5817e03b",
                 "shasum": ""
             },
             "require": {
@@ -1352,7 +1352,7 @@
                 "MIT"
             ],
             "description": "PHPStan - PHP Static Analysis Tool",
-            "time": "2020-02-12T22:03:42+00:00"
+            "time": "2020-02-16T14:00:29+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",


### PR DESCRIPTION
This PR bump phpbench to solve CI error we get on #547 . It also bumps phpstan to 0.12.11 version so we can stop bothering Ondřej Mirtes on #538 :)

The SA errors are unrelated and fixed in #547 anyway.