### PR TITLE
Reproduce #573

### DIFF
--- a/test/unit/Foo.php
+++ b/test/unit/Foo.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Roave\BetterReflectionTest;
+
+class Foo
+{
+}

--- a/test/unit/SourceLocator/AutoloadSourceLocatorWithoutParserTest.php
+++ b/test/unit/SourceLocator/AutoloadSourceLocatorWithoutParserTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Roave\BetterReflectionTest\SourceLocator;
+
+use PhpParser\Lexer\Emulative;
+use PhpParser\ParserFactory;
+use PHPUnit\Framework\TestCase;
+use Roave\BetterReflection\Reflector\ClassReflector;
+use Roave\BetterReflection\Reflector\FunctionReflector;
+use Roave\BetterReflection\SourceLocator\Ast\Locator as AstLocator;
+use Roave\BetterReflection\SourceLocator\Type\AutoloadSourceLocator;
+use Roave\BetterReflectionTest\Foo;
+
+class AutoloadSourceLocatorWithoutParserTest extends TestCase
+{
+    /**
+     * @runInSeparateProcess
+     */
+    public function testWithoutParser() : void
+    {
+    	//class_exists(\Roave\BetterReflection\SourceLocator\Ast\Parser\MemoizingParser::class);
+        $parser            = (new ParserFactory())->create(ParserFactory::PREFER_PHP7, new Emulative([
+            'usedAttributes' => ['comments', 'startLine', 'endLine', 'startFilePos', 'endFilePos'],
+        ]));
+        $functionReflector = null;
+        $astLocator        = new AstLocator($parser, static function () use (&$functionReflector) : FunctionReflector {
+            return $functionReflector;
+        });
+        $sourceLocator     = new AutoloadSourceLocator(
+            $astLocator,
+            $parser
+        );
+        $classReflector    = new ClassReflector($sourceLocator);
+        $functionReflector = new FunctionReflector($sourceLocator, $classReflector);
+        $reflection        = $classReflector->reflect(Foo::class);
+        $this->assertSame(Foo::class, $reflection->getName());
+    }
+}


### PR DESCRIPTION
This reproduces #573. But something's fishy in PHPUnit.

* If I run `vendor/bin/phpunit test/unit/SourceLocator/AutoloadSourceLocatorWithoutParserTest.php`, the test fails.
* If I uncomment the `class_exists()` line, the test passes.
* If I run `vendor/bin/phpunit`, all the tests pass. I'd suspect that `@runInSeparateProcess` doesn't work and something loads the MemoizingParser class before, but:
* If I uncomment `class_exists` and change the assert on the last line to some nonsense and run `vendor/bin/phpunit`, the whole test suite still passes. Looks like PHPUnit is skipping the test and doesn't run it at all when the whole suite is run.