### PR TITLE
Fixed methods cache in ReflectionClass

### DIFF
--- a/src/Reflection/ReflectionClass.php
+++ b/src/Reflection/ReflectionClass.php
@@ -296,7 +296,7 @@ class ReflectionClass implements Reflection
             return $this->cachedMethods;
         }
 
-        $this->cachedMethods = [];
+        $cachedMethods = [];
 
         $traitAliases = $this->getTraitAliases();
 
@@ -309,19 +309,21 @@ class ReflectionClass implements Reflection
                     continue;
                 }
 
-                if (isset($this->cachedMethods[$methodAlias])) {
+                if (isset($cachedMethods[$methodAlias])) {
                     continue;
                 }
 
-                $this->cachedMethods[$methodAlias] = $method;
+                $cachedMethods[$methodAlias] = $method;
             }
 
-            if (isset($this->cachedMethods[$methodName])) {
+            if (isset($cachedMethods[$methodName])) {
                 continue;
             }
 
-            $this->cachedMethods[$methodName] = $method;
+            $cachedMethods[$methodName] = $method;
         }
+
+        $this->cachedMethods = $cachedMethods;
 
         return $this->cachedMethods;
     }

--- a/test/unit/Fixture/ClassWithMissingParent.php
+++ b/test/unit/Fixture/ClassWithMissingParent.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Roave\BetterReflectionTest\Fixture;
+
+class ClassWithMissingParent extends ParentThatDoesNotExist
+{
+
+}

--- a/test/unit/Reflection/ReflectionClassTest.php
+++ b/test/unit/Reflection/ReflectionClassTest.php
@@ -29,6 +29,7 @@ use Roave\BetterReflection\Reflection\ReflectionClassConstant;
 use Roave\BetterReflection\Reflection\ReflectionMethod;
 use Roave\BetterReflection\Reflection\ReflectionProperty;
 use Roave\BetterReflection\Reflector\ClassReflector;
+use Roave\BetterReflection\Reflector\Exception\IdentifierNotFound;
 use Roave\BetterReflection\SourceLocator\Ast\Locator;
 use Roave\BetterReflection\SourceLocator\Type\ComposerSourceLocator;
 use Roave\BetterReflection\SourceLocator\Type\SingleFileSourceLocator;
@@ -47,6 +48,7 @@ use Roave\BetterReflectionTest\ClassWithInterfacesOther;
 use Roave\BetterReflectionTest\Fixture;
 use Roave\BetterReflectionTest\Fixture\AbstractClass;
 use Roave\BetterReflectionTest\Fixture\ClassForHinting;
+use Roave\BetterReflectionTest\Fixture\ClassWithMissingParent;
 use Roave\BetterReflectionTest\Fixture\ExampleClass;
 use Roave\BetterReflectionTest\Fixture\ExampleClassWhereConstructorIsNotFirstMethod;
 use Roave\BetterReflectionTest\Fixture\ExampleInterface;
@@ -234,6 +236,24 @@ class ReflectionClassTest extends TestCase
 
         self::assertSame('f', $classInfo->getMethod('f')->getName(), 'Failed asserting that method from SUT was returned');
         self::assertSame('Qux', $classInfo->getMethod('f')->getDeclaringClass()->getName());
+    }
+
+    public function testGetMethodsWithBrokenClass() : void
+    {
+        $classInfo = (new ClassReflector(new SingleFileSourceLocator(
+            __DIR__ . '/../Fixture/ClassWithMissingParent.php',
+            $this->astLocator
+        )))->reflect(ClassWithMissingParent::class);
+
+        try {
+            $classInfo->getMethods();
+        } catch (IdentifierNotFound $e) {
+            // Ignore error for the first time
+        }
+
+        self::expectException(IdentifierNotFound::class);
+
+        $classInfo->getMethods();
     }
 
     public function testGetMethodsOrder() : void


### PR DESCRIPTION
It should cache only when all methods are processed.

Credit goes to @ondrejmirtes 