### PR TITLE
Psalm.xml cleanup

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -14,8 +14,6 @@
     </projectFiles>
 
     <issueHandlers>
-        <LessSpecificReturnType errorLevel="suppress" />
-
         <MissingClosureReturnType errorLevel="suppress" />
         <MissingReturnType errorLevel="suppress" />
 
@@ -36,34 +34,6 @@
         <PossiblyNullArgument errorLevel="suppress" />
 
         <TypeCoercion errorLevel="suppress" />
-
-        <TooManyArguments>
-            <errorLevel type="suppress">
-                <directory name="src/Reflection/Adapter" />
-            </errorLevel>
-        </TooManyArguments>
-
-        <UnresolvableInclude errorLevel="suppress" />
-
-        <RawObjectIteration errorLevel="suppress" />
-
-        <MoreSpecificImplementedParamType>
-            <errorLevel type="suppress">
-                <file name="src/Reflection/ReflectionObject.php" />
-            </errorLevel>
-        </MoreSpecificImplementedParamType>
-
-        <LessSpecificImplementedReturnType>
-            <errorLevel type="suppress">
-                <file name="src/SourceLocator/Ast/Parser/MemoizingParser.php" />
-            </errorLevel>
-        </LessSpecificImplementedReturnType>
-
-        <ImplementedReturnTypeMismatch>
-            <errorLevel type="suppress">
-                <file name="src/Reflection/Adapter/ReflectionClassConstant.php" />
-            </errorLevel>
-        </ImplementedReturnTypeMismatch>
 
         <UndefinedPropertyAssignment>
             <errorLevel type="suppress">


### PR DESCRIPTION
This PR removes some suppressed errors in psalm.xml.

Those errors seem to not exists anymore, so this will prevent new similar errors to be introduced in future commits.