### PR TITLE
Verify `ReflectionSourceStubber` and `PhpInternalSourceLocator`  against `FFI`, `memcache`, `mongodb` and `redis` extension symbols

### DIFF
--- a/test/unit/SourceLocator/SourceStubber/PhpStormStubsSourceStubberTest.php
+++ b/test/unit/SourceLocator/SourceStubber/PhpStormStubsSourceStubberTest.php
@@ -321,8 +321,6 @@ class PhpStormStubsSourceStubberTest extends TestCase
             'printf',
             'fprintf',
             'trait_exists',
-            'user_error',
-            'preg_replace_callback_array',
             'strtok',
             'strtr',
             'hrtime',
@@ -373,7 +371,7 @@ class PhpStormStubsSourceStubberTest extends TestCase
         }
 
         // Changed in PHP 7.4.0
-        if (PHP_VERSION_ID < 70400 && $functionName === 'preg_replace_callback') {
+        if (PHP_VERSION_ID < 70400 && in_array($functionName, ['preg_replace_callback', 'preg_replace_callback_array'], true)) {
             return;
         }
 

--- a/test/unit/SourceLocator/Type/PhpInternalSourceLocatorTest.php
+++ b/test/unit/SourceLocator/Type/PhpInternalSourceLocatorTest.php
@@ -104,12 +104,7 @@ class PhpInternalSourceLocatorTest extends TestCase
                 static function (string $symbol) : bool {
                     $reflection = new CoreReflectionClass($symbol);
 
-                    if (! $reflection->isInternal()) {
-                        return false;
-                    }
-
-                    // https://github.com/Roave/BetterReflection/issues/598
-                    return ! in_array($reflection->getExtensionName(), ['FFI', 'mongodb'], true);
+                    return $reflection->isInternal();
                 }
             )
         );


### PR DESCRIPTION
Fixes #598