### PR TITLE
Exclude PhpStormStubsSourceStubber temporarily from the PHPStan analysis

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -4,6 +4,11 @@ parameters:
     paths:
         - src
 
+    excludes_analyse:
+        # references huge array PhpStormStubsMap
+        # can be removed once updated to PHPStan 0.12.26
+        - src/SourceLocator/SourceStubber/PhpStormStubsSourceStubber.php
+
     ignoreErrors:
         -
             message: '#Access to an undefined property PhpParser\\Node\\Param::\$isOptional#'


### PR DESCRIPTION
This solves problem mentioned in https://github.com/Roave/BetterReflection/pull/606#issuecomment-634989856

This is already optimized in dev-master but it will take some time for me to implement rules that we lose by starting using static reflection and release 0.12.26 so it's a good idea to do this meanwhile.