### PR TITLE
Annotations cleanup

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -14,8 +14,6 @@
         <exclude name="Generic.Files.LineLength.TooLong"/>
         <exclude name="SlevomatCodingStandard.Classes.SuperfluousAbstractClassNaming"/>
         <exclude name="SlevomatCodingStandard.Classes.SuperfluousInterfaceNaming.SuperfluousSuffix"/>
-        <!-- @psalm-return annotations are used -->
-        <exclude name="SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingTraversableTypeHintSpecification"/>
     </rule>
 
     <rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHint">
@@ -39,5 +37,9 @@
     </rule>
     <rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingAnyTypeHint">
         <exclude-pattern>src/Reflection/Adapter/*</exclude-pattern>
+    </rule>
+    <rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingTraversableTypeHintSpecification">
+        <!-- Useless for data providers -->
+        <exclude-pattern>test/unit/</exclude-pattern>
     </rule>
 </ruleset>

--- a/src/NodeCompiler/CompileNodeToValue.php
+++ b/src/NodeCompiler/CompileNodeToValue.php
@@ -24,11 +24,9 @@ class CompileNodeToValue
      *
      * @param Node\Stmt\Expression|Node\Expr $node Node has to be processed by the PhpParser\NodeVisitor\NameResolver
      *
-     * @return bool|int|float|string|array|null
+     * @return scalar|array<scalar>|null
      *
      * @throws Exception\UnableToCompileNode
-     *
-     * @psalm-return scalar|array<scalar>|null
      */
     public function __invoke(Node $node, CompilerContext $context)
     {
@@ -62,11 +60,9 @@ class CompileNodeToValue
     /**
      * Compile constant expressions
      *
-     * @return bool|int|float|string|array|null
+     * @return scalar|array<scalar>|null
      *
      * @throws Exception\UnableToCompileNode
-     *
-     * @psalm-return scalar|array<scalar>|null
      */
     private function compileConstFetch(Node\Expr\ConstFetch $constNode, CompilerContext $context)
     {
@@ -90,12 +86,10 @@ class CompileNodeToValue
     /**
      * Compile class constants
      *
-     * @return bool|int|float|string|array|null
+     * @return scalar|array<scalar>|null
      *
      * @throws IdentifierNotFound
      * @throws Exception\UnableToCompileNode If a referenced constant could not be located on the expected referenced class.
-     *
-     * @psalm-return scalar|array<scalar>|null
      */
     private function compileClassConstFetch(Node\Expr\ClassConstFetch $node, CompilerContext $context)
     {

--- a/src/Reflection/Adapter/ReflectionClass.php
+++ b/src/Reflection/Adapter/ReflectionClass.php
@@ -304,7 +304,7 @@ class ReflectionClass extends CoreReflectionClass
     {
         $traits = $this->betterReflectionClass->getTraits();
 
-        /** @psalm-var array<trait-string> $traitNames */
+        /** @var array<trait-string> $traitNames */
         $traitNames = array_map(static function (BetterReflectionClass $trait) : string {
             return $trait->getName();
         }, $traits);

--- a/src/Reflection/Adapter/ReflectionClassConstant.php
+++ b/src/Reflection/Adapter/ReflectionClassConstant.php
@@ -29,9 +29,7 @@ class ReflectionClassConstant extends CoreReflectionClassConstant
     /**
      * Returns constant value
      *
-     * @return bool|int|float|string|array|null
-     *
-     * @psalm-return scalar|array<scalar>|null
+     * @return scalar|array<scalar>|null
      */
     public function getValue()
     {

--- a/src/Reflection/Adapter/ReflectionObject.php
+++ b/src/Reflection/Adapter/ReflectionObject.php
@@ -277,7 +277,7 @@ class ReflectionObject extends CoreReflectionObject
     {
         $traits = $this->betterReflectionObject->getTraits();
 
-        /** @psalm-var array<trait-string> $traitNames */
+        /** @var array<trait-string> $traitNames */
         $traitNames = array_map(static function (BetterReflectionClass $trait) : string {
             return $trait->getName();
         }, $traits);

--- a/src/Reflection/ReflectionClass.php
+++ b/src/Reflection/ReflectionClass.php
@@ -69,28 +69,16 @@ class ReflectionClass implements Reflection
     /** @var ClassLikeNode */
     private $node;
 
-    /**
-     * @var ReflectionClassConstant[]|null indexed by name, when present
-     * @psalm-var ?array<string, ReflectionClassConstant>
-     */
+    /** @var array<string, ReflectionClassConstant>|null indexed by name, when present */
     private $cachedReflectionConstants;
 
-    /**
-     * @var ReflectionProperty[]|null
-     * @psalm-var ?array<string, ReflectionProperty>
-     */
+    /** @var array<string, ReflectionProperty>|null */
     private $cachedImmediateProperties;
 
-    /**
-     * @var ReflectionProperty[]|null
-     * @psalm-var ?array<string, ReflectionProperty>
-     */
+    /** @var array<string, ReflectionProperty>|null */
     private $cachedProperties;
 
-    /**
-     * @var ReflectionMethod[]|null
-     * @psalm-var ?array<lowercase-string, ReflectionMethod>
-     */
+    /** @var array<lowercase-string, ReflectionMethod>|null */
     private $cachedMethods;
 
     /** @var array<string, string>|null */
@@ -194,7 +182,7 @@ class ReflectionClass implements Reflection
      * Get the "full" name of the class (e.g. for A\B\Foo, this will return
      * "A\B\Foo").
      *
-     * @psalm-return class-string
+     * @return class-string
      */
     public function getName() : string
     {
@@ -339,9 +327,7 @@ class ReflectionClass implements Reflection
      * Methods are not merged via their name as array index, since internal PHP method
      * sorting does not follow `\array_merge()` semantics.
      *
-     * @return ReflectionMethod[] indexed by method name
-     *
-     * @psalm-return array<lowercase-string, ReflectionMethod>
+     * @return array<lowercase-string, ReflectionMethod> indexed by method name
      */
     private function getMethodsIndexedByName() : array
     {
@@ -380,9 +366,7 @@ class ReflectionClass implements Reflection
      * For example if $filter = \ReflectionMethod::IS_PUBLIC | \ReflectionMethod::IS_FINAL
      * the only the final public methods will be returned
      *
-     * @return ReflectionMethod[]
-     *
-     * @psalm-return list<ReflectionMethod>
+     * @return list<ReflectionMethod>
      */
     public function getMethods(?int $filter = null) : array
     {
@@ -472,7 +456,7 @@ class ReflectionClass implements Reflection
      * Get an associative array of only the constants for this specific class (i.e. do not search
      * up parent classes etc.), with keys as constant names and values as constant values.
      *
-     * @psalm-return array<string, scalar|array<scalar>|null>
+     * @return array<string, scalar|array<scalar>|null>
      */
     public function getImmediateConstants() : array
     {
@@ -485,7 +469,7 @@ class ReflectionClass implements Reflection
      * Get an associative array of the defined constants in this class,
      * with keys as constant names and values as constant values.
      *
-     * @psalm-return array<string, scalar|array<scalar>|null>
+     * @return array<string, scalar|array<scalar>|null>
      */
     public function getConstants() : array
     {
@@ -499,9 +483,7 @@ class ReflectionClass implements Reflection
      *
      * Returns null if not specified.
      *
-     * @return bool|int|float|string|array|null
-     *
-     * @psalm-return scalar|array<scalar>|null
+     * @return scalar|array<scalar>|null
      */
     public function getConstant(string $name)
     {
@@ -536,9 +518,7 @@ class ReflectionClass implements Reflection
      * Get an associative array of only the constants for this specific class (i.e. do not search
      * up parent classes etc.), with keys as constant names and values as {@see ReflectionClassConstant} objects.
      *
-     * @return ReflectionClassConstant[] indexed by name
-     *
-     * @psalm-return array<string, ReflectionClassConstant>
+     * @return array<string, ReflectionClassConstant> indexed by name
      */
     public function getImmediateReflectionConstants() : array
     {
@@ -582,9 +562,7 @@ class ReflectionClass implements Reflection
      * Get an associative array of the defined constants in this class,
      * with keys as constant names and values as {@see ReflectionClassConstant} objects.
      *
-     * @return ReflectionClassConstant[] indexed by name
-     *
-     * @psalm-return array<string, ReflectionClassConstant>
+     * @return array<string, ReflectionClassConstant> indexed by name
      */
     public function getReflectionConstants() : array
     {
@@ -651,9 +629,7 @@ class ReflectionClass implements Reflection
      *
      * @see ReflectionClass::getProperties() for the usage of filter
      *
-     * @return ReflectionProperty[]
-     *
-     * @psalm-return array<string, ReflectionProperty>
+     * @return array<string, ReflectionProperty>
      */
     public function getImmediateProperties(?int $filter = null) : array
     {
@@ -704,9 +680,7 @@ class ReflectionClass implements Reflection
      * For example if $filter = \ReflectionProperty::IS_STATIC | \ReflectionProperty::IS_PUBLIC
      * only the static public properties will be returned
      *
-     * @return ReflectionProperty[]
-     *
-     * @psalm-return array<string, ReflectionProperty>
+     * @return array<string, ReflectionProperty>
      */
     public function getProperties(?int $filter = null) : array
     {
@@ -783,7 +757,7 @@ class ReflectionClass implements Reflection
     }
 
     /**
-     * @psalm-return array<string, scalar|array<scalar>|null>
+     * @return array<string, scalar|array<scalar>|null>
      */
     public function getDefaultProperties() : array
     {
@@ -859,9 +833,7 @@ class ReflectionClass implements Reflection
     /**
      * Gets the parent class names.
      *
-     * @return string[] A numerical array with parent class names as the values.
-     *
-     * @psalm-return list<class-string>
+     * @return list<class-string> A numerical array with parent class names as the values.
      */
     public function getParentClassNames() : array
     {
@@ -945,9 +917,7 @@ class ReflectionClass implements Reflection
      * Get the traits used, if any are defined. If this class does not have any
      * defined traits, this will return an empty array.
      *
-     * @return ReflectionClass[]
-     *
-     * @psalm-return list<ReflectionClass>
+     * @return list<ReflectionClass>
      */
     public function getTraits() : array
     {
@@ -1116,10 +1086,8 @@ class ReflectionClass implements Reflection
      *
      * @link https://php.net/manual/en/reflectionclass.getinterfaces.php
      *
-     * @return ReflectionClass[] An associative array of interfaces, with keys as interface names and the array
-     *                           values as {@see ReflectionClass} objects.
-     *
-     * @psalm-return array<string, ReflectionClass>
+     * @return array<string, ReflectionClass> An associative array of interfaces, with keys as interface names and the array
+     *                                        values as {@see ReflectionClass} objects.
      */
     public function getInterfaces() : array
     {
@@ -1135,9 +1103,7 @@ class ReflectionClass implements Reflection
      * Get only the interfaces that this class implements (i.e. do not search
      * up parent classes etc.)
      *
-     * @return ReflectionClass[]
-     *
-     * @psalm-return array<string, ReflectionClass>
+     * @return array<string, ReflectionClass>
      */
     public function getImmediateInterfaces() : array
     {
@@ -1149,9 +1115,7 @@ class ReflectionClass implements Reflection
      *
      * @link https://php.net/manual/en/reflectionclass.getinterfacenames.php
      *
-     * @return string[] A numerical array with interface names as the values.
-     *
-     * @psalm-return list<string>
+     * @return list<string> A numerical array with interface names as the values.
      */
     public function getInterfaceNames() : array
     {
@@ -1273,9 +1237,7 @@ class ReflectionClass implements Reflection
     }
 
     /**
-     * @return ReflectionClass[] indexed by interface name
-     *
-     * @psalm-return array<string, ReflectionClass>
+     * @return array<string, ReflectionClass>
      */
     private function getCurrentClassImplementedInterfacesIndexedByName() : array
     {
@@ -1316,11 +1278,9 @@ class ReflectionClass implements Reflection
     /**
      * This method allows us to retrieve all interfaces parent of the this interface. Do not use on class nodes!
      *
-     * @return ReflectionClass[] parent interfaces of this interface
+     * @return array<string, ReflectionClass> parent interfaces of this interface
      *
      * @throws NotAnInterfaceReflection
-     *
-     * @psalm-return array<string, ReflectionClass>
      */
     private function getInterfacesHierarchy() : array
     {

--- a/src/Reflection/ReflectionClassConstant.php
+++ b/src/Reflection/ReflectionClassConstant.php
@@ -18,10 +18,7 @@ class ReflectionClassConstant
     /** @var bool */
     private $valueWasCached = false;
 
-    /**
-     * @var bool|int|float|string|array<bool|int|float|string>|null const value
-     * @psalm-var scalar|array<scalar>|null
-     */
+    /** @var scalar|array<scalar>|null const value */
     private $value;
 
     /** @var Reflector */
@@ -74,9 +71,7 @@ class ReflectionClassConstant
     /**
      * Returns constant value
      *
-     * @return bool|int|float|string|array|null
-     *
-     * @psalm-return scalar|array<scalar>|null
+     * @return scalar|array<scalar>|null
      */
     public function getValue()
     {

--- a/src/Reflection/ReflectionConstant.php
+++ b/src/Reflection/ReflectionConstant.php
@@ -41,10 +41,7 @@ class ReflectionConstant implements Reflection
     /** @var int|null */
     private $positionInNode;
 
-    /**
-     * @var bool|int|float|string|array<bool|int|float|string>|null const value
-     * @psalm-var scalar|array<scalar>|null
-     */
+    /** @var scalar|array<scalar>|null const value */
     private $value;
 
     /** @var bool */
@@ -213,9 +210,7 @@ class ReflectionConstant implements Reflection
     /**
      * Returns constant value
      *
-     * @return bool|int|float|string|array|null
-     *
-     * @psalm-return scalar|array<scalar>|null
+     * @return scalar|array<scalar>|null
      */
     public function getValue()
     {

--- a/src/Reflection/ReflectionFunctionAbstract.php
+++ b/src/Reflection/ReflectionFunctionAbstract.php
@@ -194,9 +194,7 @@ abstract class ReflectionFunctionAbstract
      * Get an array list of the parameters for this method signature, as an
      * array of ReflectionParameter instances.
      *
-     * @return ReflectionParameter[]
-     *
-     * @psalm-return list<ReflectionParameter>
+     * @return list<ReflectionParameter>
      */
     public function getParameters() : array
     {

--- a/src/Reflection/ReflectionObject.php
+++ b/src/Reflection/ReflectionObject.php
@@ -80,9 +80,7 @@ class ReflectionObject extends ReflectionClass
      *
      * @see ReflectionClass::getProperties() for the usage of $filter
      *
-     * @return ReflectionProperty[]
-     *
-     * @psalm-return array<string, ReflectionProperty>
+     * @return array<string, ReflectionProperty>
      */
     private function getRuntimeProperties(?int $filter = null) : array
     {

--- a/src/Reflection/ReflectionParameter.php
+++ b/src/Reflection/ReflectionParameter.php
@@ -47,10 +47,7 @@ class ReflectionParameter
     /** @var int */
     private $parameterIndex;
 
-    /**
-     * @var bool|int|float|string|array<bool|int|float|string>|null
-     * @psalm-var scalar|array<scalar>|null
-     */
+    /** @var scalar|array<scalar>|null */
     private $defaultValue;
 
     /** @var bool */
@@ -292,11 +289,9 @@ class ReflectionParameter
     /**
      * Get the default value of the parameter.
      *
-     * @return bool|int|float|string|array|null
+     * @return scalar|array<scalar>|null
      *
      * @throws LogicException
-     *
-     * @psalm-return scalar|array<scalar>|null
      */
     public function getDefaultValue()
     {

--- a/src/Reflection/ReflectionProperty.php
+++ b/src/Reflection/ReflectionProperty.php
@@ -250,9 +250,7 @@ class ReflectionProperty
      * Get the default value of the property (as defined before constructor is
      * called, when the property is defined)
      *
-     * @return bool|int|float|string|array|null
-     *
-     * @psalm-return scalar|array<scalar>|null
+     * @return scalar|array<scalar>|null
      */
     public function getDefaultValue()
     {

--- a/src/SourceLocator/Ast/FindReflectionsInTree.php
+++ b/src/SourceLocator/Ast/FindReflectionsInTree.php
@@ -34,14 +34,11 @@ final class FindReflectionsInTree
     /** @var FunctionReflector */
     private $functionReflector;
 
-    /**
-     * @var Closure
-     * @psalm-var Closure(): FunctionReflector
-     */
+    /** @var Closure(): FunctionReflector */
     private $functionReflectorGetter;
 
     /**
-     * @psalm-param Closure(): FunctionReflector $functionReflectorGetter
+     * @param Closure(): FunctionReflector $functionReflectorGetter
      */
     public function __construct(AstConversionStrategy $astConversionStrategy, Closure $functionReflectorGetter)
     {

--- a/src/SourceLocator/SourceStubber/PhpStormStubsSourceStubber.php
+++ b/src/SourceLocator/SourceStubber/PhpStormStubsSourceStubber.php
@@ -286,7 +286,7 @@ final class PhpStormStubsSourceStubber implements SourceStubber
 
                     // Some constants has different values on different systems, some are not actual in stubs
                     if (defined($constantName)) {
-                        /** @psalm-var scalar|scalar[]|null $constantValue */
+                        /** @var scalar|scalar[]|null $constantValue */
                         $constantValue        = constant($constantName);
                         $node->args[1]->value = BuilderHelpers::normalizeValue($constantValue);
                     }

--- a/src/SourceLocator/SourceStubber/ReflectionSourceStubber.php
+++ b/src/SourceLocator/SourceStubber/ReflectionSourceStubber.php
@@ -147,11 +147,11 @@ final class ReflectionSourceStubber implements SourceStubber
     }
 
     /**
-     * @psalm-return ?array{0: scalar|scalar[]|null, 1:string}
+     * @return array{0: scalar|scalar[]|null, 1: string}|null
      */
     private function findConstantData(string $constantName) : ?array
     {
-        /** @psalm-var array<string, array<string, int|string|float|bool|array|resource|null>> $constants */
+        /** @var array<string, array<string, int|string|float|bool|array|resource|null>> $constants */
         $constants = get_defined_constants(true);
 
         foreach ($constants as $constantExtensionName => $extensionConstants) {

--- a/src/SourceLocator/Type/AutoloadSourceLocator.php
+++ b/src/SourceLocator/Type/AutoloadSourceLocator.php
@@ -213,7 +213,7 @@ class AutoloadSourceLocator extends AbstractSourceLocator
             return null;
         }
 
-        /** @psalm-var array<string, array<string, int|string|float|bool|array|resource|null>> $constants */
+        /** @var array<string, array<string, int|string|float|bool|array|resource|null>> $constants */
         $constants = get_defined_constants(true);
 
         if (! array_key_exists($constantName, $constants['user'])) {

--- a/src/SourceLocator/Type/AutoloadSourceLocator/FileReadTrapStreamWrapper.php
+++ b/src/SourceLocator/Type/AutoloadSourceLocator/FileReadTrapStreamWrapper.php
@@ -42,12 +42,12 @@ final class FileReadTrapStreamWrapper
     public static $autoloadLocatedFile;
 
     /**
-     * @param string[] $streamWrapperProtocols
+     * @param callable() : ExecutedMethodReturnType $executeMeWithinStreamWrapperOverride
+     * @param string[]                              $streamWrapperProtocols
      *
      * @return mixed
      *
      * @psalm-template ExecutedMethodReturnType of mixed
-     * @psalm-param callable() : ExecutedMethodReturnType $executeMeWithinStreamWrapperOverride
      * @psalm-return ExecutedMethodReturnType
      */
     public static function withStreamWrapperOverride(

--- a/src/SourceLocator/Type/Composer/Factory/MakeLocatorForComposerJsonAndInstalledJson.php
+++ b/src/SourceLocator/Type/Composer/Factory/MakeLocatorForComposerJsonAndInstalledJson.php
@@ -166,9 +166,7 @@ final class MakeLocatorForComposerJsonAndInstalledJson
     }
 
     /**
-     * @param mixed[] $package
-     *
-     * @psalm-param array{name: string} $package
+     * @param array{name: string} $package
      */
     private function packagePrefixPath(string $trimmedInstallationPath, array $package) : string
     {
@@ -177,11 +175,9 @@ final class MakeLocatorForComposerJsonAndInstalledJson
 
     /**
      * @param array<string, array<int, string>> $paths
-     * @param array<string, array<int, string>> $package
+     * @param array{name: string}               $package $package
      *
      * @return array<string, array<int, string>>
-     *
-     * @psalm-param array{name: string} $package
      */
     private function prefixWithPackagePath(array $paths, string $trimmedInstallationPath, array $package) : array
     {

--- a/src/SourceLocator/Type/Composer/Factory/MakeLocatorForInstalledJson.php
+++ b/src/SourceLocator/Type/Composer/Factory/MakeLocatorForInstalledJson.php
@@ -155,8 +155,7 @@ final class MakeLocatorForInstalledJson
 
     /**
      * @param array{name: string, autoload: array{classmap: array<int, string>, files: array<int, string>, psr-4: array<string, array<int, string>>, psr-0: array<string, array<int, string>>}} $package
-     *
-     * @psalm-param array{name: string} $package
+     * @param array{name: string}                                                                                                                                                               $package
      */
     private function packagePrefixPath(string $trimmedInstallationPath, array $package) : string
     {
@@ -165,11 +164,9 @@ final class MakeLocatorForInstalledJson
 
     /**
      * @param array<int|string, array<string>> $paths
-     * @param array<string, array<string>>     $package
+     * @param array{name: string}              $package
      *
      * @return array<int|string, string|array<string>>
-     *
-     * @psalm-param array{name: string} $package
      */
     private function prefixWithPackagePath(array $paths, string $trimmedInstallationPath, array $package) : array
     {

--- a/src/SourceLocator/Type/Composer/Psr/PsrAutoloaderMapping.php
+++ b/src/SourceLocator/Type/Composer/Psr/PsrAutoloaderMapping.php
@@ -8,9 +8,9 @@ use Roave\BetterReflection\Identifier\Identifier;
 
 interface PsrAutoloaderMapping
 {
-    /** @psalm-return list<string> */
+    /** @return list<string> */
     public function resolvePossibleFilePaths(Identifier $identifier) : array;
 
-    /** @psalm-return list<string> */
+    /** @return list<string> */
     public function directories() : array;
 }

--- a/test/unit/SourceLocator/SourceStubber/PhpStormStubsSourceStubberTest.php
+++ b/test/unit/SourceLocator/SourceStubber/PhpStormStubsSourceStubberTest.php
@@ -429,7 +429,7 @@ class PhpStormStubsSourceStubberTest extends TestCase
     {
         $provider = [];
 
-        /** @psalm-var array<string, array<string, int|string|float|bool|array|resource|null>> $constants */
+        /** @var array<string, array<string, int|string|float|bool|array|resource|null>> $constants */
         $constants = get_defined_constants(true);
 
         foreach ($constants as $extensionName => $extensionConstants) {

--- a/test/unit/SourceLocator/Type/Composer/Factory/MakeLocatorForComposerInstalledJsonTest.php
+++ b/test/unit/SourceLocator/Type/Composer/Factory/MakeLocatorForComposerInstalledJsonTest.php
@@ -37,9 +37,7 @@ class MakeLocatorForComposerInstalledJsonTest extends TestCase
     }
 
     /**
-     * @return array<string, array<int, string|SourceLocator>>
-     *
-     * @psalm-return array<string, array{0: string, 1: SourceLocator}>
+     * @return array<string, array{0: string, 1: SourceLocator}>
      */
     public function expectedLocators() : array
     {

--- a/test/unit/SourceLocator/Type/Composer/Factory/MakeLocatorForComposerJsonAndInstalledJsonTest.php
+++ b/test/unit/SourceLocator/Type/Composer/Factory/MakeLocatorForComposerJsonAndInstalledJsonTest.php
@@ -38,9 +38,7 @@ class MakeLocatorForComposerJsonAndInstalledJsonTest extends TestCase
     }
 
     /**
-     * @return array<string, array<int, string|SourceLocator>>
-     *
-     * @psalm-return array<string, array{0: string, 1: SourceLocator}>
+     * @return array<string, array{0: string, 1: SourceLocator}>
      */
     public function expectedLocators() : array
     {

--- a/test/unit/SourceLocator/Type/Composer/Factory/MakeLocatorForComposerJsonTest.php
+++ b/test/unit/SourceLocator/Type/Composer/Factory/MakeLocatorForComposerJsonTest.php
@@ -37,9 +37,7 @@ class MakeLocatorForComposerJsonTest extends TestCase
     }
 
     /**
-     * @return array<string, array<int, string|SourceLocator>>
-     *
-     * @psalm-return array<string, array{0: string, 1: SourceLocator}>
+     * @return array<string, array{0: string, 1: SourceLocator}>
      */
     public function expectedLocators() : array
     {

--- a/test/unit/SourceLocator/Type/PhpInternalSourceLocatorTest.php
+++ b/test/unit/SourceLocator/Type/PhpInternalSourceLocatorTest.php
@@ -170,7 +170,7 @@ class PhpInternalSourceLocatorTest extends TestCase
      */
     public function internalConstantsProvider() : array
     {
-        /** @psalm-var array<string, array<string, int|string|float|bool|array|resource|null>> $allSymbols */
+        /** @var array<string, array<string, int|string|float|bool|array|resource|null>> $allSymbols */
         $allSymbols = get_defined_constants(true);
 
         return array_map(


### PR DESCRIPTION
PHPCS (thanks to Slevomat CS), PHPStan and Psalm can parse standard annotations even with extended syntax so I think we can use less specific `@psalm` annotations.