### PR TITLE
Fixed ReflectionClass::getReflectionConstant() in adapter for non-existent constant

### DIFF
--- a/src/Reflection/Adapter/ReflectionClass.php
+++ b/src/Reflection/Adapter/ReflectionClass.php
@@ -249,9 +249,12 @@ class ReflectionClass extends CoreReflectionClass
      */
     public function getReflectionConstant($name)
     {
-        return new ReflectionClassConstant(
-            $this->betterReflectionClass->getReflectionConstant($name),
-        );
+        $betterReflectionConstant = $this->betterReflectionClass->getReflectionConstant($name);
+        if ($betterReflectionConstant === null) {
+            return false;
+        }
+
+        return new ReflectionClassConstant($betterReflectionConstant);
     }
 
     /**

--- a/test/unit/Reflection/Adapter/ReflectionClassTest.php
+++ b/test/unit/Reflection/Adapter/ReflectionClassTest.php
@@ -498,4 +498,17 @@ class ReflectionClassTest extends TestCase
 
         self::assertNull($reflectionClassAdapter->isInstance('string'));
     }
+
+    public function testGetReflectionConstantReturnsFalseWhenConstantDoesNotExist() : void
+    {
+        $betterReflectionClass = $this->createMock(BetterReflectionClass::class);
+        $betterReflectionClass
+            ->method('getReflectionConstant')
+            ->with('FOO')
+            ->willReturn(null);
+
+        $reflectionClassAdapter = new ReflectionClassAdapter($betterReflectionClass);
+
+        self::assertFalse($reflectionClassAdapter->getReflectionConstant('FOO'));
+    }
 }


### PR DESCRIPTION
Fixes #625 