### PR TITLE
FileHelper - fix normalizing paths with protocol:// on Windows

### DIFF
--- a/src/Util/FileHelper.php
+++ b/src/Util/FileHelper.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Roave\BetterReflection\Util;
 
+use function preg_match;
 use function str_replace;
 use const DIRECTORY_SEPARATOR;
 
@@ -14,12 +15,19 @@ class FileHelper
         return str_replace('\\', '/', $path);
     }
 
-    public static function normalizeSystemPath(string $path) : string
+    public static function normalizeSystemPath(string $originalPath) : string
     {
-        $path = self::normalizeWindowsPath($path);
+        $path = self::normalizeWindowsPath($originalPath);
+        preg_match('~^([a-z]+)\\:\\/\\/(.+)~', $path, $matches);
+        $scheme = null;
+        if ($matches !== []) {
+            [, $scheme, $path] = $matches;
+        }
 
-        return DIRECTORY_SEPARATOR === '\\'
-            ? str_replace('/', '\\', $path)
-            : $path;
+        return ($scheme !== null ? $scheme . '://' : '') . (
+            DIRECTORY_SEPARATOR === '\\'
+                ? str_replace('/', '\\', $path)
+                : $path
+        );
     }
 }

--- a/test/unit/Util/FileHelperTest.php
+++ b/test/unit/Util/FileHelperTest.php
@@ -12,7 +12,7 @@ use const DIRECTORY_SEPARATOR;
 /**
  * @covers \Roave\BetterReflection\Util\FileHelper
  */
-class FindHelperTest extends TestCase
+class FileHelperTest extends TestCase
 {
     public function testNormalizeWindowsPath() : void
     {

--- a/test/unit/Util/FileHelperTest.php
+++ b/test/unit/Util/FileHelperTest.php
@@ -26,4 +26,17 @@ class FileHelperTest extends TestCase
 
         self::assertSame(strtr($path, '\\/', DIRECTORY_SEPARATOR . DIRECTORY_SEPARATOR), FileHelper::normalizeSystemPath($path));
     }
+
+    public function testSystemWindowsPathWithProtocol() : void
+    {
+        if (DIRECTORY_SEPARATOR !== '\\') {
+            $this->markTestSkipped('Test runs only on Windows');
+        }
+
+        $path = 'phar://C:/Users/ondrej/phpstan.phar/src/TrinaryLogic.php';
+        self::assertSame(
+            'phar://C:\Users\ondrej\phpstan.phar\src\TrinaryLogic.php',
+            FileHelper::normalizeSystemPath($path),
+        );
+    }
 }


### PR DESCRIPTION
Previously it generated path with `phar:\\...`.