### PR TITLE
Fix name of CalculateReflectionColumn class

### DIFF
--- a/src/Reflection/ReflectionClass.php
+++ b/src/Reflection/ReflectionClass.php
@@ -32,7 +32,7 @@ use Roave\BetterReflection\Reflection\StringCast\ReflectionClassStringCast;
 use Roave\BetterReflection\Reflector\Exception\IdentifierNotFound;
 use Roave\BetterReflection\Reflector\Reflector;
 use Roave\BetterReflection\SourceLocator\Located\LocatedSource;
-use Roave\BetterReflection\Util\CalculateReflectionColum;
+use Roave\BetterReflection\Util\CalculateReflectionColumn;
 use Roave\BetterReflection\Util\GetFirstDocComment;
 use Traversable;
 use function array_combine;
@@ -781,12 +781,12 @@ class ReflectionClass implements Reflection
 
     public function getStartColumn() : int
     {
-        return CalculateReflectionColum::getStartColumn($this->locatedSource->getSource(), $this->node);
+        return CalculateReflectionColumn::getStartColumn($this->locatedSource->getSource(), $this->node);
     }
 
     public function getEndColumn() : int
     {
-        return CalculateReflectionColum::getEndColumn($this->locatedSource->getSource(), $this->node);
+        return CalculateReflectionColumn::getEndColumn($this->locatedSource->getSource(), $this->node);
     }
 
     /**

--- a/src/Reflection/ReflectionClassConstant.php
+++ b/src/Reflection/ReflectionClassConstant.php
@@ -10,7 +10,7 @@ use Roave\BetterReflection\NodeCompiler\CompileNodeToValue;
 use Roave\BetterReflection\NodeCompiler\CompilerContext;
 use Roave\BetterReflection\Reflection\StringCast\ReflectionClassConstantStringCast;
 use Roave\BetterReflection\Reflector\Reflector;
-use Roave\BetterReflection\Util\CalculateReflectionColum;
+use Roave\BetterReflection\Util\CalculateReflectionColumn;
 use Roave\BetterReflection\Util\GetFirstDocComment;
 
 class ReflectionClassConstant
@@ -139,12 +139,12 @@ class ReflectionClassConstant
 
     public function getStartColumn() : int
     {
-        return CalculateReflectionColum::getStartColumn($this->owner->getLocatedSource()->getSource(), $this->node);
+        return CalculateReflectionColumn::getStartColumn($this->owner->getLocatedSource()->getSource(), $this->node);
     }
 
     public function getEndColumn() : int
     {
-        return CalculateReflectionColum::getEndColumn($this->owner->getLocatedSource()->getSource(), $this->node);
+        return CalculateReflectionColumn::getEndColumn($this->owner->getLocatedSource()->getSource(), $this->node);
     }
 
     /**

--- a/src/Reflection/ReflectionConstant.php
+++ b/src/Reflection/ReflectionConstant.php
@@ -14,7 +14,7 @@ use Roave\BetterReflection\Reflection\StringCast\ReflectionConstantStringCast;
 use Roave\BetterReflection\Reflector\Exception\IdentifierNotFound;
 use Roave\BetterReflection\Reflector\Reflector;
 use Roave\BetterReflection\SourceLocator\Located\LocatedSource;
-use Roave\BetterReflection\Util\CalculateReflectionColum;
+use Roave\BetterReflection\Util\CalculateReflectionColumn;
 use Roave\BetterReflection\Util\ConstantNodeChecker;
 use Roave\BetterReflection\Util\GetFirstDocComment;
 use function array_slice;
@@ -256,12 +256,12 @@ class ReflectionConstant implements Reflection
 
     public function getStartColumn() : int
     {
-        return CalculateReflectionColum::getStartColumn($this->locatedSource->getSource(), $this->node);
+        return CalculateReflectionColumn::getStartColumn($this->locatedSource->getSource(), $this->node);
     }
 
     public function getEndColumn() : int
     {
-        return CalculateReflectionColum::getEndColumn($this->locatedSource->getSource(), $this->node);
+        return CalculateReflectionColumn::getEndColumn($this->locatedSource->getSource(), $this->node);
     }
 
     /**

--- a/src/Reflection/ReflectionFunctionAbstract.php
+++ b/src/Reflection/ReflectionFunctionAbstract.php
@@ -28,7 +28,7 @@ use Roave\BetterReflection\SourceLocator\Ast\Exception\ParseToAstFailure;
 use Roave\BetterReflection\SourceLocator\Located\LocatedSource;
 use Roave\BetterReflection\SourceLocator\Type\ClosureSourceLocator;
 use Roave\BetterReflection\TypesFinder\FindReturnType;
-use Roave\BetterReflection\Util\CalculateReflectionColum;
+use Roave\BetterReflection\Util\CalculateReflectionColumn;
 use Roave\BetterReflection\Util\GetFirstDocComment;
 use Roave\BetterReflection\Util\Visitor\ReturnNodeVisitor;
 use function array_filter;
@@ -365,12 +365,12 @@ abstract class ReflectionFunctionAbstract
 
     public function getStartColumn() : int
     {
-        return CalculateReflectionColum::getStartColumn($this->locatedSource->getSource(), $this->getNode());
+        return CalculateReflectionColumn::getStartColumn($this->locatedSource->getSource(), $this->getNode());
     }
 
     public function getEndColumn() : int
     {
-        return CalculateReflectionColum::getEndColumn($this->locatedSource->getSource(), $this->getNode());
+        return CalculateReflectionColumn::getEndColumn($this->locatedSource->getSource(), $this->getNode());
     }
 
     /**

--- a/src/Reflection/ReflectionParameter.php
+++ b/src/Reflection/ReflectionParameter.php
@@ -21,7 +21,7 @@ use Roave\BetterReflection\Reflection\StringCast\ReflectionParameterStringCast;
 use Roave\BetterReflection\Reflector\ClassReflector;
 use Roave\BetterReflection\Reflector\Reflector;
 use Roave\BetterReflection\TypesFinder\FindParameterType;
-use Roave\BetterReflection\Util\CalculateReflectionColum;
+use Roave\BetterReflection\Util\CalculateReflectionColumn;
 use RuntimeException;
 use function assert;
 use function count;
@@ -523,12 +523,12 @@ class ReflectionParameter
 
     public function getStartColumn() : int
     {
-        return CalculateReflectionColum::getStartColumn($this->function->getLocatedSource()->getSource(), $this->node);
+        return CalculateReflectionColumn::getStartColumn($this->function->getLocatedSource()->getSource(), $this->node);
     }
 
     public function getEndColumn() : int
     {
-        return CalculateReflectionColum::getEndColumn($this->function->getLocatedSource()->getSource(), $this->node);
+        return CalculateReflectionColumn::getEndColumn($this->function->getLocatedSource()->getSource(), $this->node);
     }
 
     public function getAst() : ParamNode

--- a/src/Reflection/ReflectionProperty.php
+++ b/src/Reflection/ReflectionProperty.php
@@ -25,7 +25,7 @@ use Roave\BetterReflection\Reflection\StringCast\ReflectionPropertyStringCast;
 use Roave\BetterReflection\Reflector\Exception\IdentifierNotFound;
 use Roave\BetterReflection\Reflector\Reflector;
 use Roave\BetterReflection\TypesFinder\FindPropertyType;
-use Roave\BetterReflection\Util\CalculateReflectionColum;
+use Roave\BetterReflection\Util\CalculateReflectionColumn;
 use Roave\BetterReflection\Util\GetFirstDocComment;
 use function class_exists;
 use function func_num_args;
@@ -274,12 +274,12 @@ class ReflectionProperty
 
     public function getStartColumn() : int
     {
-        return CalculateReflectionColum::getStartColumn($this->declaringClass->getLocatedSource()->getSource(), $this->node);
+        return CalculateReflectionColumn::getStartColumn($this->declaringClass->getLocatedSource()->getSource(), $this->node);
     }
 
     public function getEndColumn() : int
     {
-        return CalculateReflectionColum::getEndColumn($this->declaringClass->getLocatedSource()->getSource(), $this->node);
+        return CalculateReflectionColumn::getEndColumn($this->declaringClass->getLocatedSource()->getSource(), $this->node);
     }
 
     public function getAst() : PropertyNode

--- a/src/Util/CalculateReflectionColumn.php
+++ b/src/Util/CalculateReflectionColumn.php
@@ -13,7 +13,7 @@ use function strrpos;
 /**
  * @internal
  */
-final class CalculateReflectionColum
+final class CalculateReflectionColumn
 {
     /**
      * @throws InvalidNodePosition

--- a/test/unit/Util/CalculateReflectionColumnTest.php
+++ b/test/unit/Util/CalculateReflectionColumnTest.php
@@ -6,12 +6,12 @@ namespace Roave\BetterReflectionTest\Util;
 
 use PhpParser\Node;
 use PHPUnit\Framework\TestCase;
-use Roave\BetterReflection\Util\CalculateReflectionColum;
+use Roave\BetterReflection\Util\CalculateReflectionColumn;
 use Roave\BetterReflection\Util\Exception\InvalidNodePosition;
 use Roave\BetterReflection\Util\Exception\NoNodePosition;
 
 /**
- * @covers \Roave\BetterReflection\Util\CalculateReflectionColum
+ * @covers \Roave\BetterReflection\Util\CalculateReflectionColumn
  */
 class CalculateReflectionColumnTest extends TestCase
 {
@@ -28,7 +28,7 @@ class CalculateReflectionColumnTest extends TestCase
             ->method('getStartFilePos')
             ->willReturn(10);
 
-        self::assertSame(5, CalculateReflectionColum::getStartColumn($source, $node));
+        self::assertSame(5, CalculateReflectionColumn::getStartColumn($source, $node));
     }
 
     public function testGetStartColumnIfAtTheBeginningOfLine() : void
@@ -44,7 +44,7 @@ class CalculateReflectionColumnTest extends TestCase
             ->method('getStartFilePos')
             ->willReturn(6);
 
-        self::assertSame(1, CalculateReflectionColum::getStartColumn($source, $node));
+        self::assertSame(1, CalculateReflectionColumn::getStartColumn($source, $node));
     }
 
     public function testGetStartColumnIfOneLineSource() : void
@@ -60,7 +60,7 @@ class CalculateReflectionColumnTest extends TestCase
             ->method('getStartFilePos')
             ->willReturn(6);
 
-        self::assertSame(7, CalculateReflectionColum::getStartColumn($source, $node));
+        self::assertSame(7, CalculateReflectionColumn::getStartColumn($source, $node));
     }
 
     public function testGetStartColumnThrowsExceptionIfInvalidPosition() : void
@@ -76,7 +76,7 @@ class CalculateReflectionColumnTest extends TestCase
             ->method('getStartFilePos')
             ->willReturn(10000);
 
-        CalculateReflectionColum::getStartColumn('', $node);
+        CalculateReflectionColumn::getStartColumn('', $node);
     }
 
     public function testGetStartColumnThrowsExceptionIfNoPosition() : void
@@ -89,7 +89,7 @@ class CalculateReflectionColumnTest extends TestCase
             ->with('startFilePos')
             ->willReturn(false);
 
-        CalculateReflectionColum::getStartColumn('', $node);
+        CalculateReflectionColumn::getStartColumn('', $node);
     }
 
     public function testGetEndColumn() : void
@@ -105,7 +105,7 @@ class CalculateReflectionColumnTest extends TestCase
             ->method('getEndFilePos')
             ->willReturn(21);
 
-        self::assertSame(16, CalculateReflectionColum::getEndColumn($source, $node));
+        self::assertSame(16, CalculateReflectionColumn::getEndColumn($source, $node));
     }
 
     public function testGetEndColumnIfAtTheEndOfLine() : void
@@ -121,7 +121,7 @@ class CalculateReflectionColumnTest extends TestCase
             ->method('getEndFilePos')
             ->willReturn(17);
 
-        self::assertSame(12, CalculateReflectionColum::getEndColumn($source, $node));
+        self::assertSame(12, CalculateReflectionColumn::getEndColumn($source, $node));
     }
 
     public function testGetEndColumnIfOneLineSource() : void
@@ -137,7 +137,7 @@ class CalculateReflectionColumnTest extends TestCase
             ->method('getEndFilePos')
             ->willReturn(17);
 
-        self::assertSame(18, CalculateReflectionColum::getEndColumn($source, $node));
+        self::assertSame(18, CalculateReflectionColumn::getEndColumn($source, $node));
     }
 
     public function testGetEndColumnThrowsExceptionIfInvalidPosition() : void
@@ -153,7 +153,7 @@ class CalculateReflectionColumnTest extends TestCase
             ->method('getEndFilePos')
             ->willReturn(10000);
 
-        CalculateReflectionColum::getEndColumn('', $node);
+        CalculateReflectionColumn::getEndColumn('', $node);
     }
 
     public function testGetEndColumnThrowsExceptionIfNoPosition() : void
@@ -166,6 +166,6 @@ class CalculateReflectionColumnTest extends TestCase
             ->with('endFilePos')
             ->willReturn(false);
 
-        CalculateReflectionColum::getEndColumn('', $node);
+        CalculateReflectionColumn::getEndColumn('', $node);
     }
 }


### PR DESCRIPTION
There is already `CalculateReflectionColumnTest` (spelled correctly) that should provide test coverage for this typo fix of the class name.