### PR TITLE
Fixed `ReflectionClass::getImmediateInterfaces()` to only return immediately implemented interfaces

### DIFF
--- a/src/Reflection/ReflectionClass.php
+++ b/src/Reflection/ReflectionClass.php
@@ -1089,7 +1089,28 @@ class ReflectionClass implements Reflection
      */
     public function getImmediateInterfaces() : array
     {
-        return $this->getCurrentClassImplementedInterfacesIndexedByName();
+        if ($this->isTrait()) {
+            return [];
+        }
+
+        assert($this->node instanceof ClassNode || $this->node instanceof InterfaceNode);
+
+        $nodes = $this->node instanceof InterfaceNode ? $this->node->extends : $this->node->implements;
+
+        return array_combine(
+            array_map(
+                static function (Node\Name $interfaceName) : string {
+                    return $interfaceName->toString();
+                },
+                $nodes,
+            ),
+            array_map(
+                function (Node\Name $interfaceName) : ReflectionClass {
+                    return $this->reflectClassForNamedNode($interfaceName);
+                },
+                $nodes,
+            ),
+        );
     }
 
     /**

--- a/test/unit/Fixture/PrototypeTree.php
+++ b/test/unit/Fixture/PrototypeTree.php
@@ -138,7 +138,8 @@ namespace Foom {
 namespace Boom {
     interface Foo {}
     interface Bar {}
+    interface Boo extends Bar {}
 
     class A implements Foo {}
-    class B extends A implements Bar {}
+    class B extends A implements Boo {}
 }

--- a/test/unit/Reflection/ReflectionClassTest.php
+++ b/test/unit/Reflection/ReflectionClassTest.php
@@ -1465,8 +1465,8 @@ PHP;
         $interfaces = $reflector->reflect('Boom\B')->getImmediateInterfaces();
 
         self::assertCount(1, $interfaces);
-        self::assertInstanceOf(ReflectionClass::class, $interfaces['Boom\Bar']);
-        self::assertSame('Boom\Bar', $interfaces['Boom\Bar']->getName());
+        self::assertInstanceOf(ReflectionClass::class, $interfaces['Boom\Boo']);
+        self::assertSame('Boom\Boo', $interfaces['Boom\Boo']->getName());
     }
 
     public function testGetImmediateInterfacesDoesNotIncludeCurrentInterface() : void
@@ -1493,7 +1493,7 @@ PHP;
         sort($dInterfaces);
 
         self::assertSame(['B'], $cInterfaces);
-        self::assertSame(['A', 'B', 'C'], $dInterfaces);
+        self::assertSame(['A', 'C'], $dInterfaces);
     }
 
     public function testReflectedTraitHasNoInterfaces() : void


### PR DESCRIPTION
Fixes #643 