### PR TITLE
Fixed `Reflection/ReflectionFunctionAbstract::isGenerator()` for functions with `yield from`

### DIFF
--- a/src/Reflection/ReflectionFunctionAbstract.php
+++ b/src/Reflection/ReflectionFunctionAbstract.php
@@ -10,6 +10,7 @@ use phpDocumentor\Reflection\Type;
 use PhpParser\Comment\Doc;
 use PhpParser\Node;
 use PhpParser\Node\Expr\Yield_ as YieldNode;
+use PhpParser\Node\Expr\YieldFrom as YieldFromNode;
 use PhpParser\Node\NullableType;
 use PhpParser\Node\Param as ParamNode;
 use PhpParser\Node\Stmt\Namespace_ as NamespaceNode;
@@ -310,6 +311,10 @@ abstract class ReflectionFunctionAbstract
     private function nodeIsOrContainsYield(Node $node) : bool
     {
         if ($node instanceof YieldNode) {
+            return true;
+        }
+
+        if ($node instanceof YieldFromNode) {
             return true;
         }
 

--- a/test/unit/Reflection/ReflectionFunctionAbstractTest.php
+++ b/test/unit/Reflection/ReflectionFunctionAbstractTest.php
@@ -189,6 +189,7 @@ class ReflectionFunctionAbstractTest extends TestCase
             ['<?php function foo() { func(yield $foo); }', true],
             ['<?php function foo() { $foo->func(yield $foo); }', true],
             ['<?php function foo() { new Foo(yield $foo); }', true],
+            ['<?php function foo() { yield from []; }', true],
         ];
     }
 


### PR DESCRIPTION
Fixes #644 