### PR TITLE
Corrected trait analysis: method ordering, abstract trait methods do not override concrete ones, method aliases now recognized

### DIFF
--- a/src/Reflection/ReflectionClass.php
+++ b/src/Reflection/ReflectionClass.php
@@ -81,6 +81,8 @@ class ReflectionClass implements Reflection
     /** @var array<string, string>|null */
     private ?array $cachedTraitPrecedences = null;
 
+    private ?ReflectionClass $cachedParentClass = null;
+
     private function __construct()
     {
     }
@@ -846,15 +848,19 @@ class ReflectionClass implements Reflection
             return null;
         }
 
-        $parent = $this->reflector->reflect($this->node->extends->toString());
-        // @TODO use actual `ClassReflector` or `FunctionReflector`?
-        assert($parent instanceof self);
+        if ($this->cachedParentClass === null) {
+            $parent = $this->reflector->reflect($this->node->extends->toString());
+            // @TODO use actual `ClassReflector` or `FunctionReflector`?
+            assert($parent instanceof self);
 
-        if ($parent->isInterface() || $parent->isTrait()) {
-            throw NotAClassReflection::fromReflectionClass($parent);
+            $this->cachedParentClass = $parent;
         }
 
-        return $parent;
+        if ($this->cachedParentClass->isInterface() || $this->cachedParentClass->isTrait()) {
+            throw NotAClassReflection::fromReflectionClass($this->cachedParentClass);
+        }
+
+        return $this->cachedParentClass;
     }
 
     /**

--- a/test/unit/Fixture/MethodsOrder.php
+++ b/test/unit/Fixture/MethodsOrder.php
@@ -2,34 +2,79 @@
 
 namespace Roave\BetterReflectionTest\Fixture;
 
-interface MethodsOrderInterface
+interface MethodsOrderParentInterface
 {
-    public function forth();
+    public function f10();
 }
 
-class MethodsOrderParent
+interface MethodsOrderInterface extends MethodsOrderParentInterface
 {
-    public function third()
+    public function f9();
+}
+
+interface InterfaceForMethodsOrderParent
+{
+    public function f6();
+}
+
+trait TraitForMethodsOrderParent
+{
+    public function f5()
+    {
+        // Not used
+    }
+}
+
+abstract class MethodsOrderParent implements InterfaceForMethodsOrderParent
+{
+    use TraitForMethodsOrderParent;
+
+    public function f3()
     {
     }
 
-    public function first()
+    public function f1()
+    {
+        // Not used
+    }
+
+    public function f4()
+    {
+    }
+}
+
+trait TraitForMethodsOrderTrait
+{
+    public function f8()
     {
     }
 }
 
 trait MethodsOrderTrait
 {
-    public function second()
+    use TraitForMethodsOrderTrait;
+
+    public function f2()
+    {
+        // Not used
+    }
+
+    public function f7()
     {
     }
+
+    abstract function f4(); // Not used
 }
 
 abstract class MethodsOrder extends MethodsOrderParent implements MethodsOrderInterface
 {
     use MethodsOrderTrait;
 
-    public function first()
+    public function f1()
+    {
+    }
+
+    public function f2()
     {
     }
 }

--- a/test/unit/Fixture/TraitFixture.php
+++ b/test/unit/Fixture/TraitFixture.php
@@ -31,12 +31,23 @@ trait TraitFixtureTraitC
     public function b() {}
     public function c() {}
 }
+trait TraitFixtureTraitC2
+{
+    public function d() {}
+}
+trait TraitFixtureTraitC3
+{
+    use TraitFixtureTraitC2;
+}
 class TraitFixtureC
 {
     use TraitFixtureTraitC {
         a as protected a_protected;
         b as b_renamed;
         c as private;
+    }
+    use TraitFixtureTraitC3 {
+        d as d_renamed;
     }
 }
 

--- a/test/unit/Fixture/TraitWithAbstractMethod.php
+++ b/test/unit/Fixture/TraitWithAbstractMethod.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Roave\BetterReflectionTest\Fixture;
+
+abstract class AbstractClassImplementingMethodFromTrait
+{
+    public function foo(): void
+    {
+    }
+
+    public function bar(): void
+    {
+    }
+}
+
+trait TraitWithAbstractMethod
+{
+    abstract public function foo(): void;
+
+    public function bar(): void
+    {
+    }
+}
+
+trait TraitWithBoo
+{
+    public function boo(): void
+    {
+    }
+}
+
+class ClassUsingTraitWithAbstractMethod extends AbstractClassImplementingMethodFromTrait
+{
+    use TraitWithAbstractMethod;
+
+    public function boo(): void
+    {
+    }
+}
+
+class ClassExtendingNonAbstractClass extends ClassUsingTraitWithAbstractMethod
+{
+    use TraitWithBoo;
+}
+
+trait AbstractTrait
+{
+    abstract public function bar(): void;
+}
+
+trait ImplementationTrait
+{
+    public function bar(): void
+    {
+    }
+}
+
+class ClassUsesTwoTraitsWithSameMethodNameOneIsAbstract
+{
+    use AbstractTrait;
+    use ImplementationTrait;
+}

--- a/test/unit/Reflection/ReflectionClassTest.php
+++ b/test/unit/Reflection/ReflectionClassTest.php
@@ -45,7 +45,10 @@ use Roave\BetterReflectionTest\ClassWithInterfacesExtendingInterfaces;
 use Roave\BetterReflectionTest\ClassWithInterfacesOther;
 use Roave\BetterReflectionTest\Fixture;
 use Roave\BetterReflectionTest\Fixture\AbstractClass;
+use Roave\BetterReflectionTest\Fixture\ClassExtendingNonAbstractClass;
 use Roave\BetterReflectionTest\Fixture\ClassForHinting;
+use Roave\BetterReflectionTest\Fixture\ClassUsesTwoTraitsWithSameMethodNameOneIsAbstract;
+use Roave\BetterReflectionTest\Fixture\ClassUsingTraitWithAbstractMethod;
 use Roave\BetterReflectionTest\Fixture\ClassWithCaseInsensitiveMethods;
 use Roave\BetterReflectionTest\Fixture\ClassWithMissingParent;
 use Roave\BetterReflectionTest\Fixture\ExampleClass;
@@ -270,10 +273,16 @@ class ReflectionClassTest extends TestCase
         }, $classInfo->getMethods());
 
         $expectedMethodNames = [
-            'first',
-            'second',
-            'third',
-            'forth',
+            'f1',
+            'f2',
+            'f3',
+            'f4',
+            'f5',
+            'f6',
+            'f7',
+            'f8',
+            'f9',
+            'f10',
         ];
 
         self::assertSame($expectedMethodNames, $actualMethodNames);
@@ -925,6 +934,60 @@ PHP;
 
         self::assertTrue($classInfo->hasMethod('foo'));
         self::assertSame('TraitFixtureTraitA', $classInfo->getMethod('foo')->getDeclaringClass()->getName());
+    }
+
+    public function declaringClassProvider() : array
+    {
+        return [
+            [
+                ClassUsingTraitWithAbstractMethod::class,
+                'foo',
+                'AbstractClassImplementingMethodFromTrait',
+                'AbstractClassImplementingMethodFromTrait',
+            ],
+            [
+                ClassUsingTraitWithAbstractMethod::class,
+                'bar',
+                'TraitWithAbstractMethod',
+                'ClassUsingTraitWithAbstractMethod',
+            ],
+            [
+                ClassExtendingNonAbstractClass::class,
+                'boo',
+                'TraitWithBoo',
+                'ClassExtendingNonAbstractClass',
+            ],
+            [
+                ClassUsesTwoTraitsWithSameMethodNameOneIsAbstract::class,
+                'bar',
+                'ImplementationTrait',
+                'ClassUsesTwoTraitsWithSameMethodNameOneIsAbstract',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider declaringClassProvider
+     */
+    public function testGetDeclaringClassWithTraitAndParent(
+        string $className,
+        string $methodName,
+        string $declaringClassShortName,
+        string $implementingClassShortName
+    ) : void {
+        $reflector = new ClassReflector(new SingleFileSourceLocator(
+            __DIR__ . '/../Fixture/TraitWithAbstractMethod.php',
+            $this->astLocator,
+        ));
+
+        $classInfo = $reflector->reflect($className);
+
+        self::assertTrue($classInfo->hasMethod($methodName));
+
+        $fooMethodInfo = $classInfo->getMethod($methodName);
+
+        self::assertSame($declaringClassShortName, $fooMethodInfo->getDeclaringClass()->getShortName());
+        self::assertSame($implementingClassShortName, $fooMethodInfo->getImplementingClass()->getShortName());
     }
 
     public function testGetTraitsReturnsEmptyArrayWhenNoTraitsUsed() : void

--- a/test/unit/Reflection/ReflectionClassTest.php
+++ b/test/unit/Reflection/ReflectionClassTest.php
@@ -1028,6 +1028,7 @@ PHP;
         self::assertSame([
             'a_protected' => 'TraitFixtureTraitC::a',
             'b_renamed' => 'TraitFixtureTraitC::b',
+            'd_renamed' => 'TraitFixtureTraitC3::d',
         ], $classInfo->getTraitAliases());
     }
 
@@ -1040,14 +1041,14 @@ PHP;
 
         $classInfo = $reflector->reflect('TraitFixtureC');
 
-        self::assertFalse($classInfo->hasMethod('a'));
+        self::assertTrue($classInfo->hasMethod('a'));
         self::assertTrue($classInfo->hasMethod('a_protected'));
 
         $aProtected = $classInfo->getMethod('a_protected');
 
         self::assertSame('TraitFixtureTraitC', $aProtected->getDeclaringClass()->getName());
 
-        self::assertFalse($classInfo->hasMethod('b'));
+        self::assertTrue($classInfo->hasMethod('b'));
         self::assertTrue($classInfo->hasMethod('b_renamed'));
 
         $bRenamed = $classInfo->getMethod('b_renamed');
@@ -1060,6 +1061,12 @@ PHP;
 
         self::assertSame('c', $c->getName());
         self::assertSame('TraitFixtureTraitC', $c->getDeclaringClass()->getName());
+
+        self::assertTrue($classInfo->hasMethod('d'));
+        self::assertTrue($classInfo->hasMethod('d_renamed'));
+
+        self::assertSame('TraitFixtureTraitC2', $classInfo->getMethod('d')->getDeclaringClass()->getName());
+        self::assertSame('TraitFixtureTraitC2', $classInfo->getMethod('d_renamed')->getDeclaringClass()->getName());
     }
 
     public function testMethodsFromTraitsWithConflicts() : void
@@ -1082,7 +1089,7 @@ PHP;
         self::assertSame('TraitFixtureTraitD1', $foo->getDeclaringClass()->getName());
         self::assertSame('TraitFixtureD', $foo->getImplementingClass()->getName());
 
-        self::assertFalse($classInfo->hasMethod('hoo'));
+        self::assertTrue($classInfo->hasMethod('hoo'));
         self::assertTrue($classInfo->hasMethod('hooFirstAlias'));
         self::assertTrue($classInfo->hasMethod('hooSecondAlias'));
 


### PR DESCRIPTION
Fixes #647 
Fixes #659

Also fixes methods order: https://3v4l.org/LiTi4