### PR TITLE
`ReflectionMethod::getPrototype()` should report implementing vlass prototype, and skip constructors

### DIFF
--- a/src/Reflection/ReflectionMethod.php
+++ b/src/Reflection/ReflectionMethod.php
@@ -103,7 +103,7 @@ class ReflectionMethod extends ReflectionFunctionAbstract
      */
     public function getPrototype() : self
     {
-        $currentClass = $this->getDeclaringClass();
+        $currentClass = $this->getImplementingClass();
 
         while ($currentClass) {
             foreach ($currentClass->getImmediateInterfaces() as $interface) {
@@ -121,6 +121,10 @@ class ReflectionMethod extends ReflectionFunctionAbstract
             $prototype = $currentClass->getMethod($this->getName())->findPrototype();
 
             if ($prototype !== null) {
+                if ($this->isConstructor() && ! $prototype->isAbstract()) {
+                    break;
+                }
+
                 return $prototype;
             }
         }

--- a/test/unit/Fixture/PrototypeTree.php
+++ b/test/unit/Fixture/PrototypeTree.php
@@ -143,3 +143,50 @@ namespace Boom {
     class A implements Foo {}
     class B extends A implements Boo {}
 }
+
+namespace Construct {
+    class Foo
+    {
+        public function __construct(int $i)
+        {
+        }
+    }
+
+    class Bar extends Foo
+    {
+        public function __construct(string $s)
+        {
+        }
+    }
+
+    abstract class Lorem
+    {
+        abstract public function __construct(int $i);
+    }
+
+    class Ipsum extends Lorem
+    {
+        public function __construct(int $i)
+        {
+        }
+    }
+}
+
+namespace Traits {
+    interface FooInterface
+    {
+        public function doFoo(): void;
+    }
+
+    trait FooTrait
+    {
+        public function doFoo(): void
+        {
+        }
+    }
+
+    class Foo implements FooInterface
+    {
+        use FooTrait;
+    }
+}

--- a/test/unit/Reflection/ReflectionMethodTest.php
+++ b/test/unit/Reflection/ReflectionMethodTest.php
@@ -315,6 +315,9 @@ class ReflectionMethodTest extends TestCase
             ['Foom\A', 'foo', 'Foom\Foo'],
             ['ClassE', 'boo', 'ClassC'],
             ['ClassF', 'zoo', 'ClassD'],
+            ['Construct\Bar', '__construct', null],
+            ['Construct\Ipsum', '__construct', 'Construct\Lorem'],
+            ['Traits\Foo', 'doFoo', 'Traits\FooInterface'],
         ];
     }
 


### PR DESCRIPTION
Fixes #640 
Fixes #639 