### PR TITLE
ReflectionParameter: try to get the correct default value for constants

### DIFF
--- a/test/unit/Reflection/ReflectionParameterTest.php
+++ b/test/unit/Reflection/ReflectionParameterTest.php
@@ -36,6 +36,8 @@ use stdClass;
 
 use function sprintf;
 
+use const SORT_ASC as SORT_ASC_TEST;
+
 /**
  * @covers \Roave\BetterReflection\Reflection\ReflectionParameter
  */
@@ -81,6 +83,28 @@ class ReflectionParameterTest extends TestCase
 
         self::assertInstanceOf(ReflectionParameter::class, $parameterInfo);
         self::assertSame('a', $parameterInfo->getName());
+    }
+
+    public function testParamWithConstant(): void
+    {
+        // @codingStandardsIgnoreStart
+        $parameterInfo = ReflectionParameter::createFromClosure(static function (int $sort = SORT_ASC): void {
+        }, 'sort');
+        // @codingStandardsIgnoreEnd
+
+        self::assertInstanceOf(ReflectionParameter::class, $parameterInfo);
+        self::assertSame(false, $parameterInfo->allowsNull());
+    }
+
+    public function testParamWithConstantAlias(): void
+    {
+        $this->markTestSkipped('@todo - implement reflection of constants aliases');
+
+        $parameterInfo = ReflectionParameter::createFromClosure(static function (int $sort = SORT_ASC_TEST): void {
+        }, 'sort');
+
+        self::assertInstanceOf(ReflectionParameter::class, $parameterInfo);
+        self::assertSame(false, $parameterInfo->allowsNull());
     }
 
     public function testCreateFromSpecWithArray(): void


### PR DESCRIPTION
For example, this function ```function foo(int $case = \CASE_LOWER);```, ReflectionParameter->allowsNull() for ```$case```will currently return ```true```.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/roave/betterreflection/678)
<!-- Reviewable:end -->
