### PR TITLE
Use `serialize()` instead of `json_encode()` in `MemoizingParser` - faster/simpler, but more memory usage

### DIFF
--- a/src/SourceLocator/Ast/Parser/MemoizingParser.php
+++ b/src/SourceLocator/Ast/Parser/MemoizingParser.php
@@ -5,16 +5,13 @@ declare(strict_types=1);
 namespace Roave\BetterReflection\SourceLocator\Ast\Parser;
 
 use PhpParser\ErrorHandler;
-use PhpParser\JsonDecoder;
 use PhpParser\Parser;
 
 use function array_key_exists;
 use function hash;
-use function json_encode;
+use function serialize;
 use function strlen;
-
-use const JSON_PARTIAL_OUTPUT_ON_ERROR;
-use const JSON_PRESERVE_ZERO_FRACTION;
+use function unserialize;
 
 /**
  * @internal
@@ -26,12 +23,9 @@ final class MemoizingParser implements Parser
 
     private Parser $wrappedParser;
 
-    private JsonDecoder $jsonDecoder;
-
     public function __construct(Parser $wrappedParser)
     {
         $this->wrappedParser = $wrappedParser;
-        $this->jsonDecoder   = new JsonDecoder();
     }
 
     /**
@@ -46,11 +40,11 @@ final class MemoizingParser implements Parser
         $hash = hash('sha256', $code) . ':' . strlen($code);
 
         if (array_key_exists($hash, $this->sourceHashToAst)) {
-            return $this->jsonDecoder->decode($this->sourceHashToAst[$hash]);
+            return unserialize($this->sourceHashToAst[$hash]);
         }
 
         $ast                          = $this->wrappedParser->parse($code, $errorHandler);
-        $this->sourceHashToAst[$hash] = json_encode($ast, JSON_PARTIAL_OUTPUT_ON_ERROR | JSON_PRESERVE_ZERO_FRACTION);
+        $this->sourceHashToAst[$hash] = serialize($ast);
 
         return $ast;
     }


### PR DESCRIPTION
This will fix https://github.com/Roave/BackwardCompatibilityCheck/issues/267 and probably aslo https://github.com/nikic/PHP-Parser/issues/710

When I ran BackwardCompatibilityCheck on [Nyholm/psr7 MessageTrait.php](https://github.com/Nyholm/psr7/blob/1.3.1/src/MessageTrait.php) I got a TypeError.

> addcslashes() expects parameter 1 to be string, null given
> vendor/nikic/php-parser/lib/PhpParser/PrettyPrinter/Standard.php:984

Somehow, a `String_` get a null value. 

After some more debugging I found that it was only true for "cached" ATS's that came from the `MemoizingParser`. Replacing `json_encode()` with `serialize()` fixed the issue. 


 