### PR TITLE
Use repeatable cache key from `spl_object_id()` instead of `spl_object_hash()` to reduce memory overhead

### DIFF
--- a/src/SourceLocator/Type/MemoizingSourceLocator.php
+++ b/src/SourceLocator/Type/MemoizingSourceLocator.php
@@ -11,7 +11,7 @@ use Roave\BetterReflection\Reflector\Reflector;
 
 use function array_key_exists;
 use function get_class;
-use function spl_object_hash;
+use function spl_object_id;
 
 final class MemoizingSourceLocator implements SourceLocator
 {
@@ -58,7 +58,7 @@ final class MemoizingSourceLocator implements SourceLocator
     private function reflectorCacheKey(Reflector $reflector): string
     {
         return 'type:' . get_class($reflector)
-            . '#oid:' . spl_object_hash($reflector);
+            . '#oid:' . spl_object_id($reflector);
     }
 
     private function identifierToCacheKey(Identifier $identifier): string


### PR DESCRIPTION
see https://3v4l.org/b4Z1G

also more performant, ref https://github.com/php/php-src/blob/php-8.0.6/ext/spl/php_spl.c#L669