### PR TITLE
expand `CompileNodeToValue` to support magic constants in functions, traits and constant declarations

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -18,6 +18,7 @@ or backwards compatibility (BC) breakages occur.
   * `string or NULL` is now `?string` 
   * `boolean` is now `bool`
   * `integer` is now `int`
+* `CompilerContext` is marked as `@internal`.
 
 ## 4.0.0
 

--- a/src/NodeCompiler/CompilerContext.php
+++ b/src/NodeCompiler/CompilerContext.php
@@ -8,6 +8,9 @@ use Roave\BetterReflection\Reflection\ReflectionClass;
 use Roave\BetterReflection\Reflector\Reflector;
 use RuntimeException;
 
+/**
+ * @internal
+ */
 class CompilerContext
 {
     public function __construct(private Reflector $reflector, private ?ReflectionClass $self)

--- a/src/NodeCompiler/CompilerContext.php
+++ b/src/NodeCompiler/CompilerContext.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Roave\BetterReflection\NodeCompiler;
 
 use Roave\BetterReflection\Reflection\ReflectionClass;
+use Roave\BetterReflection\Reflection\ReflectionFunctionAbstract;
 use Roave\BetterReflection\Reflector\Reflector;
 use RuntimeException;
 
@@ -13,27 +14,8 @@ use RuntimeException;
  */
 class CompilerContext
 {
-    public function __construct(private Reflector $reflector, private ?ReflectionClass $self)
+    public function __construct(private Reflector $reflector, private ?string $fileName, private ?string $namespace, private ?ReflectionClass $class, private ?ReflectionFunctionAbstract $function)
     {
-    }
-
-    /**
-     * Does the current context have a "self" or "this"
-     *
-     * (e.g. if the context is a function, then no, there will be no self)
-     */
-    public function hasSelf(): bool
-    {
-        return $this->self !== null;
-    }
-
-    public function getSelf(): ReflectionClass
-    {
-        if (! $this->hasSelf()) {
-            throw new RuntimeException('The current context does not have a class for self');
-        }
-
-        return $this->self;
     }
 
     public function getReflector(): Reflector
@@ -41,8 +23,41 @@ class CompilerContext
         return $this->reflector;
     }
 
-    public function getFileName(): string
+    public function getFileName(): ?string
     {
-        return $this->getSelf()->getFileName();
+        return $this->fileName;
+    }
+
+    public function getNamespace(): ?string
+    {
+        return $this->namespace;
+    }
+
+    public function inClass(): bool
+    {
+        return $this->class !== null;
+    }
+
+    public function getClass(): ReflectionClass
+    {
+        if (! $this->inClass()) {
+            throw new RuntimeException('The current context does not have a class');
+        }
+
+        return $this->class;
+    }
+
+    public function inFunction(): bool
+    {
+        return $this->function !== null;
+    }
+
+    public function getFunction(): ReflectionFunctionAbstract
+    {
+        if (! $this->inFunction()) {
+            throw new RuntimeException('The current context does not have a function');
+        }
+
+        return $this->function;
     }
 }

--- a/src/NodeCompiler/Exception/UnableToCompileNode.php
+++ b/src/NodeCompiler/Exception/UnableToCompileNode.php
@@ -69,8 +69,8 @@ class UnableToCompileNode extends LogicException
     private static function compilerContextToContextDescription(CompilerContext $fetchContext): string
     {
         // @todo improve in https://github.com/Roave/BetterReflection/issues/434
-        return $fetchContext->hasSelf()
-            ? $fetchContext->getSelf()->getName()
+        return $fetchContext->inClass()
+            ? $fetchContext->getClass()->getName()
             : 'unknown context (probably a function)';
     }
 }

--- a/src/NodeCompiler/Exception/UnableToCompileNode.php
+++ b/src/NodeCompiler/Exception/UnableToCompileNode.php
@@ -25,9 +25,10 @@ class UnableToCompileNode extends LogicException
     public static function forUnRecognizedExpressionInContext(Node\Expr $expression, CompilerContext $context): self
     {
         return new self(sprintf(
-            'Unable to compile expression in %s: unrecognized node type %s at line %d',
+            'Unable to compile expression in %s: unrecognized node type %s in file %s (line %d)',
             self::compilerContextToContextDescription($context),
             $expression::class,
+            self::getFileName($context),
             $expression->getLine(),
         ));
     }
@@ -40,10 +41,11 @@ class UnableToCompileNode extends LogicException
         assert($constantFetch->name instanceof Node\Identifier);
 
         return new self(sprintf(
-            'Could not locate constant %s::%s while trying to evaluate constant expression in %s at line %s',
+            'Could not locate constant %s::%s while trying to evaluate constant expression in %s in file %s (line %d)',
             $targetClass->getName(),
             $constantFetch->name->name,
             self::compilerContextToContextDescription($fetchContext),
+            self::getFileName($fetchContext),
             $constantFetch->getLine(),
         ));
     }
@@ -55,9 +57,10 @@ class UnableToCompileNode extends LogicException
         $constantName = reset($constantFetch->name->parts);
 
         $exception = new self(sprintf(
-            'Could not locate constant "%s" while evaluating expression in %s at line %s',
+            'Could not locate constant "%s" while evaluating expression in %s in file %s (line %d)',
             $constantName,
             self::compilerContextToContextDescription($fetchContext),
+            self::getFileName($fetchContext),
             $constantFetch->getLine(),
         ));
 
@@ -66,11 +69,25 @@ class UnableToCompileNode extends LogicException
         return $exception;
     }
 
+    private static function getFileName(CompilerContext $fetchContext): string
+    {
+        return $fetchContext->getFileName() ?? '""';
+    }
+
     private static function compilerContextToContextDescription(CompilerContext $fetchContext): string
     {
-        // @todo improve in https://github.com/Roave/BetterReflection/issues/434
-        return $fetchContext->inClass()
-            ? $fetchContext->getClass()->getName()
-            : 'unknown context (probably a function)';
+        if ($fetchContext->inClass() && $fetchContext->inFunction()) {
+            return sprintf('method %s::%s()', $fetchContext->getClass()->getName(), $fetchContext->getFunction()->getName());
+        }
+
+        if ($fetchContext->inClass()) {
+            return sprintf('class %s', $fetchContext->getClass()->getName());
+        }
+
+        if ($fetchContext->inFunction()) {
+            return sprintf('function %s()', $fetchContext->getFunction()->getName());
+        }
+
+        return 'unknown context';
     }
 }

--- a/src/Reflection/ReflectionClassConstant.php
+++ b/src/Reflection/ReflectionClassConstant.php
@@ -77,7 +77,7 @@ class ReflectionClassConstant
 
         $this->value          = (new CompileNodeToValue())->__invoke(
             $this->node->consts[$this->positionInNode]->value,
-            new CompilerContext($this->reflector, $this->getDeclaringClass()),
+            new CompilerContext($this->reflector, $this->owner->getFileName(), $this->owner->getNamespaceName(), $this->getDeclaringClass(), null),
         );
         $this->valueWasCached = true;
 

--- a/src/Reflection/ReflectionConstant.php
+++ b/src/Reflection/ReflectionConstant.php
@@ -221,7 +221,7 @@ class ReflectionConstant implements Reflection
         /** @psalm-suppress UndefinedPropertyFetch */
         $this->value          = (new CompileNodeToValue())->__invoke(
             $valueNode,
-            new CompilerContext($this->reflector, null),
+            new CompilerContext($this->reflector, $this->getFileName(), $this->getNamespaceName(), null, null),
         );
         $this->valueWasCached = true;
 

--- a/src/Reflection/ReflectionParameter.php
+++ b/src/Reflection/ReflectionParameter.php
@@ -291,9 +291,17 @@ class ReflectionParameter
         $defaultValueNode = $this->parseDefaultValueNode();
 
         if ($defaultValueNode) {
+            $namespaceName = $this->getDeclaringClass()?->getNamespaceName() ?? $this->function->getNamespaceName();
+
             $this->defaultValue = (new CompileNodeToValue())->__invoke(
                 $defaultValueNode,
-                new CompilerContext($this->reflector, $this->getDeclaringClass()),
+                new CompilerContext(
+                    $this->reflector,
+                    $this->function->getFileName(),
+                    $namespaceName,
+                    $this->getDeclaringClass(),
+                    $this->function,
+                ),
             );
         }
 

--- a/src/Reflection/ReflectionProperty.php
+++ b/src/Reflection/ReflectionProperty.php
@@ -251,9 +251,17 @@ class ReflectionProperty
             return null;
         }
 
+        $declaringClass = $this->getDeclaringClass();
+
         return (new CompileNodeToValue())->__invoke(
             $defaultValueNode,
-            new CompilerContext($this->reflector, $this->getDeclaringClass()),
+            new CompilerContext(
+                $this->reflector,
+                $declaringClass->getFileName(),
+                $declaringClass->getNamespaceName(),
+                $declaringClass,
+                null,
+            ),
         );
     }
 

--- a/test/unit/Fixture/MagicConstants.php
+++ b/test/unit/Fixture/MagicConstants.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace {
+
+    define('_DIR', __DIR__);
+    define('_FILE', __FILE__);
+    define('_LINE', __LINE__);
+    define('_NAMESPACE', __NAMESPACE__);
+    define('_CLASS', __CLASS__);
+    define('_TRAIT', __TRAIT__);
+    define('_METHOD', __METHOD__);
+    define('_FUNCTION', __FUNCTION__);
+
+}
+
+namespace Roave\BetterReflectionTest\Fixture {
+
+    const _DIR = __DIR__;
+    const _FILE = __FILE__;
+    const _LINE = __LINE__;
+    const _NAMESPACE = __NAMESPACE__;
+    const _CLASS = __CLASS__;
+    const _TRAIT = __TRAIT__;
+    const _METHOD = __METHOD__;
+    const _FUNCTION = __FUNCTION__;
+
+    trait MagicConstantsTrait
+    {
+        protected $dir = __DIR__;
+        protected $file = __FILE__;
+        protected $line = __LINE__;
+        protected $namespace = __NAMESPACE__;
+        protected $class = __CLASS__;
+        protected $trait = __TRAIT__;
+        protected $method = __METHOD__;
+        protected $function = __FUNCTION__;
+    }
+
+    class MagicConstantsClass
+    {
+        private $dir = __DIR__;
+        private $file = __FILE__;
+        private $line = __LINE__;
+        private $namespace = __NAMESPACE__;
+        private $class = __CLASS__;
+        private $trait = __TRAIT__;
+        private $method = __METHOD__;
+        private $function = __FUNCTION__;
+
+        public function magicConstantsMethod(
+            $dir = __DIR__,
+            $file = __FILE__,
+            $line = __LINE__,
+            $namespace = __NAMESPACE__,
+            $class = __CLASS__,
+            $trait = __TRAIT__,
+            $method = __METHOD__,
+            $function = __FUNCTION__,
+        )
+        {
+        }
+    }
+
+    function magicConstantsFunction(
+        $dir = __DIR__,
+        $file = __FILE__,
+        $line = __LINE__,
+        $namespace = __NAMESPACE__,
+        $class = __CLASS__,
+        $trait = __TRAIT__,
+        $method = __METHOD__,
+        $function = __FUNCTION__,
+    )
+    {
+    }
+
+}

--- a/test/unit/NodeCompiler/CompileNodeToValueTest.php
+++ b/test/unit/NodeCompiler/CompileNodeToValueTest.php
@@ -190,7 +190,7 @@ class CompileNodeToValueTest extends TestCase
     {
         $this->expectException(UnableToCompileNode::class);
         $this->expectExceptionMessage(sprintf(
-            'Unable to compile expression in unknown context (probably a function): unrecognized node type %s at line -1',
+            'Unable to compile expression in unknown context: unrecognized node type %s in file "" (line -1)',
             Yield_::class,
         ));
 
@@ -200,7 +200,7 @@ class CompileNodeToValueTest extends TestCase
     public function testExceptionThrownWhenUndefinedConstUsed(): void
     {
         $this->expectException(UnableToCompileNode::class);
-        $this->expectExceptionMessage('Could not locate constant "FOO" while evaluating expression in unknown context (probably a function) at line -1');
+        $this->expectExceptionMessage('Could not locate constant "FOO" while evaluating expression in unknown context in file "" (line -1)');
 
         (new CompileNodeToValue())->__invoke(new ConstFetch(new Name('FOO')), $this->getDummyContext());
     }
@@ -208,7 +208,7 @@ class CompileNodeToValueTest extends TestCase
     public function testExceptionThrownWhenUndefinedClassConstUsed(): void
     {
         $this->expectException(UnableToCompileNode::class);
-        $this->expectExceptionMessage('Could not locate constant EmptyClass::FOO while trying to evaluate constant expression in unknown context (probably a function) at line -1');
+        $this->expectExceptionMessage('Could not locate constant EmptyClass::FOO while trying to evaluate constant expression in unknown context in file "" (line -1)');
 
         (new CompileNodeToValue())
             ->__invoke(

--- a/test/unit/NodeCompiler/CompileNodeToValueTest.php
+++ b/test/unit/NodeCompiler/CompileNodeToValueTest.php
@@ -14,11 +14,18 @@ use Roave\BetterReflection\NodeCompiler\CompileNodeToValue;
 use Roave\BetterReflection\NodeCompiler\CompilerContext;
 use Roave\BetterReflection\NodeCompiler\Exception\UnableToCompileNode;
 use Roave\BetterReflection\Reflector\ClassReflector;
+use Roave\BetterReflection\Reflector\ConstantReflector;
+use Roave\BetterReflection\Reflector\FunctionReflector;
 use Roave\BetterReflection\SourceLocator\Ast\Locator;
+use Roave\BetterReflection\SourceLocator\Type\SingleFileSourceLocator;
 use Roave\BetterReflection\SourceLocator\Type\StringSourceLocator;
+use Roave\BetterReflection\Util\FileHelper;
 use Roave\BetterReflectionTest\BetterReflectionSingleton;
+use Roave\BetterReflectionTest\Fixture\MagicConstantsClass;
+use Roave\BetterReflectionTest\Fixture\MagicConstantsTrait;
 
 use function define;
+use function realpath;
 use function sprintf;
 use function uniqid;
 
@@ -34,13 +41,16 @@ class CompileNodeToValueTest extends TestCase
 
     private Locator $astLocator;
 
+    private ClassReflector $classReflector;
+
     protected function setUp(): void
     {
         parent::setUp();
 
-        $configuration    = BetterReflectionSingleton::instance();
-        $this->parser     = $configuration->phpParser();
-        $this->astLocator = $configuration->astLocator();
+        $configuration        = BetterReflectionSingleton::instance();
+        $this->parser         = $configuration->phpParser();
+        $this->astLocator     = $configuration->astLocator();
+        $this->classReflector = $configuration->classReflector();
     }
 
     private function parseCode(string $phpCode): Node
@@ -50,13 +60,16 @@ class CompileNodeToValueTest extends TestCase
 
     private function getDummyContext(): CompilerContext
     {
-        return new CompilerContext(new ClassReflector(new StringSourceLocator('<?php', $this->astLocator)), null);
+        return new CompilerContext(new ClassReflector(new StringSourceLocator('<?php', $this->astLocator)), null, null, null, null);
     }
 
     private function getDummyContextWithEmptyClass(): CompilerContext
     {
         return new CompilerContext(
             new ClassReflector(new StringSourceLocator('<?php class EmptyClass {}', $this->astLocator)),
+            null,
+            null,
+            null,
             null,
         );
     }
@@ -474,5 +487,172 @@ PHP;
         self::assertSame('selfConstant', $classInfo->getProperty('selfConstant')->getDefaultValue());
         self::assertSame('staticConstant', $classInfo->getProperty('staticConstant')->getDefaultValue());
         self::assertSame('parentConstant', $classInfo->getProperty('parentConstant')->getDefaultValue());
+    }
+
+    public function magicConstantsWithoutNamespaceProvider(): array
+    {
+        $dir = FileHelper::normalizeWindowsPath(realpath(__DIR__ . '/../Fixture'));
+
+        return [
+            ['_DIR', $dir],
+            ['_FILE', $dir . '/MagicConstants.php'],
+            ['_LINE', 7],
+            ['_NAMESPACE', ''],
+            ['_CLASS', ''],
+            ['_TRAIT', ''],
+            ['_METHOD', ''],
+            ['_FUNCTION', ''],
+        ];
+    }
+
+    /**
+     * @dataProvider magicConstantsWithoutNamespaceProvider
+     */
+    public function testMagicConstantsWithoutNamespace(string $constantName, mixed $expectedValue): void
+    {
+        $reflector = new ConstantReflector(new SingleFileSourceLocator(__DIR__ . '/../Fixture/MagicConstants.php', $this->astLocator), $this->classReflector);
+        $constant  = $reflector->reflect($constantName);
+
+        self::assertSame($expectedValue, $constant->getValue());
+    }
+
+    public function magicConstantsInNamespaceProvider(): array
+    {
+        $dir = FileHelper::normalizeWindowsPath(realpath(__DIR__ . '/../Fixture'));
+
+        return [
+            ['_DIR', $dir],
+            ['_FILE', $dir . '/MagicConstants.php'],
+            ['_LINE', 20],
+            ['_NAMESPACE', 'Roave\BetterReflectionTest\Fixture'],
+            ['_CLASS', ''],
+            ['_TRAIT', ''],
+            ['_METHOD', ''],
+            ['_FUNCTION', ''],
+        ];
+    }
+
+    /**
+     * @dataProvider magicConstantsInNamespaceProvider
+     */
+    public function testMagicConstantsInNamespace(string $constantName, mixed $expectedValue): void
+    {
+        $reflector = new ConstantReflector(new SingleFileSourceLocator(__DIR__ . '/../Fixture/MagicConstants.php', $this->astLocator), $this->classReflector);
+        $constant  = $reflector->reflect('Roave\BetterReflectionTest\Fixture\\' . $constantName);
+
+        self::assertSame($expectedValue, $constant->getValue());
+    }
+
+    public function magicConstantsInTraitProvider(): array
+    {
+        $dir = FileHelper::normalizeWindowsPath(realpath(__DIR__ . '/../Fixture'));
+
+        return [
+            ['dir', $dir],
+            ['file', $dir . '/MagicConstants.php'],
+            ['line', 31],
+            ['namespace', 'Roave\BetterReflectionTest\Fixture'],
+            ['class', 'Roave\BetterReflectionTest\Fixture\MagicConstantsTrait'],
+            ['trait', 'Roave\BetterReflectionTest\Fixture\MagicConstantsTrait'],
+            ['method', ''],
+            ['function', ''],
+        ];
+    }
+
+    /**
+     * @dataProvider magicConstantsInTraitProvider
+     */
+    public function testMagicConstantsInTrait(string $propertyName, mixed $expectedValue): void
+    {
+        $reflector = new ClassReflector(new SingleFileSourceLocator(__DIR__ . '/../Fixture/MagicConstants.php', $this->astLocator));
+        $class     = $reflector->reflect(MagicConstantsTrait::class);
+        $property  = $class->getProperty($propertyName);
+
+        self::assertSame($expectedValue, $property->getDefaultValue());
+    }
+
+    public function magicConstantsInClassProvider(): array
+    {
+        $dir = FileHelper::normalizeWindowsPath(realpath(__DIR__ . '/../Fixture'));
+
+        return [
+            ['dir', $dir],
+            ['file', $dir . '/MagicConstants.php'],
+            ['line', 43],
+            ['namespace', 'Roave\BetterReflectionTest\Fixture'],
+            ['class', 'Roave\BetterReflectionTest\Fixture\MagicConstantsClass'],
+            ['trait', ''],
+            ['method', ''],
+            ['function', ''],
+        ];
+    }
+
+    /**
+     * @dataProvider magicConstantsInClassProvider
+     */
+    public function testMagicConstantsInClass(string $propertyName, mixed $expectedValue): void
+    {
+        $reflector = new ClassReflector(new SingleFileSourceLocator(__DIR__ . '/../Fixture/MagicConstants.php', $this->astLocator));
+        $class     = $reflector->reflect(MagicConstantsClass::class);
+        $property  = $class->getProperty($propertyName);
+
+        self::assertSame($expectedValue, $property->getDefaultValue());
+    }
+
+    public function magicConstantsInMethodProvider(): array
+    {
+        $dir = FileHelper::normalizeWindowsPath(realpath(__DIR__ . '/../Fixture'));
+
+        return [
+            ['dir', $dir],
+            ['file', $dir . '/MagicConstants.php'],
+            ['line', 53],
+            ['namespace', 'Roave\BetterReflectionTest\Fixture'],
+            ['class', 'Roave\BetterReflectionTest\Fixture\MagicConstantsClass'],
+            ['trait', ''],
+            ['method', 'Roave\BetterReflectionTest\Fixture\MagicConstantsClass::magicConstantsMethod'],
+            ['function', 'magicConstantsMethod'],
+        ];
+    }
+
+    /**
+     * @dataProvider magicConstantsInMethodProvider
+     */
+    public function testMagicConstantsInMethod(string $parameterName, mixed $expectedValue): void
+    {
+        $reflector = new ClassReflector(new SingleFileSourceLocator(__DIR__ . '/../Fixture/MagicConstants.php', $this->astLocator));
+        $class     = $reflector->reflect(MagicConstantsClass::class);
+        $method    = $class->getMethod('magicConstantsMethod');
+        $parameter = $method->getParameter($parameterName);
+
+        self::assertSame($expectedValue, $parameter->getDefaultValue());
+    }
+
+    public function magicConstantsInFunctionProvider(): array
+    {
+        $dir = FileHelper::normalizeWindowsPath(realpath(__DIR__ . '/../Fixture'));
+
+        return [
+            ['dir', $dir],
+            ['file', $dir . '/MagicConstants.php'],
+            ['line', 67],
+            ['namespace', 'Roave\BetterReflectionTest\Fixture'],
+            ['class', ''],
+            ['trait', ''],
+            ['method', 'Roave\BetterReflectionTest\Fixture\magicConstantsFunction'],
+            ['function', 'Roave\BetterReflectionTest\Fixture\magicConstantsFunction'],
+        ];
+    }
+
+    /**
+     * @dataProvider magicConstantsInFunctionProvider
+     */
+    public function testMagicConstantsInFunction(string $parameterName, mixed $expectedValue): void
+    {
+        $reflector = new FunctionReflector(new SingleFileSourceLocator(__DIR__ . '/../Fixture/MagicConstants.php', $this->astLocator), $this->classReflector);
+        $function  = $reflector->reflect('Roave\BetterReflectionTest\Fixture\magicConstantsFunction');
+        $parameter = $function->getParameter($parameterName);
+
+        self::assertSame($expectedValue, $parameter->getDefaultValue());
     }
 }

--- a/test/unit/NodeCompiler/Exception/UnableToCompileNodeTest.php
+++ b/test/unit/NodeCompiler/Exception/UnableToCompileNodeTest.php
@@ -42,7 +42,7 @@ final class UnableToCompileNodeTest extends TestCase
             new ConstFetch(new Name($constantName)),
         );
 
-        $contextName = $context->hasSelf() ? 'EmptyClass' : 'unknown context (probably a function)';
+        $contextName = $context->inClass() ? 'EmptyClass' : 'unknown context (probably a function)';
 
         self::assertSame(
             sprintf(
@@ -59,7 +59,7 @@ final class UnableToCompileNodeTest extends TestCase
     /** @dataProvider supportedContextTypes */
     public function testBecauseOfNotFoundClassConstantReference(CompilerContext $context): void
     {
-        $contextName = $context->hasSelf() ? 'EmptyClass' : 'unknown context (probably a function)';
+        $contextName = $context->inClass() ? 'EmptyClass' : 'unknown context (probably a function)';
 
         $targetClass = $this->createMock(ReflectionClass::class);
 
@@ -85,7 +85,7 @@ final class UnableToCompileNodeTest extends TestCase
     /** @dataProvider supportedContextTypes */
     public function testForUnRecognizedExpressionInContext(CompilerContext $context): void
     {
-        $contextName = $context->hasSelf() ? 'EmptyClass' : 'unknown context (probably a function)';
+        $contextName = $context->inClass() ? 'EmptyClass' : 'unknown context (probably a function)';
 
         self::assertSame(
             'Unable to compile expression in ' . $contextName
@@ -107,8 +107,8 @@ final class UnableToCompileNodeTest extends TestCase
         ));
 
         return [
-            [new CompilerContext($reflector, null)],
-            [new CompilerContext($reflector, $reflector->reflect('EmptyClass'))],
+            [new CompilerContext($reflector, null, null, null, null)],
+            [new CompilerContext($reflector, null, null, $reflector->reflect('EmptyClass'), null)],
         ];
     }
 }

--- a/test/unit/NodeCompiler/Exception/UnableToCompileNodeTest.php
+++ b/test/unit/NodeCompiler/Exception/UnableToCompileNodeTest.php
@@ -15,6 +15,7 @@ use Roave\BetterReflection\NodeCompiler\CompilerContext;
 use Roave\BetterReflection\NodeCompiler\Exception\UnableToCompileNode;
 use Roave\BetterReflection\Reflection\ReflectionClass;
 use Roave\BetterReflection\Reflector\ClassReflector;
+use Roave\BetterReflection\Reflector\FunctionReflector;
 use Roave\BetterReflection\SourceLocator\Type\StringSourceLocator;
 use Roave\BetterReflectionTest\BetterReflectionSingleton;
 
@@ -33,7 +34,7 @@ final class UnableToCompileNodeTest extends TestCase
     }
 
     /** @dataProvider supportedContextTypes */
-    public function testBecauseOfNotFoundConstantReference(CompilerContext $context): void
+    public function testBecauseOfNotFoundConstantReference(CompilerContext $context, string $contextName): void
     {
         $constantName = 'FOO';
 
@@ -42,11 +43,9 @@ final class UnableToCompileNodeTest extends TestCase
             new ConstFetch(new Name($constantName)),
         );
 
-        $contextName = $context->inClass() ? 'EmptyClass' : 'unknown context (probably a function)';
-
         self::assertSame(
             sprintf(
-                'Could not locate constant "%s" while evaluating expression in %s at line -1',
+                'Could not locate constant "%s" while evaluating expression in %s in file someFile (line -1)',
                 $constantName,
                 $contextName,
             ),
@@ -57,10 +56,8 @@ final class UnableToCompileNodeTest extends TestCase
     }
 
     /** @dataProvider supportedContextTypes */
-    public function testBecauseOfNotFoundClassConstantReference(CompilerContext $context): void
+    public function testBecauseOfNotFoundClassConstantReference(CompilerContext $context, string $contextName): void
     {
-        $contextName = $context->inClass() ? 'EmptyClass' : 'unknown context (probably a function)';
-
         $targetClass = $this->createMock(ReflectionClass::class);
 
         $targetClass
@@ -69,8 +66,10 @@ final class UnableToCompileNodeTest extends TestCase
             ->willReturn('An\\Example');
 
         self::assertSame(
-            'Could not locate constant An\Example::SOME_CONSTANT while trying to evaluate constant expression in '
-            . $contextName . ' at line -1',
+            sprintf(
+                'Could not locate constant An\Example::SOME_CONSTANT while trying to evaluate constant expression in %s in file someFile (line -1)',
+                $contextName,
+            ),
             UnableToCompileNode::becauseOfNotFoundClassConstantReference(
                 $context,
                 $targetClass,
@@ -83,14 +82,14 @@ final class UnableToCompileNodeTest extends TestCase
     }
 
     /** @dataProvider supportedContextTypes */
-    public function testForUnRecognizedExpressionInContext(CompilerContext $context): void
+    public function testForUnRecognizedExpressionInContext(CompilerContext $context, string $contextName): void
     {
-        $contextName = $context->inClass() ? 'EmptyClass' : 'unknown context (probably a function)';
-
         self::assertSame(
-            'Unable to compile expression in ' . $contextName
-            . ': unrecognized node type ' . Yield_::class
-            . ' at line -1',
+            sprintf(
+                'Unable to compile expression in %s: unrecognized node type %s in file someFile (line -1)',
+                $contextName,
+                Yield_::class,
+            ),
             UnableToCompileNode::forUnRecognizedExpressionInContext(
                 new Yield_(new String_('')),
                 $context,
@@ -101,14 +100,35 @@ final class UnableToCompileNodeTest extends TestCase
     /** @return CompilerContext[] */
     public function supportedContextTypes(): array
     {
-        $reflector = new ClassReflector(new StringSourceLocator(
-            '<?php class EmptyClass {}',
-            BetterReflectionSingleton::instance()->astLocator(),
-        ));
+        $php = <<<'PHP'
+            <?php
+            
+            class SomeClass
+            {
+                public function someMethod()
+                {
+                }
+            }
+
+            function someFunction()
+            {
+            }
+        PHP;
+
+        $sourceLocator     = new StringSourceLocator($php, BetterReflectionSingleton::instance()->astLocator());
+        $classReflector    = new ClassReflector($sourceLocator);
+        $functionReflector = new FunctionReflector($sourceLocator, $classReflector);
+
+        $namespace = null;
+        $class     = $classReflector->reflect('SomeClass');
+        $method    = $class->getMethod('someMethod');
+        $function  = $functionReflector->reflect('someFunction');
 
         return [
-            [new CompilerContext($reflector, null, null, null, null)],
-            [new CompilerContext($reflector, null, null, $reflector->reflect('EmptyClass'), null)],
+            [new CompilerContext($classReflector, 'someFile', $namespace, null, null), 'unknown context'],
+            [new CompilerContext($classReflector, 'someFile', $namespace, $class, null), 'class SomeClass'],
+            [new CompilerContext($classReflector, 'someFile', $namespace, $class, $method), 'method SomeClass::someMethod()'],
+            [new CompilerContext($classReflector, 'someFile', $namespace, null, $function), 'function someFunction()'],
         ];
     }
 }


### PR DESCRIPTION
Fixes #434
Fixes #645 
Fixes #657