### PR TITLE
remove expired "extra" field in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -59,11 +59,6 @@
     "suggest": {
         "composer/composer": "Required to use the ComposerSourceLocator"
     },
-    "extra": {
-        "branch-alias": {
-            "dev-master": "4.0-dev"
-        }
-    },
     "minimum-stability": "dev",
     "prefer-stable": true
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0b649bd78cb2919835f0d3319e26b7ce",
+    "content-hash": "5471653dd1135c8b2cf75c1a604b41e3",
     "packages": [
         {
             "name": "jetbrains/phpstorm-stubs",


### PR DESCRIPTION
`dev-master` is old branch model.

I do
* edit composer.json
* and do `composer require phpdocumentor/reflection-docblock:^5.2.2` to dump `content-hash`