### PR TITLE
Clean ReflectionClass constants API

### DIFF
--- a/src/NodeCompiler/CompileNodeToValue.php
+++ b/src/NodeCompiler/CompileNodeToValue.php
@@ -165,7 +165,7 @@ class CompileNodeToValue
             assert($classInfo instanceof ReflectionClass);
         }
 
-        $reflectionConstant = $classInfo->getReflectionConstant($nodeName);
+        $reflectionConstant = $classInfo->getConstant($nodeName);
 
         if (! $reflectionConstant instanceof ReflectionClassConstant) {
             throw Exception\UnableToCompileNode::becauseOfNotFoundClassConstantReference($context, $classInfo, $node);

--- a/src/Reflection/Adapter/ReflectionClass.php
+++ b/src/Reflection/Adapter/ReflectionClass.php
@@ -220,7 +220,7 @@ class ReflectionClass extends CoreReflectionClass
      */
     public function getConstant($name)
     {
-        return $this->betterReflectionClass->getConstant($name);
+        return $this->betterReflectionClass->getConstantValue($name);
     }
 
     /**
@@ -228,7 +228,7 @@ class ReflectionClass extends CoreReflectionClass
      */
     public function getReflectionConstant($name)
     {
-        $betterReflectionConstant = $this->betterReflectionClass->getReflectionConstant($name);
+        $betterReflectionConstant = $this->betterReflectionClass->getConstant($name);
         if ($betterReflectionConstant === null) {
             return false;
         }
@@ -249,11 +249,11 @@ class ReflectionClass extends CoreReflectionClass
      */
     private function filterBetterReflectionClassConstants(?int $filter): array
     {
-        $reflectionConstants = $this->betterReflectionClass->getReflectionConstants();
+        $reflectionConstants = $this->betterReflectionClass->getConstants();
 
         if ($filter !== null) {
             $reflectionConstants = array_filter(
-                $this->betterReflectionClass->getReflectionConstants(),
+                $this->betterReflectionClass->getConstants(),
                 static fn (BetterReflectionClassConstant $betterConstant): bool => (bool) ($betterConstant->getModifiers() & $filter),
             );
         }

--- a/src/Reflection/Adapter/ReflectionObject.php
+++ b/src/Reflection/Adapter/ReflectionObject.php
@@ -202,7 +202,7 @@ class ReflectionObject extends CoreReflectionObject
      */
     public function getConstants(?int $filter = null): array
     {
-        $reflectionConstants = $this->betterReflectionObject->getReflectionConstants();
+        $reflectionConstants = $this->betterReflectionObject->getConstants();
 
         if ($filter !== null) {
             $reflectionConstants = array_filter(
@@ -222,7 +222,7 @@ class ReflectionObject extends CoreReflectionObject
      */
     public function getConstant($name)
     {
-        return $this->betterReflectionObject->getConstant($name);
+        return $this->betterReflectionObject->getConstantValue($name);
     }
 
     /**
@@ -230,7 +230,7 @@ class ReflectionObject extends CoreReflectionObject
      */
     public function getReflectionConstant($name)
     {
-        $betterReflectionConstant = $this->betterReflectionObject->getReflectionConstant($name);
+        $betterReflectionConstant = $this->betterReflectionObject->getConstant($name);
 
         if ($betterReflectionConstant === null) {
             return false;
@@ -246,7 +246,7 @@ class ReflectionObject extends CoreReflectionObject
     {
         return array_values(array_map(
             static fn (BetterReflectionClassConstant $betterConstant): ReflectionClassConstant => new ReflectionClassConstant($betterConstant),
-            $this->betterReflectionObject->getReflectionConstants(),
+            $this->betterReflectionObject->getConstants(),
         ));
     }
 

--- a/src/Reflection/ReflectionObject.php
+++ b/src/Reflection/ReflectionObject.php
@@ -178,6 +178,37 @@ class ReflectionObject extends ReflectionClass
     /**
      * {@inheritdoc}
      */
+    public function getImmediateConstantsValues(): array
+    {
+        return $this->reflectionClass->getImmediateConstantsValues();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getConstantsValues(): array
+    {
+        return $this->reflectionClass->getConstantsValues();
+    }
+
+    public function getConstantValue(string $name): string|int|float|bool|array|null
+    {
+        return $this->reflectionClass->getConstantValue($name);
+    }
+
+    public function hasConstant(string $name): bool
+    {
+        return $this->reflectionClass->hasConstant($name);
+    }
+
+    public function getConstant(string $name): ?ReflectionClassConstant
+    {
+        return $this->reflectionClass->getConstant($name);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function getImmediateConstants(): array
     {
         return $this->reflectionClass->getImmediateConstants();
@@ -189,37 +220,6 @@ class ReflectionObject extends ReflectionClass
     public function getConstants(): array
     {
         return $this->reflectionClass->getConstants();
-    }
-
-    public function getConstant(string $name): string|int|float|bool|array|null
-    {
-        return $this->reflectionClass->getConstant($name);
-    }
-
-    public function hasConstant(string $name): bool
-    {
-        return $this->reflectionClass->hasConstant($name);
-    }
-
-    public function getReflectionConstant(string $name): ?ReflectionClassConstant
-    {
-        return $this->reflectionClass->getReflectionConstant($name);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getImmediateReflectionConstants(): array
-    {
-        return $this->reflectionClass->getImmediateReflectionConstants();
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getReflectionConstants(): array
-    {
-        return $this->reflectionClass->getReflectionConstants();
     }
 
     public function getConstructor(): ReflectionMethod

--- a/src/Reflection/StringCast/ReflectionClassStringCast.php
+++ b/src/Reflection/StringCast/ReflectionClassStringCast.php
@@ -41,7 +41,7 @@ final class ReflectionClassStringCast
 
         $type = self::typeToString($classReflection);
 
-        $constants         = $classReflection->getReflectionConstants();
+        $constants         = $classReflection->getConstants();
         $staticProperties  = self::getStaticProperties($classReflection);
         $staticMethods     = self::getStaticMethods($classReflection);
         $defaultProperties = self::getDefaultProperties($classReflection);

--- a/test/unit/NodeCompiler/CompileNodeToValueTest.php
+++ b/test/unit/NodeCompiler/CompileNodeToValueTest.php
@@ -269,11 +269,11 @@ PHP;
         $reflector = new ClassReflector(new StringSourceLocator($phpCode, $this->astLocator));
         $classInfo = $reflector->reflect('Bar\Foo');
 
-        self::assertSame(1, $classInfo->getReflectionConstant('SECOND')->getValue());
-        self::assertSame(60, $classInfo->getReflectionConstant('MINUTE')->getValue());
-        self::assertSame(3600, $classInfo->getReflectionConstant('HOUR')->getValue());
-        self::assertSame(86400, $classInfo->getReflectionConstant('DAY')->getValue());
-        self::assertSame(604800, $classInfo->getReflectionConstant('WEEK')->getValue());
+        self::assertSame(1, $classInfo->getConstant('SECOND')->getValue());
+        self::assertSame(60, $classInfo->getConstant('MINUTE')->getValue());
+        self::assertSame(3600, $classInfo->getConstant('HOUR')->getValue());
+        self::assertSame(86400, $classInfo->getConstant('DAY')->getValue());
+        self::assertSame(604800, $classInfo->getConstant('WEEK')->getValue());
     }
 
     public function testClassConstantResolutionExternalForMethod(): void
@@ -326,7 +326,7 @@ PHP;
 
         $reflector = new ClassReflector(new StringSourceLocator($phpCode, $this->astLocator));
         $classInfo = $reflector->reflect('Bat');
-        self::assertSame('Foo', $classInfo->getConstant('QUX'));
+        self::assertSame('Foo', $classInfo->getConstantValue('QUX'));
     }
 
     public function testClassConstantClassNameNamespaceResolution(): void
@@ -343,7 +343,7 @@ PHP;
 
         $reflector = new ClassReflector(new StringSourceLocator($phpCode, $this->astLocator));
         $classInfo = $reflector->reflect('Bar\Bat');
-        self::assertSame('Bar\Foo', $classInfo->getConstant('QUX'));
+        self::assertSame('Bar\Foo', $classInfo->getConstantValue('QUX'));
     }
 
     public function testClassConstantClassNameOutOfScopeResolution(): void
@@ -360,7 +360,7 @@ PHP;
 
         $reflector = new ClassReflector(new StringSourceLocator($phpCode, $this->astLocator));
         $classInfo = $reflector->reflect('Bar\Bat');
-        self::assertSame('My\Awesome\Foo', $classInfo->getConstant('QUX'));
+        self::assertSame('My\Awesome\Foo', $classInfo->getConstantValue('QUX'));
     }
 
     public function testClassConstantClassNameAliasedResolution(): void
@@ -377,7 +377,7 @@ PHP;
 
         $reflector = new ClassReflector(new StringSourceLocator($phpCode, $this->astLocator));
         $classInfo = $reflector->reflect('Bar\Bat');
-        self::assertSame('My\Awesome\Foo', $classInfo->getConstant('QUX'));
+        self::assertSame('My\Awesome\Foo', $classInfo->getConstantValue('QUX'));
     }
 
     public function testClassConstantResolutionFromParent(): void

--- a/test/unit/Reflection/Adapter/ReflectionClassTest.php
+++ b/test/unit/Reflection/Adapter/ReflectionClassTest.php
@@ -264,7 +264,7 @@ class ReflectionClassTest extends TestCase
             ->willReturn('protected constant');
 
         $betterReflectionClass
-            ->method('getReflectionConstants')
+            ->method('getConstants')
             ->willReturn([
                 $publicBetterReflectionClassConstant->getName() => $publicBetterReflectionClassConstant,
                 $privateBetterReflectionClassConstant->getName() => $privateBetterReflectionClassConstant,
@@ -335,7 +335,7 @@ class ReflectionClassTest extends TestCase
             ->willReturn('protected constant');
 
         $betterReflectionClass
-            ->method('getReflectionConstants')
+            ->method('getConstants')
             ->willReturn([
                 $publicBetterReflectionClassConstant->getName() => $publicBetterReflectionClassConstant,
                 $privateBetterReflectionClassConstant->getName() => $privateBetterReflectionClassConstant,
@@ -679,7 +679,7 @@ class ReflectionClassTest extends TestCase
     {
         $betterReflectionClass = $this->createMock(BetterReflectionClass::class);
         $betterReflectionClass
-            ->method('getReflectionConstant')
+            ->method('getConstant')
             ->with('FOO')
             ->willReturn(null);
 

--- a/test/unit/Reflection/Adapter/ReflectionObjectTest.php
+++ b/test/unit/Reflection/Adapter/ReflectionObjectTest.php
@@ -77,9 +77,9 @@ class ReflectionObjectTest extends TestCase
             ['getProperty', null, $mockProperty, ['foo']],
             ['getProperties', null, [$mockProperty], []],
             ['hasConstant', null, true, ['foo']],
-            ['getConstant', null, 'a', ['foo']],
-            ['getReflectionConstant', null, $mockConstant, ['foo']],
-            ['getReflectionConstants', null, [$mockConstant], []],
+            ['getConstantValue', null, 'a', ['foo']],
+            ['getConstant', null, $mockConstant, ['foo']],
+            ['getConstants', null, [$mockConstant], []],
             ['getInterfaces', null, [$mockClassLike], []],
             ['getInterfaceNames', null, ['a', 'b'], []],
             ['isInterface', null, true, []],
@@ -512,7 +512,7 @@ class ReflectionObjectTest extends TestCase
             ->willReturn('protected constant');
 
         $betterReflectionObject
-            ->method('getReflectionConstants')
+            ->method('getConstants')
             ->willReturn([
                 $publicBetterReflectionClassConstant->getName() => $publicBetterReflectionClassConstant,
                 $privateBetterReflectionClassConstant->getName() => $privateBetterReflectionClassConstant,
@@ -544,7 +544,7 @@ class ReflectionObjectTest extends TestCase
 
         $betterReflectionObject
             ->expects($this->once())
-            ->method('getReflectionConstant')
+            ->method('getConstant')
             ->with('NON_EXISTENT_CONSTANT')
             ->willReturn(null);
 
@@ -560,7 +560,7 @@ class ReflectionObjectTest extends TestCase
 
         $betterReflectionObject
             ->expects($this->once())
-            ->method('getReflectionConstant')
+            ->method('getConstant')
             ->with('SOME_CONSTANT')
             ->willReturn($betterReflectionClassConstant);
 
@@ -576,7 +576,7 @@ class ReflectionObjectTest extends TestCase
 
         $betterReflectionObject
             ->expects($this->once())
-            ->method('getReflectionConstants')
+            ->method('getConstants')
             ->willReturn([$betterReflectionClassConstant]);
 
         $reflectionObjectAdapter = new ReflectionObjectAdapter($betterReflectionObject);

--- a/test/unit/Reflection/ReflectionClassConstantTest.php
+++ b/test/unit/Reflection/ReflectionClassConstantTest.php
@@ -29,7 +29,7 @@ class ReflectionClassConstantTest extends TestCase
         $reflector = new ClassReflector($this->getComposerLocator());
         $classInfo = $reflector->reflect(ExampleClass::class);
 
-        return $classInfo->getReflectionConstant($name);
+        return $classInfo->getConstant($name);
     }
 
     public function testDefaultVisibility(): void
@@ -95,7 +95,7 @@ class ReflectionClassConstantTest extends TestCase
     {
         $reflector = new ClassReflector($this->getComposerLocator());
         $classInfo = $reflector->reflect(ExampleClass::class);
-        $const     = $classInfo->getReflectionConstant('MY_CONST_1');
+        $const     = $classInfo->getConstant('MY_CONST_1');
         self::assertSame($classInfo, $const->getDeclaringClass());
     }
 
@@ -106,7 +106,7 @@ class ReflectionClassConstantTest extends TestCase
     {
         $reflector       = new ClassReflector(new StringSourceLocator($php, BetterReflectionSingleton::instance()->astLocator()));
         $classReflection = $reflector->reflect('\T');
-        $constReflection = $classReflection->getReflectionConstant('TEST');
+        $constReflection = $classReflection->getConstant('TEST');
         self::assertEquals($startLine, $constReflection->getStartLine());
         self::assertEquals($endLine, $constReflection->getEndLine());
     }
@@ -137,7 +137,7 @@ class ReflectionClassConstantTest extends TestCase
     {
         $reflector          = new ClassReflector(new StringSourceLocator($php, BetterReflectionSingleton::instance()->astLocator()));
         $classReflection    = $reflector->reflect('T');
-        $constantReflection = $classReflection->getReflectionConstant('TEST');
+        $constantReflection = $classReflection->getConstant('TEST');
 
         self::assertEquals($startColumn, $constantReflection->getStartColumn());
         self::assertEquals($endColumn, $constantReflection->getEndColumn());
@@ -167,7 +167,7 @@ PHP;
 
         $reflector          = new ClassReflector(new StringSourceLocator($php, BetterReflectionSingleton::instance()->astLocator()));
         $classReflection    = $reflector->reflect('Foo');
-        $constantReflection = $classReflection->getReflectionConstant($constantName);
+        $constantReflection = $classReflection->getConstant($constantName);
 
         $ast = $constantReflection->getAst();
 

--- a/test/unit/Reflection/ReflectionClassTest.php
+++ b/test/unit/Reflection/ReflectionClassTest.php
@@ -309,38 +309,38 @@ class ReflectionClassTest extends TestCase
             'MY_CONST_3' => 345,
             'MY_CONST_4' => 456,
             'MY_CONST_5' => 567,
-        ], $classInfo->getConstants());
+        ], $classInfo->getConstantsValues());
     }
 
     public function testGetConstant(): void
     {
         $reflector = new ClassReflector($this->getComposerLocator());
         $classInfo = $reflector->reflect(ExampleClass::class);
-        self::assertSame(123, $classInfo->getConstant('MY_CONST_1'));
-        self::assertSame(234, $classInfo->getConstant('MY_CONST_2'));
-        self::assertSame(345, $classInfo->getConstant('MY_CONST_3'));
-        self::assertSame(456, $classInfo->getConstant('MY_CONST_4'));
-        self::assertSame(567, $classInfo->getConstant('MY_CONST_5'));
-        self::assertNull($classInfo->getConstant('NON_EXISTENT_CONSTANT'));
+        self::assertSame(123, $classInfo->getConstantValue('MY_CONST_1'));
+        self::assertSame(234, $classInfo->getConstantValue('MY_CONST_2'));
+        self::assertSame(345, $classInfo->getConstantValue('MY_CONST_3'));
+        self::assertSame(456, $classInfo->getConstantValue('MY_CONST_4'));
+        self::assertSame(567, $classInfo->getConstantValue('MY_CONST_5'));
+        self::assertNull($classInfo->getConstantValue('NON_EXISTENT_CONSTANT'));
     }
 
     public function testGetReflectionConstants(): void
     {
         $reflector = new ClassReflector($this->getComposerLocator());
         $classInfo = $reflector->reflect(ExampleClass::class);
-        self::assertCount(5, $classInfo->getReflectionConstants());
+        self::assertCount(5, $classInfo->getConstants());
     }
 
     public function testGetReflectionConstant(): void
     {
         $reflector = new ClassReflector($this->getComposerLocator());
         $classInfo = $reflector->reflect(ExampleClass::class);
-        self::assertSame(123, $classInfo->getReflectionConstant('MY_CONST_1')->getValue());
-        self::assertSame(234, $classInfo->getReflectionConstant('MY_CONST_2')->getValue());
-        self::assertSame(345, $classInfo->getReflectionConstant('MY_CONST_3')->getValue());
-        self::assertSame(456, $classInfo->getReflectionConstant('MY_CONST_4')->getValue());
-        self::assertSame(567, $classInfo->getReflectionConstant('MY_CONST_5')->getValue());
-        self::assertNull($classInfo->getConstant('NON_EXISTENT_CONSTANT'));
+        self::assertSame(123, $classInfo->getConstant('MY_CONST_1')->getValue());
+        self::assertSame(234, $classInfo->getConstant('MY_CONST_2')->getValue());
+        self::assertSame(345, $classInfo->getConstant('MY_CONST_3')->getValue());
+        self::assertSame(456, $classInfo->getConstant('MY_CONST_4')->getValue());
+        self::assertSame(567, $classInfo->getConstant('MY_CONST_5')->getValue());
+        self::assertNull($classInfo->getConstantValue('NON_EXISTENT_CONSTANT'));
     }
 
     public function testGetConstructor(): void
@@ -1772,7 +1772,7 @@ PHP;
             'BAR_DEFAULT' => 4,
         ];
 
-        self::assertSame($expectedConstants, $reflection->getConstants());
+        self::assertSame($expectedConstants, $reflection->getConstantsValues());
 
         array_walk(
             $expectedConstants,
@@ -1780,7 +1780,7 @@ PHP;
                 self::assertTrue($reflection->hasConstant($constantName), 'Constant ' . $constantName . ' not set');
                 self::assertSame(
                     $constantValue,
-                    $reflection->getConstant($constantName),
+                    $reflection->getConstantValue($constantName),
                     'Constant value for ' . $constantName . ' does not match',
                 );
             },
@@ -1802,7 +1802,7 @@ PHP;
             'B' => 'b',
         ];
 
-        self::assertSame($expectedConstants, $classInfo->getConstants());
+        self::assertSame($expectedConstants, $classInfo->getConstantsValues());
     }
 
     public function testGetImmediateConstants(): void
@@ -1812,7 +1812,7 @@ PHP;
             $this->astLocator,
         )))->reflect('Next');
 
-        self::assertSame(['F' => 'ff'], $classInfo->getImmediateConstants());
+        self::assertSame(['F' => 'ff'], $classInfo->getImmediateConstantsValues());
     }
 
     public function testGetReflectionConstantsReturnsInheritedConstants(): void
@@ -1830,7 +1830,7 @@ PHP;
             'B' => 'b',
         ];
 
-        $reflectionConstants = $classInfo->getReflectionConstants();
+        $reflectionConstants = $classInfo->getConstants();
 
         self::assertCount(5, $reflectionConstants);
         self::assertContainsOnlyInstancesOf(ReflectionClassConstant::class, $reflectionConstants);
@@ -1856,7 +1856,7 @@ PHP;
             $this->astLocator,
         )))->reflect('Next');
 
-        $reflectionConstants = $classInfo->getImmediateReflectionConstants();
+        $reflectionConstants = $classInfo->getImmediateConstants();
 
         self::assertCount(1, $reflectionConstants);
         self::assertArrayHasKey('F', $reflectionConstants);
@@ -1882,7 +1882,7 @@ PHP;
 
         $classInfo = (new ClassReflector(new StringSourceLocator($php, $this->astLocator)))->reflect('Foo');
 
-        $constants = $classInfo->getConstants();
+        $constants = $classInfo->getConstantsValues();
 
         self::assertCount(2, $constants);
         self::assertSame($expectedConstants, $constants);

--- a/test/unit/Reflection/StringCast/ReflectionClassConstantStringCastTest.php
+++ b/test/unit/Reflection/StringCast/ReflectionClassConstantStringCastTest.php
@@ -43,6 +43,6 @@ class ReflectionClassConstantStringCastTest extends TestCase
         $reflector       = new ClassReflector(new SingleFileSourceLocator(__DIR__ . '/../../Fixture/StringCastClassConstants.php', $this->astLocator));
         $classReflection = $reflector->reflect(StringCastConstants::class);
 
-        self::assertSame($expectedString, (string) $classReflection->getReflectionConstant($constantName));
+        self::assertSame($expectedString, (string) $classReflection->getConstant($constantName));
     }
 }

--- a/test/unit/SourceLocator/SourceStubber/PhpStormStubsSourceStubberTest.php
+++ b/test/unit/SourceLocator/SourceStubber/PhpStormStubsSourceStubberTest.php
@@ -152,7 +152,7 @@ class PhpStormStubsSourceStubberTest extends TestCase
             $this->assertSameMethodAttributes($method, $stubbed->getMethod($method->getName()));
         }
 
-        self::assertEquals($original->getConstants(), $stubbed->getConstants());
+        self::assertEquals($original->getConstants(), $stubbed->getConstantsValues());
     }
 
     private function assertSameMethodAttributes(CoreReflectionMethod $original, ReflectionMethod $stubbed): void

--- a/test/unit/SourceLocator/SourceStubber/ReflectionSourceStubberTest.php
+++ b/test/unit/SourceLocator/SourceStubber/ReflectionSourceStubberTest.php
@@ -255,7 +255,7 @@ class ReflectionSourceStubberTest extends TestCase
             $this->assertSameMethodAttributes($method, $stubbed->getMethod($method->getName()));
         }
 
-        self::assertEquals($original->getConstants(), $stubbed->getConstants());
+        self::assertEquals($original->getConstants(), $stubbed->getConstantsValues());
     }
 
     private function assertSameMethodAttributes(CoreReflectionMethod $original, ReflectionMethod $stubbed): void


### PR DESCRIPTION
BetterReflection should have "better" API. Only adapters need ugly API.

It's BC break but why not in major version?