### PR TITLE
Use `is_file()` instead of `file_exists()` when we need to be sure that the checked locations are files, and not directories

### DIFF
--- a/src/SourceLocator/Exception/InvalidDirectory.php
+++ b/src/SourceLocator/Exception/InvalidDirectory.php
@@ -6,8 +6,8 @@ namespace Roave\BetterReflection\SourceLocator\Exception;
 
 use RuntimeException;
 
-use function file_exists;
 use function gettype;
+use function is_file;
 use function is_object;
 use function sprintf;
 
@@ -15,11 +15,11 @@ class InvalidDirectory extends RuntimeException
 {
     public static function fromNonDirectory(string $nonDirectory): self
     {
-        if (! file_exists($nonDirectory)) {
-            return new self(sprintf('"%s" does not exist', $nonDirectory));
+        if (is_file($nonDirectory)) {
+            return new self(sprintf('"%s" must be a directory, not a file', $nonDirectory));
         }
 
-        return new self(sprintf('"%s" must be a directory, not a file', $nonDirectory));
+        return new self(sprintf('"%s" does not exist', $nonDirectory));
     }
 
     /**

--- a/src/SourceLocator/FileChecker.php
+++ b/src/SourceLocator/FileChecker.php
@@ -6,7 +6,6 @@ namespace Roave\BetterReflection\SourceLocator;
 
 use Roave\BetterReflection\SourceLocator\Exception\InvalidFileLocation;
 
-use function file_exists;
 use function is_file;
 use function is_readable;
 use function sprintf;
@@ -22,16 +21,12 @@ class FileChecker
             throw new InvalidFileLocation('Filename was empty');
         }
 
-        if (! file_exists($filename)) {
-            throw new InvalidFileLocation(sprintf('File "%s" does not exist', $filename));
+        if (! is_file($filename)) {
+            throw new InvalidFileLocation(sprintf('"%s" is not a file', $filename));
         }
 
         if (! is_readable($filename)) {
             throw new InvalidFileLocation(sprintf('File "%s" is not readable', $filename));
-        }
-
-        if (! is_file($filename)) {
-            throw new InvalidFileLocation(sprintf('"%s" is not a file', $filename));
         }
     }
 }

--- a/src/SourceLocator/Type/AutoloadSourceLocator.php
+++ b/src/SourceLocator/Type/AutoloadSourceLocator.php
@@ -28,12 +28,12 @@ use function array_reverse;
 use function assert;
 use function class_exists;
 use function defined;
-use function file_exists;
 use function file_get_contents;
 use function function_exists;
 use function get_defined_constants;
 use function get_included_files;
 use function interface_exists;
+use function is_file;
 use function is_string;
 use function restore_error_handler;
 use function set_error_handler;
@@ -79,7 +79,7 @@ class AutoloadSourceLocator extends AbstractSourceLocator
     {
         $potentiallyLocatedFile = $this->attemptAutoloadForIdentifier($identifier);
 
-        if (! ($potentiallyLocatedFile && file_exists($potentiallyLocatedFile))) {
+        if (! ($potentiallyLocatedFile && is_file($potentiallyLocatedFile))) {
             return null;
         }
 

--- a/src/SourceLocator/Type/Composer/Factory/MakeLocatorForComposerJson.php
+++ b/src/SourceLocator/Type/Composer/Factory/MakeLocatorForComposerJson.php
@@ -19,10 +19,10 @@ use Roave\BetterReflection\SourceLocator\Type\SourceLocator;
 use function array_filter;
 use function array_map;
 use function array_merge;
-use function file_exists;
 use function file_get_contents;
 use function is_array;
 use function is_dir;
+use function is_file;
 use function json_decode;
 use function realpath;
 
@@ -38,7 +38,7 @@ final class MakeLocatorForComposerJson
 
         $composerJsonPath = $realInstallationPath . '/composer.json';
 
-        if (! file_exists($composerJsonPath)) {
+        if (! is_file($composerJsonPath)) {
             throw MissingComposerJson::inProjectPath($installationPath);
         }
 

--- a/src/SourceLocator/Type/Composer/Factory/MakeLocatorForComposerJsonAndInstalledJson.php
+++ b/src/SourceLocator/Type/Composer/Factory/MakeLocatorForComposerJsonAndInstalledJson.php
@@ -21,10 +21,10 @@ use function array_filter;
 use function array_map;
 use function array_merge;
 use function array_merge_recursive;
-use function file_exists;
 use function file_get_contents;
 use function is_array;
 use function is_dir;
+use function is_file;
 use function json_decode;
 use function realpath;
 use function rtrim;
@@ -41,7 +41,7 @@ final class MakeLocatorForComposerJsonAndInstalledJson
 
         $composerJsonPath = $realInstallationPath . '/composer.json';
 
-        if (! file_exists($composerJsonPath)) {
+        if (! is_file($composerJsonPath)) {
             throw MissingComposerJson::inProjectPath($installationPath);
         }
 
@@ -57,7 +57,7 @@ final class MakeLocatorForComposerJsonAndInstalledJson
 
         $installedJsonPath = $realInstallationPath . '/' . $vendorDir . '/composer/installed.json';
 
-        if (! file_exists($installedJsonPath)) {
+        if (! is_file($installedJsonPath)) {
             throw MissingInstalledJson::inProjectPath($realInstallationPath . '/' . $vendorDir);
         }
 

--- a/src/SourceLocator/Type/Composer/Factory/MakeLocatorForInstalledJson.php
+++ b/src/SourceLocator/Type/Composer/Factory/MakeLocatorForInstalledJson.php
@@ -21,10 +21,10 @@ use function array_filter;
 use function array_map;
 use function array_merge;
 use function array_merge_recursive;
-use function file_exists;
 use function file_get_contents;
 use function is_array;
 use function is_dir;
+use function is_file;
 use function json_decode;
 use function realpath;
 use function rtrim;
@@ -41,7 +41,7 @@ final class MakeLocatorForInstalledJson
 
         $composerJsonPath = $realInstallationPath . '/composer.json';
 
-        if (! file_exists($composerJsonPath)) {
+        if (! is_file($composerJsonPath)) {
             throw MissingComposerJson::inProjectPath($installationPath);
         }
 
@@ -57,7 +57,7 @@ final class MakeLocatorForInstalledJson
 
         $installedJsonPath = $realInstallationPath . '/' . $vendorDir . '/composer/installed.json';
 
-        if (! file_exists($installedJsonPath)) {
+        if (! is_file($installedJsonPath)) {
             throw MissingInstalledJson::inProjectPath($realInstallationPath . '/' . $vendorDir);
         }
 

--- a/src/SourceLocator/Type/Composer/PsrAutoloaderLocator.php
+++ b/src/SourceLocator/Type/Composer/PsrAutoloaderLocator.php
@@ -15,8 +15,8 @@ use Roave\BetterReflection\SourceLocator\Type\Composer\Psr\PsrAutoloaderMapping;
 use Roave\BetterReflection\SourceLocator\Type\DirectoriesSourceLocator;
 use Roave\BetterReflection\SourceLocator\Type\SourceLocator;
 
-use function file_exists;
 use function file_get_contents;
+use function is_file;
 
 final class PsrAutoloaderLocator implements SourceLocator
 {
@@ -27,7 +27,7 @@ final class PsrAutoloaderLocator implements SourceLocator
     public function locateIdentifier(Reflector $reflector, Identifier $identifier): ?Reflection
     {
         foreach ($this->mapping->resolvePossibleFilePaths($identifier) as $file) {
-            if (! file_exists($file)) {
+            if (! is_file($file)) {
                 continue;
             }
 

--- a/src/SourceLocator/Type/EvaledCodeSourceLocator.php
+++ b/src/SourceLocator/Type/EvaledCodeSourceLocator.php
@@ -14,8 +14,8 @@ use Roave\BetterReflection\SourceLocator\Located\LocatedSource;
 use Roave\BetterReflection\SourceLocator\SourceStubber\SourceStubber;
 
 use function class_exists;
-use function file_exists;
 use function interface_exists;
+use function is_file;
 use function trait_exists;
 
 final class EvaledCodeSourceLocator extends AbstractSourceLocator
@@ -67,7 +67,7 @@ final class EvaledCodeSourceLocator extends AbstractSourceLocator
         $reflection = new ReflectionClass($name);
         $sourceFile = $reflection->getFileName();
 
-        return $sourceFile && file_exists($sourceFile)
+        return $sourceFile && is_file($sourceFile)
             ? null : $reflection;
     }
 }

--- a/src/Util/Autoload/ClassLoaderMethod/FileCacheLoader.php
+++ b/src/Util/Autoload/ClassLoaderMethod/FileCacheLoader.php
@@ -14,9 +14,9 @@ use Roave\Signature\FileContentChecker;
 use Roave\Signature\FileContentSigner;
 use Roave\Signature\SignerInterface;
 
-use function file_exists;
 use function file_get_contents;
 use function file_put_contents;
+use function is_file;
 use function sha1;
 use function str_replace;
 
@@ -39,7 +39,7 @@ final class FileCacheLoader implements LoaderMethodInterface
     {
         $filename = $this->cacheDirectory . '/' . sha1($classInfo->getName());
 
-        if (! file_exists($filename)) {
+        if (! is_file($filename)) {
             $code = "<?php\n" . $this->classPrinter->__invoke($classInfo);
             file_put_contents(
                 $filename,

--- a/test/unit/SourceLocator/FileCheckerTest.php
+++ b/test/unit/SourceLocator/FileCheckerTest.php
@@ -30,7 +30,7 @@ class FileCheckerTest extends TestCase
     public function testCheckFileThrowsExceptionIfFileDoesNotExist(): void
     {
         $this->expectException(InvalidFileLocation::class);
-        $this->expectExceptionMessage('File "sdklfjdfslsdfhlkjsdglkjsdflgkj" does not exist');
+        $this->expectExceptionMessage('"sdklfjdfslsdfhlkjsdglkjsdflgkj" is not a file');
         FileChecker::assertReadableFile('sdklfjdfslsdfhlkjsdglkjsdflgkj');
     }
 


### PR DESCRIPTION
I had probably some active filter in PHPStorm yesterday so I did not spot all places...