### PR TITLE
Change `push:` rule branch from `master` to `5.0.x` in workflow definitions

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
   push:
     branches:
-      - "master"
+      - "5.0.x"
 
 jobs:
   benchmarks:

--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
   push:
     branches:
-      - "master"
+      - "5.0.x"
 
 jobs:
   coding-standards:

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
   push:
     branches:
-      - "master"
+      - "5.0.x"
 
 jobs:
   compatibility:

--- a/.github/workflows/demo-scripts.yml
+++ b/.github/workflows/demo-scripts.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
   push:
     branches:
-      - "master"
+      - "5.0.x"
 
 jobs:
   demo-scripts:

--- a/.github/workflows/mutation-tests.yml
+++ b/.github/workflows/mutation-tests.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
   push:
     branches:
-      - "master"
+      - "5.0.x"
 
 jobs:
   mutation-tests:

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
   push:
     branches:
-      - "master"
+      - "5.0.x"
 
 jobs:
   static-analysis-phpstan:

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
   push:
     branches:
-      - "master"
+      - "5.0.x"
 
 jobs:
   phpunit:

--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
   push:
     branches:
-      - "master"
+      - "5.0.x"
 
 jobs:
   static-analysis-psalm:


### PR DESCRIPTION
Sorry. After #793, I noticed to have to change workflow branch to hook actions.