### PR TITLE
Improved "deprecated" support to work with internal classes and PHP version constraints

### DIFF
--- a/src/Reflection/Deprecated/DeprecatedHelper.php
+++ b/src/Reflection/Deprecated/DeprecatedHelper.php
@@ -13,16 +13,19 @@ final class DeprecatedHelper
 {
     private static ?DocBlockFactory $docBlockFactory = null;
 
+    /**
+     * @psalm-pure
+     */
     public static function isDeprecated(string $docComment): bool
     {
         if ($docComment === '') {
             return false;
         }
 
+        /** @psalm-suppress ImpureStaticProperty, ImpureMethodCall */
         self::$docBlockFactory ??= DocBlockFactory::createInstance();
 
-        $docBlock = self::$docBlockFactory->create($docComment);
-
-        return $docBlock->hasTag('deprecated');
+        /** @psalm-suppress ImpureStaticProperty, ImpureMethodCall */
+        return self::$docBlockFactory->create($docComment)->hasTag('deprecated');
     }
 }

--- a/src/Reflection/Deprecated/DeprecatedHelper.php
+++ b/src/Reflection/Deprecated/DeprecatedHelper.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Roave\BetterReflection\Reflection\Deprecated;
+
+use phpDocumentor\Reflection\DocBlockFactory;
+
+/**
+ * @internal
+ */
+final class DeprecatedHelper
+{
+    private static ?DocBlockFactory $docBlockFactory = null;
+
+    public static function isDeprecated(string $docComment): bool
+    {
+        if ($docComment === '') {
+            return false;
+        }
+
+        self::$docBlockFactory ??= DocBlockFactory::createInstance();
+
+        $docBlock = self::$docBlockFactory->create($docComment);
+
+        return $docBlock->hasTag('deprecated');
+    }
+}

--- a/src/Reflection/ReflectionClass.php
+++ b/src/Reflection/ReflectionClass.php
@@ -20,6 +20,7 @@ use ReflectionClass as CoreReflectionClass;
 use ReflectionException;
 use ReflectionProperty as CoreReflectionProperty;
 use Roave\BetterReflection\BetterReflection;
+use Roave\BetterReflection\Reflection\Deprecated\DeprecatedHelper;
 use Roave\BetterReflection\Reflection\Exception\ClassDoesNotExist;
 use Roave\BetterReflection\Reflection\Exception\NoObjectProvided;
 use Roave\BetterReflection\Reflection\Exception\NotAClassReflection;
@@ -914,6 +915,11 @@ class ReflectionClass implements Reflection
     public function isUserDefined(): bool
     {
         return ! $this->isInternal();
+    }
+
+    public function isDeprecated(): bool
+    {
+        return DeprecatedHelper::isDeprecated($this->getDocComment());
     }
 
     /**

--- a/src/Reflection/ReflectionClassConstant.php
+++ b/src/Reflection/ReflectionClassConstant.php
@@ -8,6 +8,7 @@ use PhpParser\Node\Stmt\ClassConst;
 use ReflectionProperty;
 use Roave\BetterReflection\NodeCompiler\CompileNodeToValue;
 use Roave\BetterReflection\NodeCompiler\CompilerContext;
+use Roave\BetterReflection\Reflection\Deprecated\DeprecatedHelper;
 use Roave\BetterReflection\Reflection\StringCast\ReflectionClassConstantStringCast;
 use Roave\BetterReflection\Reflector\Reflector;
 use Roave\BetterReflection\Util\CalculateReflectionColumn;
@@ -161,6 +162,11 @@ class ReflectionClassConstant
     public function getDocComment(): string
     {
         return GetLastDocComment::forNode($this->node);
+    }
+
+    public function isDeprecated(): bool
+    {
+        return DeprecatedHelper::isDeprecated($this->getDocComment());
     }
 
     public function __toString(): string

--- a/src/Reflection/ReflectionConstant.php
+++ b/src/Reflection/ReflectionConstant.php
@@ -9,6 +9,7 @@ use PhpParser\Node\Stmt\Namespace_ as NamespaceNode;
 use Roave\BetterReflection\BetterReflection;
 use Roave\BetterReflection\NodeCompiler\CompileNodeToValue;
 use Roave\BetterReflection\NodeCompiler\CompilerContext;
+use Roave\BetterReflection\Reflection\Deprecated\DeprecatedHelper;
 use Roave\BetterReflection\Reflection\Exception\InvalidConstantNode;
 use Roave\BetterReflection\Reflection\StringCast\ReflectionConstantStringCast;
 use Roave\BetterReflection\Reflector\Exception\IdentifierNotFound;
@@ -197,6 +198,11 @@ class ReflectionConstant implements Reflection
     public function isUserDefined(): bool
     {
         return ! $this->isInternal();
+    }
+
+    public function isDeprecated(): bool
+    {
+        return DeprecatedHelper::isDeprecated($this->getDocComment());
     }
 
     /**

--- a/src/Reflection/ReflectionFunctionAbstract.php
+++ b/src/Reflection/ReflectionFunctionAbstract.php
@@ -6,7 +6,6 @@ namespace Roave\BetterReflection\Reflection;
 
 use Closure;
 use LogicException;
-use phpDocumentor\Reflection\DocBlockFactory;
 use phpDocumentor\Reflection\Type;
 use PhpParser\Comment\Doc;
 use PhpParser\Node;
@@ -22,6 +21,7 @@ use Roave\BetterReflection\BetterReflection;
 use Roave\BetterReflection\Identifier\Exception\InvalidIdentifierName;
 use Roave\BetterReflection\Identifier\Identifier;
 use Roave\BetterReflection\Identifier\IdentifierType;
+use Roave\BetterReflection\Reflection\Deprecated\DeprecatedHelper;
 use Roave\BetterReflection\Reflection\Exception\InvalidArrowFunctionBodyNode;
 use Roave\BetterReflection\Reflection\Exception\Uncloneable;
 use Roave\BetterReflection\Reflector\Reflector;
@@ -218,16 +218,7 @@ abstract class ReflectionFunctionAbstract
 
     public function isDeprecated(): bool
     {
-        $docComment = $this->getDocComment();
-
-        if ($docComment === '') {
-            return false;
-        }
-
-        $docBlockFactory = DocBlockFactory::createInstance();
-        $docBlock        = $docBlockFactory->create($docComment);
-
-        return $docBlock->hasTag('deprecated');
+        return DeprecatedHelper::isDeprecated($this->getDocComment());
     }
 
     public function isInternal(): bool

--- a/src/Reflection/ReflectionObject.php
+++ b/src/Reflection/ReflectionObject.php
@@ -339,6 +339,11 @@ class ReflectionObject extends ReflectionClass
         return $this->reflectionClass->isUserDefined();
     }
 
+    public function isDeprecated(): bool
+    {
+        return $this->reflectionClass->isDeprecated();
+    }
+
     public function isAbstract(): bool
     {
         return $this->reflectionClass->isAbstract();

--- a/src/Reflection/ReflectionProperty.php
+++ b/src/Reflection/ReflectionProperty.php
@@ -17,6 +17,7 @@ use ReflectionException;
 use ReflectionProperty as CoreReflectionProperty;
 use Roave\BetterReflection\NodeCompiler\CompileNodeToValue;
 use Roave\BetterReflection\NodeCompiler\CompilerContext;
+use Roave\BetterReflection\Reflection\Deprecated\DeprecatedHelper;
 use Roave\BetterReflection\Reflection\Exception\ClassDoesNotExist;
 use Roave\BetterReflection\Reflection\Exception\NoObjectProvided;
 use Roave\BetterReflection\Reflection\Exception\NotAnObject;
@@ -295,6 +296,11 @@ class ReflectionProperty
                 $this,
             ),
         );
+    }
+
+    public function isDeprecated(): bool
+    {
+        return DeprecatedHelper::isDeprecated($this->getDocComment());
     }
 
     /**

--- a/src/SourceLocator/SourceStubber/ReflectionSourceStubber.php
+++ b/src/SourceLocator/SourceStubber/ReflectionSourceStubber.php
@@ -188,11 +188,21 @@ final class ReflectionSourceStubber implements SourceStubber
         Class_|Interface_|Trait_|Method|Property|Function_ $node,
         CoreReflectionClass|CoreReflectionMethod|CoreReflectionProperty|CoreReflectionFunction $reflection,
     ): void {
-        if ($reflection->getDocComment() === false) {
+        if (
+            ($reflection instanceof CoreReflectionMethod || $reflection instanceof CoreReflectionFunction)
+            && $reflection->isInternal()
+            && $reflection->isDeprecated()
+        ) {
+            $docComment = '/** @deprecated */';
+        } else {
+            $docComment = $reflection->getDocComment();
+        }
+
+        if ($docComment === false) {
             return;
         }
 
-        $node->setDocComment(new Doc($reflection->getDocComment()));
+        $node->setDocComment(new Doc($docComment));
     }
 
     private function addClassModifiers(Class_ $classNode, CoreReflectionClass $classReflection): void

--- a/test/unit/Reflection/Deprecated/DeprecatedHelperTest.php
+++ b/test/unit/Reflection/Deprecated/DeprecatedHelperTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Roave\BetterReflectionTest\Reflection\StringCast;
+
+use PHPUnit\Framework\TestCase;
+use Roave\BetterReflection\Reflection\Deprecated\DeprecatedHelper;
+
+/**
+ * @covers \Roave\BetterReflection\Reflection\Deprecated\DeprecatedHelper
+ */
+class DeprecatedHelperTest extends TestCase
+{
+    public function docCommentProvider(): array
+    {
+        return [
+            ['', false],
+            [
+                '/**
+                 * @return string
+                 */',
+                false,
+            ],
+            [
+                '/**
+                 * @deprecatedPolicy
+                 */',
+                false,
+            ],
+            ['/** @deprecated */', true],
+            [
+                '/**
+                 * @deprecated since 8.0.0
+                 */',
+                true,
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider docCommentProvider
+     */
+    public function testIsDeprecated(string $docComment, bool $isDeprecated): void
+    {
+        self::assertSame($isDeprecated, DeprecatedHelper::isDeprecated($docComment));
+    }
+}

--- a/test/unit/Reflection/ReflectionClassTest.php
+++ b/test/unit/Reflection/ReflectionClassTest.php
@@ -72,6 +72,7 @@ use function class_exists;
 use function count;
 use function file_get_contents;
 use function sort;
+use function sprintf;
 use function uniqid;
 
 /**
@@ -2087,5 +2088,42 @@ PHP;
         $class = $reflector->reflectClass('HasStringable');
 
         self::assertSame(['Iterator', 'Traversable', 'Stringable'], $class->getInterfaceNames());
+    }
+
+    public function deprecatedDocCommentProvider(): array
+    {
+        return [
+            [
+                '/** 
+                  * @deprecated since 8.0
+                  */',
+                true,
+            ],
+            [
+                '/** 
+                  * @deprecated
+                  */',
+                true,
+            ],
+            [
+                '',
+                false,
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider deprecatedDocCommentProvider
+     */
+    public function testIsDeprecated(string $docComment, bool $isDeprecated): void
+    {
+        $php = sprintf('<?php
+        %s
+        class Foo {}', $docComment);
+
+        $reflector       = new DefaultReflector(new StringSourceLocator($php, $this->astLocator));
+        $classReflection = $reflector->reflectClass('Foo');
+
+        self::assertSame($isDeprecated, $classReflection->isDeprecated());
     }
 }

--- a/test/unit/SourceLocator/SourceStubber/ReflectionSourceStubberTest.php
+++ b/test/unit/SourceLocator/SourceStubber/ReflectionSourceStubberTest.php
@@ -287,6 +287,7 @@ class ReflectionSourceStubberTest extends TestCase
         self::assertSame($original->isStatic(), $stubbed->isStatic());
         self::assertSame($original->isFinal(), $stubbed->isFinal());
         self::assertSame($original->isAbstract(), $stubbed->isAbstract());
+        self::assertSame($original->isDeprecated(), $stubbed->isDeprecated());
 
         self::assertSame((string) $original->getReturnType(), (string) $stubbed->getReturnType());
     }


### PR DESCRIPTION
The "deprecated" support is provided by the `@deprecated` annotation. There was already support for it, so I've just extend it.

There's just one disadvantage - the doccomment is not the same that is in the stubs but I don't think it's an issue for internal stubs.

---

There's another possible solution. The support can be provided by special BR `Deprecated` attribute that will be added in `ReflectionSourceStubber` or `PhpStormSourceStubber`.

Advantages:
- The doccomment will be untouched
- The attribute can be easily filtered in future `getAttributes()` methods so we can ignore it where we want.
- It allows to support even deprecated parameters: https://github.com/JetBrains/phpstorm-stubs/blob/master/Core/Core.php#L343

Waiting for ideas/thoughts :)