### PR TITLE
Fixed `ReflectionParameter::isArray()` and `isCallable()` to handle union types

### DIFF
--- a/src/Reflection/ReflectionParameter.php
+++ b/src/Reflection/ReflectionParameter.php
@@ -30,7 +30,6 @@ use function in_array;
 use function is_array;
 use function is_object;
 use function is_string;
-use function preg_match;
 use function sprintf;
 use function strtolower;
 
@@ -409,7 +408,7 @@ class ReflectionParameter
      */
     public function isArray(): bool
     {
-        return preg_match('~^\??array$~i', (string) $this->getType()) === 1;
+        return $this->isType($this->getType(), 'array');
     }
 
     /**
@@ -417,7 +416,42 @@ class ReflectionParameter
      */
     public function isCallable(): bool
     {
-        return preg_match('~^\??callable$~i', (string) $this->getType()) === 1;
+        return $this->isType($this->getType(), 'callable');
+    }
+
+    /**
+     * For isArray() and isCallable().
+     */
+    private function isType(ReflectionNamedType|ReflectionUnionType|null $typeReflection, string $type): bool
+    {
+        if ($typeReflection === null) {
+            return false;
+        }
+
+        $isOneOfAllowedTypes = static function (ReflectionNamedType $namedType, string ...$types): bool {
+            foreach ($types as $type) {
+                if (strtolower($namedType->getName()) === $type) {
+                    return true;
+                }
+            }
+
+            return false;
+        };
+
+        if ($typeReflection instanceof ReflectionUnionType) {
+            /** @var list<ReflectionNamedType> $unionTypes */
+            $unionTypes = $typeReflection->getTypes();
+
+            foreach ($unionTypes as $unionType) {
+                if (! $isOneOfAllowedTypes($unionType, $type, 'null')) {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        return $isOneOfAllowedTypes($typeReflection, $type);
     }
 
     /**

--- a/src/Reflection/ReflectionParameter.php
+++ b/src/Reflection/ReflectionParameter.php
@@ -439,7 +439,6 @@ class ReflectionParameter
         };
 
         if ($typeReflection instanceof ReflectionUnionType) {
-            /** @var list<ReflectionNamedType> $unionTypes */
             $unionTypes = $typeReflection->getTypes();
 
             foreach ($unionTypes as $unionType) {
@@ -529,7 +528,6 @@ class ReflectionParameter
 
         if ($type instanceof ReflectionUnionType) {
             foreach ($type->getTypes() as $innerType) {
-                assert($innerType instanceof ReflectionNamedType);
                 $innerTypeClassName = $this->getClassNameFromNamedType($innerType);
                 if ($innerTypeClassName !== null) {
                     return $innerTypeClassName;

--- a/src/Reflection/ReflectionUnionType.php
+++ b/src/Reflection/ReflectionUnionType.php
@@ -7,21 +7,27 @@ namespace Roave\BetterReflection\Reflection;
 use PhpParser\Node\UnionType;
 
 use function array_map;
+use function assert;
 use function implode;
 
 class ReflectionUnionType extends ReflectionType
 {
-    /** @var list<ReflectionNamedType|ReflectionUnionType> */
+    /** @var list<ReflectionNamedType> */
     private array $types;
 
     public function __construct(UnionType $type, bool $allowsNull)
     {
         parent::__construct($allowsNull);
-        $this->types = array_map(static fn ($type): ReflectionNamedType|ReflectionUnionType => ReflectionType::createFromTypeAndReflector($type), $type->types);
+        $this->types = array_map(static function ($type): ReflectionNamedType {
+            $reflectionType = ReflectionType::createFromTypeAndReflector($type);
+            assert($reflectionType instanceof ReflectionNamedType);
+
+            return $reflectionType;
+        }, $type->types);
     }
 
     /**
-     * @return list<ReflectionNamedType|ReflectionUnionType>
+     * @return list<ReflectionNamedType>
      */
     public function getTypes(): array
     {

--- a/test/unit/Fixture/Methods.php
+++ b/test/unit/Fixture/Methods.php
@@ -63,6 +63,36 @@ abstract class Methods
     ) {
     }
 
+    public function methodIsArrayParameters(
+        $noTypeParameter,
+        bool $boolParameter,
+        array $arrayParameter,
+        ArRaY $arrayCaseInsensitiveParameter,
+        ?array $nullableArrayParameter,
+        null|array $unionArrayParameterNullFirst,
+        array|null $unionArrayParameterNullLast,
+        string|bool $unionNotArrayParameter,
+        array|string|null $unionWithArrayNotArrayParameter,
+        array|object $unionWithArrayAndObjectNotArrayParameter,
+    )
+    {
+    }
+
+    public function methodIsCallableParameters(
+        $noTypeParameter,
+        bool $boolParameter,
+        callable $callableParameter,
+        cAlLaBlE $callableCaseInsensitiveParameter,
+        ?callable $nullableCallableParameter,
+        null|callable $unionCallableParameterNullFirst,
+        callable|null $unionCallableParameterNullLast,
+        string|bool $unionNotCallableParameter,
+        callable|string|null $unionWithCallableNotCallableParameter,
+        callable|object $unionWithCallableAndObjectNotArrayParameter,
+    )
+    {
+    }
+
     public function methodWithVariadic($nonVariadicParameter, ...$variadicParameter)
     {
     }

--- a/test/unit/Reflection/ReflectionClassTest.php
+++ b/test/unit/Reflection/ReflectionClassTest.php
@@ -176,7 +176,7 @@ class ReflectionClassTest extends TestCase
             [CoreReflectionMethod::IS_STATIC, 1],
             [CoreReflectionMethod::IS_ABSTRACT, 1],
             [CoreReflectionMethod::IS_FINAL, 1],
-            [CoreReflectionMethod::IS_PUBLIC, 17],
+            [CoreReflectionMethod::IS_PUBLIC, 19],
             [CoreReflectionMethod::IS_PROTECTED, 1],
             [CoreReflectionMethod::IS_PRIVATE, 1],
             [
@@ -186,7 +186,7 @@ class ReflectionClassTest extends TestCase
                 CoreReflectionMethod::IS_PUBLIC |
                 CoreReflectionMethod::IS_PROTECTED |
                 CoreReflectionMethod::IS_PRIVATE,
-                19,
+                21,
             ],
         ];
     }

--- a/test/unit/Reflection/ReflectionParameterTest.php
+++ b/test/unit/Reflection/ReflectionParameterTest.php
@@ -401,30 +401,60 @@ class ReflectionParameterTest extends TestCase
         );
     }
 
-    public function testIsCallable(): void
+    public function isCallableProvider(): array
     {
-        $classInfo = $this->reflector->reflectClass(Methods::class);
-
-        $method = $classInfo->getMethod('methodWithExplicitTypedParameters');
-
-        $nonCallableParam = $method->getParameter('stdClassParameter');
-        self::assertFalse($nonCallableParam->isCallable());
-
-        $callableParam = $method->getParameter('callableParameter');
-        self::assertTrue($callableParam->isCallable());
+        return [
+            ['noTypeParameter', false],
+            ['boolParameter', false],
+            ['callableParameter', true],
+            ['callableCaseInsensitiveParameter', true],
+            ['nullableCallableParameter', true],
+            ['unionCallableParameterNullFirst', true],
+            ['unionCallableParameterNullLast', true],
+            ['unionNotCallableParameter', false],
+            ['unionWithCallableNotCallableParameter', false],
+            ['unionWithCallableAndObjectNotArrayParameter', false],
+        ];
     }
 
-    public function testIsArray(): void
+    /**
+     * @dataProvider isCallableProvider
+     */
+    public function testIsCallable(string $parameterName, bool $isCallable): void
     {
-        $classInfo = $this->reflector->reflectClass(Methods::class);
+        $classReflection     = $this->reflector->reflectClass(Methods::class);
+        $methodReflection    = $classReflection->getMethod('methodIsCallableParameters');
+        $parameterReflection = $methodReflection->getParameter($parameterName);
 
-        $method = $classInfo->getMethod('methodWithExplicitTypedParameters');
+        self::assertSame($isCallable, $parameterReflection->isCallable());
+    }
 
-        $nonArrayParam = $method->getParameter('stdClassParameter');
-        self::assertFalse($nonArrayParam->isArray());
+    public function isArrayProvider(): array
+    {
+        return [
+            ['noTypeParameter', false],
+            ['boolParameter', false],
+            ['arrayParameter', true],
+            ['arrayCaseInsensitiveParameter', true],
+            ['nullableArrayParameter', true],
+            ['unionArrayParameterNullFirst', true],
+            ['unionArrayParameterNullLast', true],
+            ['unionNotArrayParameter', false],
+            ['unionWithArrayNotArrayParameter', false],
+            ['unionWithArrayAndObjectNotArrayParameter', false],
+        ];
+    }
 
-        $arrayParam = $method->getParameter('arrayParameter');
-        self::assertTrue($arrayParam->isArray());
+    /**
+     * @dataProvider isArrayProvider
+     */
+    public function testIsArray(string $parameterName, bool $isArray): void
+    {
+        $classReflection     = $this->reflector->reflectClass(Methods::class);
+        $methodReflection    = $classReflection->getMethod('methodIsArrayParameters');
+        $parameterReflection = $methodReflection->getParameter($parameterName);
+
+        self::assertSame($isArray, $parameterReflection->isArray());
     }
 
     public function testIsVariadic(): void


### PR DESCRIPTION
Improved version of https://github.com/Roave/BetterReflection/pull/792

Fixes #792 