### PR TITLE
The resolving of constant name and constant value is now always done in `CompileNodeToValue`

### DIFF
--- a/src/NodeCompiler/CompileNodeToValue.php
+++ b/src/NodeCompiler/CompileNodeToValue.php
@@ -38,7 +38,7 @@ class CompileNodeToValue
             return $this($node->expr, $context);
         }
 
-        $constExprEvaluator = new ConstExprEvaluator(function (Node\Expr $node) use ($context) {
+        $constExprEvaluator = new ConstExprEvaluator(function (Node\Expr $node) use ($context): string|int|float|bool|array|null {
             if ($node instanceof Node\Expr\ConstFetch) {
                 return $this->compileConstFetch($node, $context);
             }

--- a/src/NodeCompiler/CompileNodeToValue.php
+++ b/src/NodeCompiler/CompileNodeToValue.php
@@ -111,34 +111,22 @@ class CompileNodeToValue
      */
     private function compileConstFetch(Node\Expr\ConstFetch $constNode, CompilerContext $context): string|int|float|bool|array|null
     {
-        switch ($constNode->name->toLowerString()) {
-            case 'null':
-                return null;
+        $constantName = $constNode->name->toString();
 
-            case 'false':
-                return false;
+        if ($context->getNamespace() !== null && $constNode->name->isUnqualified()) {
+            $namespacedConstantName = sprintf('%s\\%s', $context->getNamespace(), $constantName);
 
-            case 'true':
-                return true;
+            try {
+                return $this->getConstantValue($namespacedConstantName, $context);
+            } catch (IdentifierNotFound) {
+                // Try constant name without namespace
+            }
+        }
 
-            default:
-                $constantName = $constNode->name->toString();
-
-                if ($context->getNamespace() !== null && $constNode->name->isUnqualified()) {
-                    $namespacedConstantName = sprintf('%s\\%s', $context->getNamespace(), $constantName);
-
-                    try {
-                        return $this->getConstantValue($namespacedConstantName, $context);
-                    } catch (IdentifierNotFound) {
-                        // Try constant name without namespace
-                    }
-                }
-
-                try {
-                    return $this->getConstantValue($constantName, $context);
-                } catch (IdentifierNotFound) {
-                    throw Exception\UnableToCompileNode::becauseOfNotFoundConstantReference($context, $constNode, $constantName);
-                }
+        try {
+            return $this->getConstantValue($constantName, $context);
+        } catch (IdentifierNotFound) {
+            throw Exception\UnableToCompileNode::becauseOfNotFoundConstantReference($context, $constNode, $constantName);
         }
     }
 

--- a/src/NodeCompiler/CompileNodeToValue.php
+++ b/src/NodeCompiler/CompileNodeToValue.php
@@ -18,6 +18,9 @@ use function dirname;
 use function realpath;
 use function sprintf;
 
+/**
+ * @internal
+ */
 class CompileNodeToValue
 {
     /**

--- a/src/NodeCompiler/CompiledValue.php
+++ b/src/NodeCompiler/CompiledValue.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Roave\BetterReflection\NodeCompiler;
+
+/**
+ * @internal
+ */
+class CompiledValue
+{
+    /**
+     * @param scalar|array<scalar>|null $value
+     */
+    public function __construct(public string|int|float|bool|array|null $value, public ?string $constantName = null)
+    {
+    }
+}

--- a/src/NodeCompiler/Exception/UnableToCompileNode.php
+++ b/src/NodeCompiler/Exception/UnableToCompileNode.php
@@ -12,6 +12,9 @@ use Roave\BetterReflection\Reflection\ReflectionClass;
 use function assert;
 use function sprintf;
 
+/**
+ * @internal
+ */
 class UnableToCompileNode extends LogicException
 {
     private ?string $constantName = null;

--- a/src/Reflection/ReflectionProperty.php
+++ b/src/Reflection/ReflectionProperty.php
@@ -15,6 +15,7 @@ use PhpParser\Node\Stmt\Namespace_;
 use PhpParser\Node\Stmt\Property as PropertyNode;
 use ReflectionException;
 use ReflectionProperty as CoreReflectionProperty;
+use Roave\BetterReflection\NodeCompiler\CompiledValue;
 use Roave\BetterReflection\NodeCompiler\CompileNodeToValue;
 use Roave\BetterReflection\NodeCompiler\CompilerContext;
 use Roave\BetterReflection\Reflection\Deprecated\DeprecatedHelper;
@@ -55,6 +56,8 @@ class ReflectionProperty
     private bool $declaredAtCompileTime = true;
 
     private Reflector $reflector;
+
+    private ?CompiledValue $compiledDefaultValue = null;
 
     private function __construct()
     {
@@ -289,13 +292,17 @@ class ReflectionProperty
             return null;
         }
 
-        return (new CompileNodeToValue())->__invoke(
-            $defaultValueNode,
-            new CompilerContext(
-                $this->reflector,
-                $this,
-            ),
-        );
+        if ($this->compiledDefaultValue === null) {
+            $this->compiledDefaultValue = (new CompileNodeToValue())->__invoke(
+                $defaultValueNode,
+                new CompilerContext(
+                    $this->reflector,
+                    $this,
+                ),
+            );
+        }
+
+        return $this->compiledDefaultValue->value;
     }
 
     public function isDeprecated(): bool

--- a/test/unit/NodeCompiler/CompiledValueTest.php
+++ b/test/unit/NodeCompiler/CompiledValueTest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Roave\BetterReflectionTest\NodeCompiler;
+
+use PHPUnit\Framework\TestCase;
+use Roave\BetterReflection\NodeCompiler\CompiledValue;
+
+/**
+ * @covers \Roave\BetterReflection\NodeCompiler\CompiledValue
+ */
+class CompiledValueTest extends TestCase
+{
+    public function testValuesHappyPath(): void
+    {
+        $compiledValue = new CompiledValue('value', 'constantName');
+
+        self::assertSame('value', $compiledValue->value);
+        self::assertSame('constantName', $compiledValue->constantName);
+    }
+}


### PR DESCRIPTION
The resolving of constant name and constant value is now always done in `CompileNodeToValue` - it means we don't need to resolve constant name for the first time in `ReflectionParameter` and for the second time in `CompileNodeToValue` again.