### PR TITLE
PHP 8.1: Implemented `ReflectionMethod`/`ReflectionFunction::hasTentativeReturnType()` and `getTentativeReturnType()`

### DIFF
--- a/src/Reflection/Adapter/ReflectionFunction.php
+++ b/src/Reflection/Adapter/ReflectionFunction.php
@@ -213,12 +213,12 @@ final class ReflectionFunction extends CoreReflectionFunction
 
     public function hasTentativeReturnType(): bool
     {
-        throw new Exception\NotImplemented('Not implemented');
+        return $this->betterReflectionFunction->hasTentativeReturnType();
     }
 
     public function getTentativeReturnType(): ?CoreReflectionType
     {
-        throw new Exception\NotImplemented('Not implemented');
+        return ReflectionType::fromTypeOrNull($this->betterReflectionFunction->getTentativeReturnType());
     }
 
     /**

--- a/src/Reflection/Adapter/ReflectionMethod.php
+++ b/src/Reflection/Adapter/ReflectionMethod.php
@@ -299,12 +299,12 @@ final class ReflectionMethod extends CoreReflectionMethod
 
     public function hasTentativeReturnType(): bool
     {
-        throw new Exception\NotImplemented('Not implemented');
+        return $this->betterReflectionMethod->hasTentativeReturnType();
     }
 
     public function getTentativeReturnType(): ?CoreReflectionType
     {
-        throw new Exception\NotImplemented('Not implemented');
+        return ReflectionType::fromTypeOrNull($this->betterReflectionMethod->getTentativeReturnType());
     }
 
     /**

--- a/src/Reflection/ReflectionFunctionAbstract.php
+++ b/src/Reflection/ReflectionFunctionAbstract.php
@@ -367,6 +367,24 @@ abstract class ReflectionFunctionAbstract
         return $this->node->getReturnType() !== null;
     }
 
+    public function hasTentativeReturnType(): bool
+    {
+        if ($this->isUserDefined()) {
+            return false;
+        }
+
+        return $this->hasReturnType();
+    }
+
+    public function getTentativeReturnType(): ReflectionNamedType|ReflectionUnionType|null
+    {
+        if ($this->isUserDefined()) {
+            return null;
+        }
+
+        return $this->getReturnType();
+    }
+
     /**
      * Set the return type declaration.
      */

--- a/src/SourceLocator/SourceStubber/ReflectionSourceStubber.php
+++ b/src/SourceLocator/SourceStubber/ReflectionSourceStubber.php
@@ -46,6 +46,7 @@ use function function_exists;
 use function get_defined_constants;
 use function in_array;
 use function interface_exists;
+use function method_exists;
 use function trait_exists;
 
 /**
@@ -116,6 +117,10 @@ final class ReflectionSourceStubber implements SourceStubber
         $this->addParameters($functionNode, $functionReflection);
 
         $returnType = $functionReflection->getReturnType();
+        if ($returnType === null && method_exists($functionReflection, 'getTentativeReturnType')) {
+            $returnType = $functionReflection->getTentativeReturnType();
+        }
+
         assert($returnType instanceof CoreReflectionNamedType || $returnType instanceof CoreReflectionUnionType || $returnType === null);
 
         if ($returnType !== null) {
@@ -379,6 +384,10 @@ final class ReflectionSourceStubber implements SourceStubber
             $this->addParameters($methodNode, $methodReflection);
 
             $returnType = $methodReflection->getReturnType();
+            if ($returnType === null && method_exists($methodReflection, 'getTentativeReturnType')) {
+                $returnType = $methodReflection->getTentativeReturnType();
+            }
+
             assert($returnType instanceof CoreReflectionNamedType || $returnType instanceof CoreReflectionUnionType || $returnType === null);
 
             if ($returnType !== null) {

--- a/test/unit/Reflection/Adapter/ReflectionFunctionTest.php
+++ b/test/unit/Reflection/Adapter/ReflectionFunctionTest.php
@@ -82,8 +82,8 @@ class ReflectionFunctionTest extends TestCase
             ['isGenerator', null, true, []],
             ['isVariadic', null, true, []],
             ['getAttributes', NotImplemented::class, null, []],
-            ['hasTentativeReturnType', NotImplemented::class, null, []],
-            ['getTentativeReturnType', NotImplemented::class, null, []],
+            ['hasTentativeReturnType', null, false, []],
+            ['getTentativeReturnType', null, null, []],
             ['getClosureUsedVariables', NotImplemented::class, null, []],
 
             // ReflectionFunction

--- a/test/unit/Reflection/Adapter/ReflectionMethodTest.php
+++ b/test/unit/Reflection/Adapter/ReflectionMethodTest.php
@@ -90,8 +90,8 @@ class ReflectionMethodTest extends TestCase
             ['isGenerator', null, true, []],
             ['isVariadic', null, true, []],
             ['getAttributes', NotImplemented::class, null, []],
-            ['hasTentativeReturnType', NotImplemented::class, null, []],
-            ['getTentativeReturnType', NotImplemented::class, null, []],
+            ['hasTentativeReturnType', null, false, []],
+            ['getTentativeReturnType', null, null, []],
             ['getClosureUsedVariables', NotImplemented::class, null, []],
 
             // ReflectionMethod

--- a/test/unit/SourceLocator/SourceStubber/ReflectionSourceStubberTest.php
+++ b/test/unit/SourceLocator/SourceStubber/ReflectionSourceStubberTest.php
@@ -37,6 +37,7 @@ use function get_declared_interfaces;
 use function get_declared_traits;
 use function get_defined_functions;
 use function in_array;
+use function method_exists;
 use function sort;
 
 /**
@@ -307,7 +308,13 @@ class ReflectionSourceStubberTest extends TestCase
         self::assertSame($original->isAbstract(), $stubbed->isAbstract());
         self::assertSame($original->isDeprecated(), $stubbed->isDeprecated());
 
-        self::assertSame((string) $original->getReturnType(), (string) $stubbed->getReturnType());
+        if (method_exists($original, 'hasTentativeReturnType') && $original->hasTentativeReturnType()) {
+            self::assertSame($original->hasTentativeReturnType(), $stubbed->hasTentativeReturnType());
+            self::assertSame((string) $original->getTentativeReturnType(), (string) $stubbed->getTentativeReturnType());
+        } else {
+            self::assertSame($original->hasReturnType(), $stubbed->hasReturnType());
+            self::assertSame((string) $original->getReturnType(), (string) $stubbed->getReturnType());
+        }
     }
 
     private function assertSameParameterAttributes(
@@ -377,7 +384,13 @@ class ReflectionSourceStubberTest extends TestCase
         $stubbedReflection  = $this->reflector->reflectFunction($functionName);
         $originalReflection = new CoreReflectionFunction($functionName);
 
-        self::assertSame((string) $originalReflection->getReturnType(), (string) $stubbedReflection->getReturnType());
+        if (method_exists($originalReflection, 'hasTentativeReturnType') && $originalReflection->hasTentativeReturnType()) {
+            self::assertSame($originalReflection->hasTentativeReturnType(), $stubbedReflection->hasTentativeReturnType());
+            self::assertSame((string) $originalReflection->getTentativeReturnType(), (string) $stubbedReflection->getTentativeReturnType());
+        } else {
+            self::assertSame($originalReflection->hasReturnType(), $stubbedReflection->hasReturnType());
+            self::assertSame((string) $originalReflection->getReturnType(), (string) $stubbedReflection->getReturnType());
+        }
     }
 
     public function testFunctionWithParameterPassedByReference(): void


### PR DESCRIPTION
It's just very stupid implementation:

- is user-defined -> is not tentative
- is internal -> is tentative

May be improved with next release of PHPStorm stubs: https://github.com/JetBrains/phpstorm-stubs/pull/1234

So we may wait...
