### PR TITLE
`ReflectionMethod` and `ReflectionFunction` no longer extend `ReflectionFunctionAbstract`

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -54,7 +54,7 @@ ReflectionParameter::createFromSpec([new \SplDoublyLinkedList, 'add'], 'index');
 ReflectionParameter::createFromSpec('my_function', 'param1');
 // Creating a ReflectionParameter from a closure is not supported yet :(
 
-ReflectionProperty::createFromName(\ReflectionFunctionAbstract::class, 'name');
+ReflectionProperty::createFromName(\ReflectionFunction::class, 'name');
 ReflectionProperty::createFromInstance(new \ReflectionClass(\stdClass::class), 'name');
 ```
 

--- a/src/Identifier/Identifier.php
+++ b/src/Identifier/Identifier.php
@@ -6,7 +6,7 @@ namespace Roave\BetterReflection\Identifier;
 
 use Roave\BetterReflection\Identifier\Exception\InvalidIdentifierName;
 use Roave\BetterReflection\Reflection\ReflectionClass;
-use Roave\BetterReflection\Reflection\ReflectionFunctionAbstract;
+use Roave\BetterReflection\Reflection\ReflectionFunction;
 
 use function ltrim;
 use function preg_match;
@@ -27,7 +27,7 @@ class Identifier
     {
         if (
             $name === self::WILDCARD
-            || $name === ReflectionFunctionAbstract::CLOSURE_NAME
+            || $name === ReflectionFunction::CLOSURE_NAME
             || strpos($name, ReflectionClass::ANONYMOUS_CLASS_NAME_PREFIX) === 0
         ) {
             $this->name = $name;

--- a/src/NodeCompiler/CompilerContext.php
+++ b/src/NodeCompiler/CompilerContext.php
@@ -9,7 +9,6 @@ use Roave\BetterReflection\Reflection\ReflectionClassConstant;
 use Roave\BetterReflection\Reflection\ReflectionConstant;
 use Roave\BetterReflection\Reflection\ReflectionEnumCase;
 use Roave\BetterReflection\Reflection\ReflectionFunction;
-use Roave\BetterReflection\Reflection\ReflectionFunctionAbstract;
 use Roave\BetterReflection\Reflection\ReflectionMethod;
 use Roave\BetterReflection\Reflection\ReflectionParameter;
 use Roave\BetterReflection\Reflection\ReflectionProperty;
@@ -74,7 +73,7 @@ class CompilerContext
         return $this->contextReflection->getImplementingClass();
     }
 
-    public function getFunction(): ?ReflectionFunctionAbstract
+    public function getFunction(): ReflectionMethod|ReflectionFunction|null
     {
         if ($this->contextReflection instanceof ReflectionMethod) {
             return $this->contextReflection;

--- a/src/Reflection/Adapter/ReflectionParameter.php
+++ b/src/Reflection/Adapter/ReflectionParameter.php
@@ -12,7 +12,6 @@ use Roave\BetterReflection\Reflection\ReflectionMethod as BetterReflectionMethod
 use Roave\BetterReflection\Reflection\ReflectionParameter as BetterReflectionParameter;
 
 use function array_map;
-use function assert;
 
 final class ReflectionParameter extends CoreReflectionParameter
 {
@@ -43,7 +42,6 @@ final class ReflectionParameter extends CoreReflectionParameter
     public function getDeclaringFunction(): CoreReflectionFunctionAbstract
     {
         $function = $this->betterReflectionParameter->getDeclaringFunction();
-        assert($function instanceof BetterReflectionMethod || $function instanceof \Roave\BetterReflection\Reflection\ReflectionFunction);
 
         if ($function instanceof BetterReflectionMethod) {
             return new ReflectionMethod($function);

--- a/src/Reflection/ReflectionClass.php
+++ b/src/Reflection/ReflectionClass.php
@@ -239,7 +239,6 @@ class ReflectionClass implements Reflection
         $traitModifiers   = $this->getTraitModifiers();
 
         $methodAst = $method->getAst();
-        assert($methodAst instanceof ClassMethod);
 
         $methodHash = $this->methodHash($method->getImplementingClass()->getName(), $method->getName());
 
@@ -284,20 +283,15 @@ class ReflectionClass implements Reflection
             ...array_map(
                 function (ReflectionClass $ancestor): array {
                     return array_map(
-                        function (ReflectionMethod $method): ReflectionMethod {
-                            $methodAst = $method->getAst();
-                            assert($methodAst instanceof ClassMethod);
-
-                            return ReflectionMethod::createFromNode(
-                                $this->reflector,
-                                $methodAst,
-                                $this->locatedSource,
-                                $method->getDeclaringClass()->getDeclaringNamespaceAst(),
-                                $method->getDeclaringClass(),
-                                $method->getImplementingClass(),
-                                $this,
-                            );
-                        },
+                        fn (ReflectionMethod $method): ReflectionMethod => ReflectionMethod::createFromNode(
+                            $this->reflector,
+                            $method->getAst(),
+                            $this->locatedSource,
+                            $method->getDeclaringClass()->getDeclaringNamespaceAst(),
+                            $method->getDeclaringClass(),
+                            $method->getImplementingClass(),
+                            $this,
+                        ),
                         $ancestor->getMethods(),
                     );
                 },

--- a/src/Reflection/ReflectionFunction.php
+++ b/src/Reflection/ReflectionFunction.php
@@ -69,6 +69,11 @@ class ReflectionFunction implements Reflection
         return $function;
     }
 
+    public function getAst(): Node\Stmt\Function_|Node\Expr\Closure|Node\Expr\ArrowFunction
+    {
+        return $this->functionNode;
+    }
+
     /**
      * Get the "short" name of the function (e.g. for A\B\foo, this will return
      * "foo").

--- a/src/Reflection/ReflectionFunctionAbstract.php
+++ b/src/Reflection/ReflectionFunctionAbstract.php
@@ -177,7 +177,7 @@ trait ReflectionFunctionAbstract
 
     public function setDocCommentFromString(string $string): void
     {
-        $this->getAst()->setDocComment(new Doc($string));
+        $this->node->setDocComment(new Doc($string));
     }
 
     public function getFileName(): ?string
@@ -446,10 +446,7 @@ trait ReflectionFunctionAbstract
     /**
      * Fetch the AST for this method or function.
      */
-    public function getAst(): Node\Stmt\ClassMethod|Node\Stmt\Function_|Node\Expr\Closure|Node\Expr\ArrowFunction
-    {
-        return $this->node;
-    }
+    abstract public function getAst(): Node\Stmt\ClassMethod|Node\Stmt\Function_|Node\Expr\Closure|Node\Expr\ArrowFunction;
 
     /**
      * @return list<ReflectionAttribute>

--- a/src/Reflection/ReflectionFunctionAbstract.php
+++ b/src/Reflection/ReflectionFunctionAbstract.php
@@ -40,13 +40,11 @@ use function is_array;
 use function is_string;
 use function strtolower;
 
-abstract class ReflectionFunctionAbstract
+trait ReflectionFunctionAbstract
 {
-    public const CLOSURE_NAME = '{closure}';
-
     private static ?Parser $parser;
 
-    protected function __construct(
+    private function __construct(
         private Reflector $reflector,
         private Node\Stmt\ClassMethod|Node\Stmt\Function_|Node\Expr\Closure|Node\Expr\ArrowFunction $node,
         private LocatedSource $locatedSource,
@@ -91,28 +89,11 @@ abstract class ReflectionFunctionAbstract
     }
 
     /**
-     * Get the "short" name of the function (e.g. for A\B\foo, this will return
-     * "foo").
-     */
-    public function getShortName(): string
-    {
-        if ($this->node instanceof Node\Expr\Closure || $this->node instanceof Node\Expr\ArrowFunction) {
-            return self::CLOSURE_NAME;
-        }
-
-        return $this->node->name->name;
-    }
-
-    /**
      * Get the "namespace" name of the function (e.g. for A\B\foo, this will
      * return "A\B").
      */
     public function getNamespaceName(): string
     {
-        if (! $this->inNamespace()) {
-            return '';
-        }
-
         return $this->declaringNamespace?->name?->toString() ?? '';
     }
 
@@ -395,8 +376,6 @@ abstract class ReflectionFunctionAbstract
             return null;
         }
 
-        assert($this instanceof ReflectionMethod || $this instanceof ReflectionFunction);
-
         return ReflectionType::createFromNode($this->reflector, $this, $returnType);
     }
 
@@ -512,12 +491,11 @@ abstract class ReflectionFunctionAbstract
     {
         $closureReflection = (new ClosureSourceLocator($newBody, $this->loadStaticParser()))->locateIdentifier(
             $this->reflector,
-            new Identifier(self::CLOSURE_NAME, new IdentifierType(IdentifierType::IDENTIFIER_FUNCTION)),
+            new Identifier(ReflectionFunction::CLOSURE_NAME, new IdentifierType(IdentifierType::IDENTIFIER_FUNCTION)),
         );
-        assert($closureReflection instanceof self);
-        assert($closureReflection->node instanceof Node\Expr\Closure || $closureReflection->node instanceof Node\Expr\ArrowFunction);
+        assert($closureReflection instanceof ReflectionFunction);
 
-        $this->setBodyFromAst($closureReflection->node->getStmts());
+        $this->setBodyFromAst($closureReflection->getAst()->getStmts());
     }
 
     /**

--- a/src/Reflection/ReflectionFunctionAbstract.php
+++ b/src/Reflection/ReflectionFunctionAbstract.php
@@ -75,6 +75,10 @@ trait ReflectionFunctionAbstract
         }
     }
 
+    abstract public function __toString(): string;
+
+    abstract public function getShortName(): string;
+
     /**
      * Get the "full" name of the function (e.g. for A\B\foo, this will return
      * "A\B\foo").

--- a/src/Reflection/ReflectionMethod.php
+++ b/src/Reflection/ReflectionMethod.php
@@ -194,6 +194,11 @@ class ReflectionMethod
         return '';
     }
 
+    public function isClosure(): bool
+    {
+        return false;
+    }
+
     /**
      * Is the method abstract.
      */

--- a/src/Reflection/ReflectionMethod.php
+++ b/src/Reflection/ReflectionMethod.php
@@ -86,6 +86,11 @@ class ReflectionMethod
         return ReflectionClass::createFromInstance($instance)->getMethod($methodName);
     }
 
+    public function getAst(): MethodNode
+    {
+        return $this->methodNode;
+    }
+
     public function getShortName(): string
     {
         if ($this->aliasName !== null) {

--- a/src/Reflection/ReflectionMethod.php
+++ b/src/Reflection/ReflectionMethod.php
@@ -24,8 +24,10 @@ use function sprintf;
 use function strtolower;
 use function trait_exists;
 
-class ReflectionMethod extends ReflectionFunctionAbstract
+class ReflectionMethod
 {
+    use ReflectionFunctionAbstract;
+
     private ReflectionClass $declaringClass;
 
     private ReflectionClass $implementingClass;
@@ -90,7 +92,7 @@ class ReflectionMethod extends ReflectionFunctionAbstract
             return $this->aliasName;
         }
 
-        return parent::getShortName();
+        return $this->methodNode->name->name;
     }
 
     public function getAliasName(): ?string
@@ -180,6 +182,11 @@ class ReflectionMethod extends ReflectionFunctionAbstract
     public function inNamespace(): bool
     {
         return false;
+    }
+
+    public function getNamespaceName(): string
+    {
+        return '';
     }
 
     /**

--- a/src/Reflection/ReflectionParameter.php
+++ b/src/Reflection/ReflectionParameter.php
@@ -37,7 +37,7 @@ class ReflectionParameter
 
     private ?Namespace_ $declaringNamespace;
 
-    private ReflectionFunctionAbstract $function;
+    private ReflectionMethod|ReflectionFunction $function;
 
     private int $parameterIndex;
 
@@ -137,7 +137,7 @@ class ReflectionParameter
         Reflector $reflector,
         ParamNode $node,
         ?Namespace_ $declaringNamespace,
-        ReflectionFunctionAbstract $function,
+        ReflectionMethod|ReflectionFunction $function,
         int $parameterIndex,
     ): self {
         $param                     = new self();
@@ -182,7 +182,7 @@ class ReflectionParameter
     /**
      * Get the function (or method) that declared this parameter.
      */
-    public function getDeclaringFunction(): ReflectionFunctionAbstract
+    public function getDeclaringFunction(): ReflectionMethod|ReflectionFunction
     {
         return $this->function;
     }

--- a/src/TypesFinder/FindParameterType.php
+++ b/src/TypesFinder/FindParameterType.php
@@ -10,7 +10,8 @@ use phpDocumentor\Reflection\Type;
 use PhpParser\Node\Expr\Error;
 use PhpParser\Node\Param as ParamNode;
 use PhpParser\Node\Stmt\Namespace_;
-use Roave\BetterReflection\Reflection\ReflectionFunctionAbstract;
+use Roave\BetterReflection\Reflection\ReflectionFunction;
+use Roave\BetterReflection\Reflection\ReflectionMethod;
 use Roave\BetterReflection\TypesFinder\PhpDocumentor\NamespaceNodeToReflectionTypeContext;
 
 use function explode;
@@ -35,7 +36,7 @@ class FindParameterType
      *
      * @return list<Type>
      */
-    public function __invoke(ReflectionFunctionAbstract $function, ?Namespace_ $namespace, ParamNode $node): array
+    public function __invoke(ReflectionMethod|ReflectionFunction $function, ?Namespace_ $namespace, ParamNode $node): array
     {
         $docComment = $function->getDocComment();
 

--- a/src/TypesFinder/FindReturnType.php
+++ b/src/TypesFinder/FindReturnType.php
@@ -8,7 +8,8 @@ use phpDocumentor\Reflection\DocBlock\Tags\Return_;
 use phpDocumentor\Reflection\DocBlockFactory;
 use phpDocumentor\Reflection\Type;
 use PhpParser\Node\Stmt\Namespace_;
-use Roave\BetterReflection\Reflection\ReflectionFunctionAbstract;
+use Roave\BetterReflection\Reflection\ReflectionFunction;
+use Roave\BetterReflection\Reflection\ReflectionMethod;
 use Roave\BetterReflection\TypesFinder\PhpDocumentor\NamespaceNodeToReflectionTypeContext;
 
 use function explode;
@@ -33,7 +34,7 @@ class FindReturnType
      *
      * @return list<Type>
      */
-    public function __invoke(ReflectionFunctionAbstract $function, ?Namespace_ $namespace): array
+    public function __invoke(ReflectionMethod|ReflectionFunction $function, ?Namespace_ $namespace): array
     {
         $docComment = $function->getDocComment();
 

--- a/test/unit/Identifier/IdentifierTest.php
+++ b/test/unit/Identifier/IdentifierTest.php
@@ -9,7 +9,7 @@ use Roave\BetterReflection\Identifier\Exception\InvalidIdentifierName;
 use Roave\BetterReflection\Identifier\Identifier;
 use Roave\BetterReflection\Identifier\IdentifierType;
 use Roave\BetterReflection\Reflection\ReflectionClass;
-use Roave\BetterReflection\Reflection\ReflectionFunctionAbstract;
+use Roave\BetterReflection\Reflection\ReflectionFunction;
 
 /**
  * @covers \Roave\BetterReflection\Identifier\Identifier
@@ -62,8 +62,8 @@ class IdentifierTest extends TestCase
 
     public function testGetNameForClosure(): void
     {
-        $identifier = new Identifier(ReflectionFunctionAbstract::CLOSURE_NAME, new IdentifierType(IdentifierType::IDENTIFIER_FUNCTION));
-        self::assertSame(ReflectionFunctionAbstract::CLOSURE_NAME, $identifier->getName());
+        $identifier = new Identifier(ReflectionFunction::CLOSURE_NAME, new IdentifierType(IdentifierType::IDENTIFIER_FUNCTION));
+        self::assertSame(ReflectionFunction::CLOSURE_NAME, $identifier->getName());
     }
 
     public function testGetNameForAnonymousClass(): void

--- a/test/unit/Reflection/ReflectionFunctionAbstractTest.php
+++ b/test/unit/Reflection/ReflectionFunctionAbstractTest.php
@@ -19,7 +19,6 @@ use ReflectionClass as CoreReflectionClass;
 use Roave\BetterReflection\Reflection\Exception\InvalidArrowFunctionBodyNode;
 use Roave\BetterReflection\Reflection\Exception\Uncloneable;
 use Roave\BetterReflection\Reflection\ReflectionFunction;
-use Roave\BetterReflection\Reflection\ReflectionFunctionAbstract;
 use Roave\BetterReflection\Reflection\ReflectionParameter;
 use Roave\BetterReflection\Reflection\ReflectionType;
 use Roave\BetterReflection\Reflector\DefaultReflector;
@@ -66,6 +65,7 @@ class ReflectionFunctionAbstractTest extends TestCase
         $functionInfo = $reflector->reflectFunction('Foo\bar');
 
         self::assertSame('Foo\bar', $functionInfo->getName());
+        self::assertTrue($functionInfo->inNamespace());
         self::assertSame('Foo', $functionInfo->getNamespaceName());
         self::assertSame('bar', $functionInfo->getShortName());
     }
@@ -78,6 +78,20 @@ class ReflectionFunctionAbstractTest extends TestCase
         $functionInfo = $reflector->reflectFunction('foo');
 
         self::assertSame('foo', $functionInfo->getName());
+        self::assertFalse($functionInfo->inNamespace());
+        self::assertSame('', $functionInfo->getNamespaceName());
+        self::assertSame('foo', $functionInfo->getShortName());
+    }
+
+    public function testNameMethodsInRootNamespace(): void
+    {
+        $php = '<?php namespace { function foo() {} }';
+
+        $reflector    = new DefaultReflector(new StringSourceLocator($php, $this->astLocator));
+        $functionInfo = $reflector->reflectFunction('foo');
+
+        self::assertSame('foo', $functionInfo->getName());
+        self::assertFalse($functionInfo->inNamespace());
         self::assertSame('', $functionInfo->getNamespaceName());
         self::assertSame('foo', $functionInfo->getShortName());
     }
@@ -92,9 +106,9 @@ class ReflectionFunctionAbstractTest extends TestCase
             ),
         ))->reflectFunction('foo');
 
-        self::assertSame('Roave\BetterReflectionTest\Reflection\\' . ReflectionFunctionAbstract::CLOSURE_NAME, $functionInfo->getName());
+        self::assertSame('Roave\BetterReflectionTest\Reflection\\' . ReflectionFunction::CLOSURE_NAME, $functionInfo->getName());
         self::assertSame('Roave\BetterReflectionTest\Reflection', $functionInfo->getNamespaceName());
-        self::assertSame(ReflectionFunctionAbstract::CLOSURE_NAME, $functionInfo->getShortName());
+        self::assertSame(ReflectionFunction::CLOSURE_NAME, $functionInfo->getShortName());
     }
 
     public function testIsClosureWithRegularFunction(): void
@@ -115,7 +129,7 @@ class ReflectionFunctionAbstractTest extends TestCase
                 },
                 $this->parser,
             ),
-        ))->reflectFunction(ReflectionFunctionAbstract::CLOSURE_NAME);
+        ))->reflectFunction(ReflectionFunction::CLOSURE_NAME);
 
         self::assertTrue($function->isClosure());
     }

--- a/test/unit/Reflection/ReflectionMethodTest.php
+++ b/test/unit/Reflection/ReflectionMethodTest.php
@@ -85,6 +85,14 @@ class ReflectionMethodTest extends TestCase
         self::assertSame('add', $method->getName());
     }
 
+    public function testIsClosure(): void
+    {
+        $classInfo = $this->reflector->reflectClass(Methods::class);
+        $method    = $classInfo->getMethod('__construct');
+
+        self::assertFalse($method->isClosure());
+    }
+
     /**
      * @return array
      */

--- a/test/unit/TypesFinder/FindParameterTypeTest.php
+++ b/test/unit/TypesFinder/FindParameterTypeTest.php
@@ -15,7 +15,6 @@ use PhpParser\Node\Stmt\Namespace_;
 use PhpParser\Node\Stmt\Use_ as UseStatement;
 use PHPUnit\Framework\TestCase;
 use Roave\BetterReflection\Reflection\ReflectionFunction;
-use Roave\BetterReflection\Reflection\ReflectionFunctionAbstract;
 use Roave\BetterReflection\Reflector\DefaultReflector;
 use Roave\BetterReflection\SourceLocator\Type\StringSourceLocator;
 use Roave\BetterReflection\TypesFinder\FindParameterType;
@@ -111,7 +110,7 @@ class FindParameterTypeTest extends TestCase
         $node     = new ParamNode(new Variable($nodeName));
         $docBlock = sprintf("/**\n * %s\n */", $docBlock);
 
-        $method = $this->createMock(ReflectionFunctionAbstract::class);
+        $method = $this->createMock(ReflectionFunction::class);
 
         $method
             ->expects($this->once())
@@ -131,7 +130,7 @@ class FindParameterTypeTest extends TestCase
     {
         $node = new ParamNode(new Variable('foo'));
 
-        $function = $this->createMock(ReflectionFunctionAbstract::class);
+        $function = $this->createMock(ReflectionFunction::class);
 
         $function
             ->expects(self::once())
@@ -157,7 +156,7 @@ class FindParameterTypeTest extends TestCase
 
         $parameterNode = new ParamNode(new Variable('foo'));
 
-        $function = $this->createMock(ReflectionFunctionAbstract::class);
+        $function = $this->createMock(ReflectionFunction::class);
 
         $function
             ->expects(self::once())

--- a/test/unit/TypesFinder/FindReturnTypeTest.php
+++ b/test/unit/TypesFinder/FindReturnTypeTest.php
@@ -13,7 +13,6 @@ use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\Namespace_;
 use PHPUnit\Framework\TestCase;
 use Roave\BetterReflection\Reflection\ReflectionFunction;
-use Roave\BetterReflection\Reflection\ReflectionFunctionAbstract;
 use Roave\BetterReflection\Reflection\ReflectionMethod;
 use Roave\BetterReflection\TypesFinder\FindReturnType;
 
@@ -117,7 +116,7 @@ class FindReturnTypeTest extends TestCase
     ): void {
         $docBlock = sprintf("/**\n * @return %s\n */", $returnType);
 
-        $function = $this->createMock(ReflectionFunctionAbstract::class);
+        $function = $this->createMock(ReflectionFunction::class);
 
         $function
             ->expects($this->once())


### PR DESCRIPTION
`ReflectionFunctionAbstract` is trait now

This change is necessary because `ReflectionFunctionAbstract`, when used as a type hint, is too generic, and may refer to multiple things.

In fact, we often have to `assert($function instanceof ReflectionMethod)` or similar: by using PHP 8 union types, we can be much more specific about which kind of function we want, and `ReflectionFunctionAbstract` can be avoided. 