### PR TITLE
Run coverage and mutation tests all at once

### DIFF
--- a/.github/workflows/mutation-tests.yml
+++ b/.github/workflows/mutation-tests.yml
@@ -33,8 +33,6 @@ jobs:
           coverage: "xdebug"
           php-version: "${{ matrix.php-version }}"
           ini-values: memory_limit=-1, zend.assertions=1
-        env:
-          update: true
 
       - name: "Cache dependencies"
         uses: "actions/cache@v2"
@@ -57,20 +55,8 @@ jobs:
         if: ${{ matrix.dependencies == 'locked' }}
         run: "composer install --no-interaction --no-progress"
 
-      - name: "Generate code coverage"
-        run: "vendor/bin/phpunit --coverage-xml=coverage/coverage-xml --log-junit=coverage/junit.xml"
-
-      - name: "Install PHP without xdebug"
-        uses: "shivammathur/setup-php@v2"
-        with:
-          coverage: "none"
-          php-version: "${{ matrix.php-version }}"
-          ini-values: memory_limit=-1
-        env:
-          update: true
-
       - name: "Infection"
-        run: "vendor/bin/roave-infection-static-analysis-plugin --skip-initial-tests --coverage=coverage --threads=$(nproc)"
+        run: "vendor/bin/roave-infection-static-analysis-plugin --threads=$(nproc)"
         env:
           INFECTION_BADGE_API_KEY: ${{ secrets.INFECTION_BADGE_API_KEY }}
           STRYKER_DASHBOARD_API_KEY: ${{ secrets.STRYKER_DASHBOARD_API_KEY }}

--- a/infection.json.dist
+++ b/infection.json.dist
@@ -14,6 +14,6 @@
     "mutators": {
         "@default": true
     },
-    "minMsi": 93,
+    "minMsi": 94,
     "minCoveredMsi": 94
 }


### PR DESCRIPTION
It has better results 🤷‍♂️ 

```diff
 3429 mutations were generated:
-    2700 mutants were killed
+    2779 mutants were killed
        1 mutants were not covered by tests
-     157 covered mutants were not detected
+     139 covered mutants were not detected
        8 errors were encountered
        0 syntax errors were encountered
-       4 time outs were encountered
+       5 time outs were encountered
-     559 mutants required more time than configured
+     497 mutants required more time than configured
```