### PR TITLE
Fixed parsing of `PhpStormStubsElementAvailable` in `PhpStormStubsSourceStubber`

### DIFF
--- a/src/SourceLocator/SourceStubber/PhpStormStubsSourceStubber.php
+++ b/src/SourceLocator/SourceStubber/PhpStormStubsSourceStubber.php
@@ -507,7 +507,7 @@ final class PhpStormStubsSourceStubber implements SourceStubber
 
                         assert($attributeArg->value instanceof Node\Scalar\String_);
 
-                        $toVersion = $this->parsePhpVersion($attributeArg->value->value);
+                        $toVersion = $this->parsePhpVersion($attributeArg->value->value, 99);
                     }
                 }
             }
@@ -516,11 +516,11 @@ final class PhpStormStubsSourceStubber implements SourceStubber
         return [$fromVersion, $toVersion];
     }
 
-    private function parsePhpVersion(string $version): int
+    private function parsePhpVersion(string $version, int $defaultPatch = 0): int
     {
         $parts = array_map('intval', explode('.', $version));
 
-        return $parts[0] * 10000 + $parts[1] * 100 + ($parts[2] ?? 0);
+        return $parts[0] * 10000 + $parts[1] * 100 + ($parts[2] ?? $defaultPatch);
     }
 
     private function getStubsDirectory(): string

--- a/test/unit/SourceLocator/SourceStubber/PhpStormStubsSourceStubberTest.php
+++ b/test/unit/SourceLocator/SourceStubber/PhpStormStubsSourceStubberTest.php
@@ -906,7 +906,7 @@ class PhpStormStubsSourceStubberTest extends TestCase
 
     public function testFunctionWithDifferentParameterInPhpVersion74(): void
     {
-        $sourceStubber            = new PhpStormStubsSourceStubber($this->phpParser, 70400);
+        $sourceStubber            = new PhpStormStubsSourceStubber($this->phpParser, 70499);
         $phpInternalSourceLocator = new PhpInternalSourceLocator($this->astLocator, $sourceStubber);
         $reflector                = new DefaultReflector($phpInternalSourceLocator);
 


### PR DESCRIPTION
`to: '7.2'` means to PHP "7.2.99"

It will be needed for stubs 2021.3, see https://github.com/JetBrains/phpstorm-stubs/blob/master/bcmath/bcmath.php#L198-L201