### PR TITLE
Promoted property with a default value does not have a default value - the default value is on the parameter only

### DIFF
--- a/src/Reflection/ReflectionClass.php
+++ b/src/Reflection/ReflectionClass.php
@@ -765,7 +765,7 @@ class ReflectionClass implements Reflection
 
                     $propertyNode                     = new Node\Stmt\Property(
                         $parameterNode->flags,
-                        [new Node\Stmt\PropertyProperty($parameterNameNode->name, $parameterNode->default)],
+                        [new Node\Stmt\PropertyProperty($parameterNameNode->name)],
                         $parameterNode->getAttributes(),
                         $parameterNode->type,
                         $parameterNode->attrGroups,

--- a/test/unit/Reflection/ReflectionPropertyTest.php
+++ b/test/unit/Reflection/ReflectionPropertyTest.php
@@ -254,8 +254,8 @@ class ReflectionPropertyTest extends TestCase
         self::assertTrue($promotedProperty->isPrivate());
         self::assertTrue($promotedProperty->hasType());
         self::assertSame('?int', $promotedProperty->getType()->__toString());
-        self::assertTrue($promotedProperty->hasDefaultValue());
-        self::assertSame(123, $promotedProperty->getDefaultValue());
+        self::assertFalse($promotedProperty->hasDefaultValue());
+        self::assertNull($promotedProperty->getDefaultValue());
         self::assertSame(46, $promotedProperty->getStartLine());
         self::assertSame(46, $promotedProperty->getEndLine());
         self::assertSame(60, $promotedProperty->getStartColumn());


### PR DESCRIPTION
The desugaring is described in the RFC (https://wiki.php.net/rfc/constructor_promotion#desugaring):

> Notably, the property is declared without a default value (i.e. it starts out in an uninitialized state), and the default value is only specified on the constructor parameter. 

Runtime proof: https://3v4l.org/tu2AT