### PR TITLE
We should add `Stringable` interface only when it can be reflected

### DIFF
--- a/src/Reflection/ReflectionClass.php
+++ b/src/Reflection/ReflectionClass.php
@@ -1112,7 +1112,16 @@ class ReflectionClass implements Reflection
 
         foreach ($this->node->getMethods() as $methodNode) {
             if ($methodNode->name->toLowerString() === '__tostring') {
-                $interfaces[$stringableClassName] = $this->reflectClassForNamedNode(new Node\Name(Stringable::class));
+                try {
+                    $stringableInterfaceReflection = $this->reflectClassForNamedNode(new Node\Name($stringableClassName));
+
+                    if ($stringableInterfaceReflection->isInternal()) {
+                        $interfaces[$stringableClassName] = $stringableInterfaceReflection;
+                    }
+                } catch (IdentifierNotFound) {
+                    // Stringable interface does not exist on target PHP version
+                }
+
                 break;
             }
         }

--- a/test/unit/Reflection/ReflectionClassTest.php
+++ b/test/unit/Reflection/ReflectionClassTest.php
@@ -2383,6 +2383,50 @@ PHP;
         self::assertArrayHasKey(Stringable::class, $interfaceNotExtendingStringable->getImmediateInterfaces());
     }
 
+    public function testNoStringableInterfaceWhenStringableNotFound(): void
+    {
+        $php = <<<'PHP'
+            <?php
+
+            class NoStringable
+            {
+                public function __toString(): string
+                {
+                }
+            }
+        PHP;
+
+        $reflector = new DefaultReflector(new StringSourceLocator($php, $this->astLocator));
+
+        $noStringable = $reflector->reflectClass('NoStringable');
+
+        self::assertNotContains(Stringable::class, $noStringable->getInterfaceNames());
+    }
+
+    public function testNoStringableInterfaceWhenStringableIsNotInternal(): void
+    {
+        $php = <<<'PHP'
+            <?php
+
+            class Stringable
+            {
+            }
+
+            class NoStringable
+            {
+                public function __toString(): string
+                {
+                }
+            }
+        PHP;
+
+        $reflector = new DefaultReflector(new StringSourceLocator($php, $this->astLocator));
+
+        $noStringable = $reflector->reflectClass('NoStringable');
+
+        self::assertNotContains(Stringable::class, $noStringable->getInterfaceNames());
+    }
+
     public function testHasAllInterfacesWithStringable(): void
     {
         $php = <<<'PHP'


### PR DESCRIPTION
I made a little ugly optimization.