### PR TITLE
Ensure that simple union types like `A|null` yield a nullable `ReflectionNamedType`

### DIFF
--- a/src/Reflection/Adapter/ReflectionEnum.php
+++ b/src/Reflection/Adapter/ReflectionEnum.php
@@ -509,7 +509,7 @@ final class ReflectionEnum extends CoreReflectionEnum
     public function getBackingType(): ?ReflectionNamedType
     {
         if ($this->betterReflectionEnum->isBacked()) {
-            return new ReflectionNamedType($this->betterReflectionEnum->getBackingType());
+            return new ReflectionNamedType($this->betterReflectionEnum->getBackingType(), false);
         }
 
         return null;

--- a/src/Reflection/Adapter/ReflectionNamedType.php
+++ b/src/Reflection/Adapter/ReflectionNamedType.php
@@ -12,7 +12,7 @@ use Roave\BetterReflection\Reflection\ReflectionNamedType as BetterReflectionNam
  */
 final class ReflectionNamedType extends CoreReflectionNamedType
 {
-    public function __construct(private BetterReflectionNamedType $betterReflectionType)
+    public function __construct(private BetterReflectionNamedType $betterReflectionType, private bool $allowsNull)
     {
     }
 
@@ -23,12 +23,13 @@ final class ReflectionNamedType extends CoreReflectionNamedType
 
     public function __toString(): string
     {
-        return $this->betterReflectionType->__toString();
+        return ($this->allowsNull ? '?' : '')
+            . $this->betterReflectionType->__toString();
     }
 
     public function allowsNull(): bool
     {
-        return $this->betterReflectionType->allowsNull();
+        return $this->allowsNull;
     }
 
     public function isBuiltin(): bool

--- a/src/Reflection/ReflectionIntersectionType.php
+++ b/src/Reflection/ReflectionIntersectionType.php
@@ -22,7 +22,7 @@ class ReflectionIntersectionType extends ReflectionType
         ReflectionParameter|ReflectionMethod|ReflectionFunction|ReflectionEnum|ReflectionProperty $owner,
         IntersectionType $type,
     ) {
-        parent::__construct($reflector, $owner, false);
+        parent::__construct($reflector, $owner);
 
         $this->types = array_filter(
             array_map(static fn (Node\Identifier|Node\Name $type): ReflectionNamedType|ReflectionUnionType|ReflectionIntersectionType => ReflectionType::createFromNode($reflector, $owner, $type), $type->types),
@@ -36,6 +36,11 @@ class ReflectionIntersectionType extends ReflectionType
     public function getTypes(): array
     {
         return $this->types;
+    }
+
+    public function allowsNull(): bool
+    {
+        return false;
     }
 
     public function __toString(): string

--- a/src/Reflection/ReflectionNamedType.php
+++ b/src/Reflection/ReflectionNamedType.php
@@ -40,9 +40,8 @@ class ReflectionNamedType extends ReflectionType
         Reflector $reflector,
         ReflectionParameter|ReflectionMethod|ReflectionFunction|ReflectionEnum|ReflectionProperty $owner,
         Identifier|Name $type,
-        bool $allowsNull,
     ) {
-        parent::__construct($reflector, $owner, $allowsNull);
+        parent::__construct($reflector, $owner);
 
         $this->name = $type->toString();
     }
@@ -102,13 +101,13 @@ class ReflectionNamedType extends ReflectionType
         throw new LogicException(sprintf('The type %s cannot be resolved to class', $this->name));
     }
 
+    public function allowsNull(): bool
+    {
+        return false;
+    }
+
     public function __toString(): string
     {
-        $name = '';
-        if ($this->allowsNull()) {
-            $name .= '?';
-        }
-
-        return $name . $this->getName();
+        return $this->getName();
     }
 }

--- a/src/Reflection/ReflectionType.php
+++ b/src/Reflection/ReflectionType.php
@@ -11,6 +11,10 @@ use PhpParser\Node\NullableType;
 use PhpParser\Node\UnionType;
 use Roave\BetterReflection\Reflector\Reflector;
 
+use function array_filter;
+use function array_values;
+use function count;
+
 abstract class ReflectionType
 {
     protected function __construct(
@@ -41,6 +45,15 @@ abstract class ReflectionType
 
         if ($type instanceof IntersectionType) {
             return new ReflectionIntersectionType($reflector, $owner, $type);
+        }
+
+        $nonNullTypes = array_values(array_filter(
+            $type->types,
+            static fn (Identifier|Name $type): bool => $type->toString() !== 'null',
+        ));
+
+        if (count($nonNullTypes) === 1) {
+            return self::createFromNode($reflector, $owner, $nonNullTypes[0], true);
         }
 
         return new ReflectionUnionType($reflector, $owner, $type, $allowsNull);

--- a/src/Reflection/ReflectionUnionType.php
+++ b/src/Reflection/ReflectionUnionType.php
@@ -21,9 +21,8 @@ class ReflectionUnionType extends ReflectionType
         Reflector $reflector,
         ReflectionParameter|ReflectionMethod|ReflectionFunction|ReflectionEnum|ReflectionProperty $owner,
         UnionType $type,
-        bool $allowsNull,
     ) {
-        parent::__construct($reflector, $owner, $allowsNull);
+        parent::__construct($reflector, $owner);
 
         $this->types = array_filter(
             array_map(static fn (Node\Identifier|Node\Name $type): ReflectionNamedType|ReflectionUnionType|ReflectionIntersectionType => ReflectionType::createFromNode($reflector, $owner, $type), $type->types),
@@ -37,6 +36,17 @@ class ReflectionUnionType extends ReflectionType
     public function getTypes(): array
     {
         return $this->types;
+    }
+
+    public function allowsNull(): bool
+    {
+        foreach ($this->types as $type) {
+            if ($type->getName() === 'null') {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     public function __toString(): string

--- a/src/Reflection/StringCast/ReflectionFunctionStringCast.php
+++ b/src/Reflection/StringCast/ReflectionFunctionStringCast.php
@@ -72,6 +72,12 @@ final class ReflectionFunctionStringCast
 
     private static function returnTypeToString(ReflectionFunction $methodReflection): string
     {
-        return $methodReflection->getReturnType()?->__toString() ?? '';
+        $type = $methodReflection->getReturnType();
+
+        if ($type === null) {
+            return '';
+        }
+
+        return ReflectionTypeStringCast::toString($type);
     }
 }

--- a/src/Reflection/StringCast/ReflectionMethodStringCast.php
+++ b/src/Reflection/StringCast/ReflectionMethodStringCast.php
@@ -126,6 +126,12 @@ final class ReflectionMethodStringCast
 
     private static function returnTypeToString(ReflectionMethod $methodReflection): string
     {
-        return $methodReflection->getReturnType()?->__toString() ?? '';
+        $type = $methodReflection->getReturnType();
+
+        if ($type === null) {
+            return '';
+        }
+
+        return ReflectionTypeStringCast::toString($type);
     }
 }

--- a/src/Reflection/StringCast/ReflectionParameterStringCast.php
+++ b/src/Reflection/StringCast/ReflectionParameterStringCast.php
@@ -34,11 +34,13 @@ final class ReflectionParameterStringCast
 
     private static function typeToString(ReflectionParameter $parameterReflection): string
     {
-        if (! $parameterReflection->hasType()) {
+        $type = $parameterReflection->getType();
+
+        if ($type === null) {
             return '';
         }
 
-        return (string) $parameterReflection->getType() . ' ';
+        return ReflectionTypeStringCast::toString($type) . ' ';
     }
 
     private static function valueToString(ReflectionParameter $parameterReflection): string

--- a/src/Reflection/StringCast/ReflectionPropertyStringCast.php
+++ b/src/Reflection/StringCast/ReflectionPropertyStringCast.php
@@ -29,7 +29,7 @@ final class ReflectionPropertyStringCast
             self::visibilityToString($propertyReflection),
             $propertyReflection->isStatic() ? ' static' : '',
             $propertyReflection->isReadOnly() ? ' readonly' : '',
-            $type !== null ? sprintf(' %s', $type->__toString()) : '',
+            $type !== null ? sprintf(' %s', ReflectionTypeStringCast::toString($type)) : '',
             $propertyReflection->getName(),
         );
     }

--- a/src/Reflection/StringCast/ReflectionTypeStringCast.php
+++ b/src/Reflection/StringCast/ReflectionTypeStringCast.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Roave\BetterReflection\Reflection\StringCast;
+
+use Roave\BetterReflection\Reflection\ReflectionIntersectionType;
+use Roave\BetterReflection\Reflection\ReflectionNamedType;
+use Roave\BetterReflection\Reflection\ReflectionUnionType;
+
+use function array_filter;
+use function array_values;
+use function count;
+
+/**
+ * @internal
+ */
+final class ReflectionTypeStringCast
+{
+    public static function toString(
+        ReflectionNamedType|ReflectionUnionType|ReflectionIntersectionType $type,
+    ): string {
+        if ($type instanceof ReflectionUnionType) {
+            // php-src has this weird behavior where a union type composed of a single type `T`
+            // together with `null` means that a `ReflectionNamedType` for `?T` is produced,
+            // rather than `T|null`. This is done to keep BC compatibility with PHP 7.1 (which
+            // introduced nullable types), but at reflection level, this is mostly a nuisance.
+            // In order to keep parity with core `Reflector#__toString()` behavior, we stashed
+            // this weird behavior in here.
+            $nonNullTypes = array_values(array_filter(
+                $type->getTypes(),
+                static fn (ReflectionNamedType $type): bool => $type->getName() !== 'null',
+            ));
+
+            if ($type->allowsNull() && count($nonNullTypes) === 1) {
+                return '?' . $nonNullTypes[0]->__toString();
+            }
+        }
+
+        return $type->__toString();
+    }
+}

--- a/test/compat/ResolvePHP7Types.phpt
+++ b/test/compat/ResolvePHP7Types.phpt
@@ -24,7 +24,6 @@ $functionInfo = $reflector->reflectFunction('myFunction');
 $returnType = $functionInfo->getReturnType();
 
 var_dump([
-    'builtIn' => $returnType->isBuiltin(),
     'type' => $returnType->__toString(),
 ]);
 
@@ -32,28 +31,21 @@ array_map(function (\Roave\BetterReflection\Reflection\ReflectionParameter $para
     $type = $param->getType();
 
     var_dump([
-        'builtIn' => $type->isBuiltin(),
         'type' => $type->__toString(),
     ]);
 }, $functionInfo->getParameters());
 
 ?>
 --EXPECTF--
-array(2) {
-  ["builtIn"]=>
-  bool(true)
+array(1) {
   ["type"]=>
   string(4) "bool"
 }
-array(2) {
-  ["builtIn"]=>
-  bool(true)
+array(1) {
   ["type"]=>
   string(3) "int"
 }
-array(2) {
-  ["builtIn"]=>
-  bool(true)
+array(1) {
   ["type"]=>
-  string(7) "?string"
+  string(11) "string|null"
 }

--- a/test/unit/Reflection/Adapter/ReflectionEnumTest.php
+++ b/test/unit/Reflection/Adapter/ReflectionEnumTest.php
@@ -648,8 +648,10 @@ class ReflectionEnumTest extends TestCase
             ->willReturn($betterReflectionNamedType);
 
         $reflectionEnumAdapter = new ReflectionEnumAdapter($betterReflectionEnum);
+        $backingType           = $reflectionEnumAdapter->getBackingType();
 
-        self::assertInstanceOf(ReflectionNamedTypeAdapter::class, $reflectionEnumAdapter->getBackingType());
+        self::assertInstanceOf(ReflectionNamedTypeAdapter::class, $backingType);
+        self::assertFalse($backingType->allowsNull());
     }
 
     public function testHasConstantWithEnumCase(): void

--- a/test/unit/Reflection/Adapter/ReflectionNamedTypeTest.php
+++ b/test/unit/Reflection/Adapter/ReflectionNamedTypeTest.php
@@ -37,11 +37,27 @@ class ReflectionNamedTypeTest extends TestCase
         self::assertSame(ReflectionNamedTypeAdapter::class, $reflectionTypeAdapterReflection->getMethod($methodName)->getDeclaringClass()->getName());
     }
 
+    public function testWillRenderNullabilityMarkerWhenGiven(): void
+    {
+        $reflectionStub = $this->createMock(BetterReflectionNamedType::class);
+        $reflectionStub->method('__toString')
+            ->willReturn('foo');
+
+        self::assertSame('foo', (new ReflectionNamedTypeAdapter($reflectionStub, false))->__toString());
+        self::assertSame('?foo', (new ReflectionNamedTypeAdapter($reflectionStub, true))->__toString());
+    }
+
+    public function testWillReportThatItAcceptsOrRejectsNull(): void
+    {
+        $reflectionStub = $this->createMock(BetterReflectionNamedType::class);
+
+        self::assertFalse((new ReflectionNamedTypeAdapter($reflectionStub, false))->allowsNull());
+        self::assertTrue((new ReflectionNamedTypeAdapter($reflectionStub, true))->allowsNull());
+    }
+
     public function methodExpectationProvider(): array
     {
         return [
-            ['__toString', null, 'int', []],
-            ['allowsNull', null, true, []],
             ['isBuiltin', null, true, []],
             ['getName', null, 'int', []],
         ];
@@ -67,7 +83,7 @@ class ReflectionNamedTypeTest extends TestCase
             $this->expectException($expectedException);
         }
 
-        $adapter = new ReflectionNamedTypeAdapter($reflectionStub);
+        $adapter = new ReflectionNamedTypeAdapter($reflectionStub, false);
         $adapter->{$methodName}(...$args);
     }
 }

--- a/test/unit/Reflection/ReflectionClassTest.php
+++ b/test/unit/Reflection/ReflectionClassTest.php
@@ -240,8 +240,8 @@ class ReflectionClassTest extends TestCase
             [
                 'tryFrom',
                 ['value' => [ReflectionUnionType::class, 'string|int']],
-                ReflectionNamedType::class,
-                '?static',
+                ReflectionUnionType::class,
+                'static|null',
             ],
         ];
     }

--- a/test/unit/Reflection/ReflectionFunctionAbstractTest.php
+++ b/test/unit/Reflection/ReflectionFunctionAbstractTest.php
@@ -456,9 +456,9 @@ class ReflectionFunctionAbstractTest extends TestCase
     public function nullableReturnTypeFunctionProvider(): array
     {
         return [
-            ['returnsNullableInt', '?int'],
-            ['returnsNullableString', '?string'],
-            ['returnsNullableObject', '?' . stdClass::class],
+            ['returnsNullableInt', 'int|null'],
+            ['returnsNullableString', 'string|null'],
+            ['returnsNullableObject', stdClass::class . '|null'],
         ];
     }
 

--- a/test/unit/Reflection/ReflectionIntersectionTypeTest.php
+++ b/test/unit/Reflection/ReflectionIntersectionTypeTest.php
@@ -44,5 +44,6 @@ class ReflectionIntersectionTypeTest extends TestCase
 
         self::assertContainsOnlyInstancesOf(ReflectionNamedType::class, $typeReflection->getTypes());
         self::assertSame($expectedString, $typeReflection->__toString());
+        self::assertFalse($typeReflection->allowsNull());
     }
 }

--- a/test/unit/Reflection/ReflectionNamedTypeTest.php
+++ b/test/unit/Reflection/ReflectionNamedTypeTest.php
@@ -49,9 +49,6 @@ class ReflectionNamedTypeTest extends TestCase
     {
         $noNullType = $this->createType('string');
         self::assertFalse($noNullType->allowsNull());
-
-        $allowsNullType = $this->createType('string', true);
-        self::assertTrue($allowsNullType->allowsNull());
     }
 
     public function isBuildinProvider(): Generator
@@ -96,7 +93,6 @@ class ReflectionNamedTypeTest extends TestCase
     public function testImplicitCastToString(): void
     {
         self::assertSame('int', (string) $this->createType('int'));
-        self::assertSame('?int', (string) $this->createType('int', true));
         self::assertSame('string', (string) $this->createType('string'));
         self::assertSame('array', (string) $this->createType('array'));
         self::assertSame('callable', (string) $this->createType('callable'));
@@ -110,12 +106,11 @@ class ReflectionNamedTypeTest extends TestCase
 
         self::assertSame('Foo\Bar\Baz', (string) $this->createType('Foo\Bar\Baz'));
         self::assertSame('\Foo\Bar\Baz', (string) $this->createType('\Foo\Bar\Baz'));
-        self::assertSame('?\Foo\Bar\Baz', (string) $this->createType('\Foo\Bar\Baz', true));
     }
 
-    private function createType(string $type, bool $allowsNull = false): ReflectionNamedType
+    private function createType(string $type): ReflectionNamedType
     {
-        return new ReflectionNamedType($this->reflector, $this->owner, new Identifier($type), $allowsNull);
+        return new ReflectionNamedType($this->reflector, $this->owner, new Identifier($type));
     }
 
     public function testGetClassFromPropertyType(): void

--- a/test/unit/Reflection/ReflectionPropertyTest.php
+++ b/test/unit/Reflection/ReflectionPropertyTest.php
@@ -195,7 +195,7 @@ class ReflectionPropertyTest extends TestCase
         self::assertTrue($promotedProperty->isPromoted());
         self::assertTrue($promotedProperty->isPrivate());
         self::assertTrue($promotedProperty->hasType());
-        self::assertSame('?int', $promotedProperty->getType()->__toString());
+        self::assertSame('int|null', $promotedProperty->getType()->__toString());
         self::assertFalse($promotedProperty->hasDefaultValue());
         self::assertNull($promotedProperty->getDefaultValue());
         self::assertSame(46, $promotedProperty->getStartLine());
@@ -675,7 +675,7 @@ PHP;
             ['integerProperty', 'int'],
             ['classProperty', 'stdClass'],
             ['noTypeProperty', ''],
-            ['nullableStringProperty', '?string'],
+            ['nullableStringProperty', 'string|null'],
             ['arrayProperty', 'array'],
         ];
     }

--- a/test/unit/Reflection/ReflectionTypeTest.php
+++ b/test/unit/Reflection/ReflectionTypeTest.php
@@ -15,6 +15,9 @@ use Roave\BetterReflection\Reflector\Reflector;
 
 /**
  * @covers \Roave\BetterReflection\Reflection\ReflectionType
+ * @covers \Roave\BetterReflection\Reflection\ReflectionNamedType
+ * @covers \Roave\BetterReflection\Reflection\ReflectionIntersectionType
+ * @covers \Roave\BetterReflection\Reflection\ReflectionUnionType
  */
 class ReflectionTypeTest extends TestCase
 {
@@ -34,21 +37,31 @@ class ReflectionTypeTest extends TestCase
         return [
             [new Node\Name('A'), false, ReflectionNamedType::class, false],
             [new Node\Identifier('string'), false, ReflectionNamedType::class, false],
-            [new Node\Identifier('string'), true, ReflectionNamedType::class, true],
-            [new Node\NullableType(new Node\Identifier('string')), false, ReflectionNamedType::class, true],
-            [new Node\IntersectionType([new Node\Name('A'), new Node\Name('B')]), false, ReflectionIntersectionType::class, false],
-            [new Node\UnionType([new Node\Name('A'), new Node\Name('B')]), false, ReflectionUnionType::class, false],
-            'Union types composed of just `null` and a type are simplified into a ReflectionNamedType' => [
-                new Node\UnionType([new Node\Name('A'), new Node\Name('null')]),
-                false,
-                ReflectionNamedType::class,
+            'Forcing a type to be nullable turns it into a `T|null` ReflectionUnionType' => [
+                new Node\Identifier('string'),
+                true,
+                ReflectionUnionType::class,
                 true,
             ],
-            'Union types composed of `null` and more than one type are kept as ReflectionUnionType' => [
+            'Nullable types are converted into `T|null` ReflectionUnionType instances' => [
+                new Node\NullableType(new Node\Identifier('string')),
+                false,
+                ReflectionUnionType::class,
+                true,
+            ],
+            [new Node\IntersectionType([new Node\Name('A'), new Node\Name('B')]), false, ReflectionIntersectionType::class, false],
+            [new Node\UnionType([new Node\Name('A'), new Node\Name('B')]), false, ReflectionUnionType::class, false],
+            'Union types composed of just `null` and a type are kept as `T|null` ReflectionUnionType' => [
+                new Node\UnionType([new Node\Name('A'), new Node\Name('null')]),
+                false,
+                ReflectionUnionType::class,
+                true,
+            ],
+            'Union types composed of `null` and more than one type are kept as `T|U|null` ReflectionUnionType' => [
                 new Node\UnionType([new Node\Name('A'), new Node\Name('B'), new Node\Name('null')]),
                 false,
                 ReflectionUnionType::class,
-                false,
+                true,
             ],
         ];
     }

--- a/test/unit/Reflection/ReflectionTypeTest.php
+++ b/test/unit/Reflection/ReflectionTypeTest.php
@@ -38,6 +38,18 @@ class ReflectionTypeTest extends TestCase
             [new Node\NullableType(new Node\Identifier('string')), false, ReflectionNamedType::class, true],
             [new Node\IntersectionType([new Node\Name('A'), new Node\Name('B')]), false, ReflectionIntersectionType::class, false],
             [new Node\UnionType([new Node\Name('A'), new Node\Name('B')]), false, ReflectionUnionType::class, false],
+            'Union types composed of just `null` and a type are simplified into a ReflectionNamedType' => [
+                new Node\UnionType([new Node\Name('A'), new Node\Name('null')]),
+                false,
+                ReflectionNamedType::class,
+                true,
+            ],
+            'Union types composed of `null` and more than one type are kept as ReflectionUnionType' => [
+                new Node\UnionType([new Node\Name('A'), new Node\Name('B'), new Node\Name('null')]),
+                false,
+                ReflectionUnionType::class,
+                false,
+            ],
         ];
     }
 

--- a/test/unit/Reflection/ReflectionUnionTypeTest.php
+++ b/test/unit/Reflection/ReflectionUnionTypeTest.php
@@ -30,19 +30,20 @@ class ReflectionUnionTypeTest extends TestCase
     public function dataProvider(): array
     {
         return [
-            [new Node\UnionType([new Node\Name('\A\Foo'), new Node\Name('Boo')]), '\A\Foo|Boo'],
-            [new Node\UnionType([new Node\Name('A'), new Node\Name('B'), new Node\Identifier('null')]), 'A|B|null'],
+            [new Node\UnionType([new Node\Name('\A\Foo'), new Node\Name('Boo')]), '\A\Foo|Boo', false],
+            [new Node\UnionType([new Node\Name('A'), new Node\Name('B'), new Node\Identifier('null')]), 'A|B|null', true],
         ];
     }
 
     /**
      * @dataProvider dataProvider
      */
-    public function test(Node\UnionType $unionType, string $expectedString): void
+    public function test(Node\UnionType $unionType, string $expectedString, bool $expectedNullable): void
     {
-        $typeReflection = new ReflectionUnionType($this->reflector, $this->owner, $unionType, false);
+        $typeReflection = new ReflectionUnionType($this->reflector, $this->owner, $unionType);
 
         self::assertContainsOnlyInstancesOf(ReflectionNamedType::class, $typeReflection->getTypes());
         self::assertSame($expectedString, $typeReflection->__toString());
+        self::assertSame($expectedNullable, $typeReflection->allowsNull());
     }
 }

--- a/test/unit/Reflection/StringCast/ReflectionTypeStringCastTest.php
+++ b/test/unit/Reflection/StringCast/ReflectionTypeStringCastTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Roave\BetterReflectionTest\Reflection\StringCast;
+
+use PHPUnit\Framework\TestCase;
+use Roave\BetterReflection\Reflection\ReflectionIntersectionType;
+use Roave\BetterReflection\Reflection\ReflectionNamedType;
+use Roave\BetterReflection\Reflection\ReflectionUnionType;
+use Roave\BetterReflection\Reflection\StringCast\ReflectionTypeStringCast;
+use Roave\BetterReflection\Reflector\DefaultReflector;
+use Roave\BetterReflection\SourceLocator\Type\StringSourceLocator;
+use Roave\BetterReflectionTest\BetterReflectionSingleton;
+
+use function assert;
+
+/**
+ * @covers \Roave\BetterReflection\Reflection\StringCast\ReflectionTypeStringCast
+ */
+final class ReflectionTypeStringCastTest extends TestCase
+{
+    public function toStringProvider(): array
+    {
+        $reflector = new DefaultReflector(new StringSourceLocator(
+            <<<'PHP'
+<?php
+
+interface A {}
+interface B {}
+function a(): int|string|null {}
+function b(): int|null {}
+function c(): ?int {}
+function d(): A&B {}
+function e(): int {}
+PHP
+            ,
+            BetterReflectionSingleton::instance()
+                ->astLocator(),
+        ));
+
+        $returnTypeForFunction = static function (string $function) use ($reflector): ReflectionNamedType|ReflectionUnionType|ReflectionIntersectionType {
+            $type = $reflector->reflectFunction($function)
+                ->getReturnType();
+
+            assert($type !== null);
+
+            return $type;
+        };
+
+        return [
+            [$returnTypeForFunction('a'), 'int|string|null'],
+            [$returnTypeForFunction('b'), '?int'],
+            [$returnTypeForFunction('c'), '?int'],
+            [$returnTypeForFunction('d'), 'A&B'],
+            [$returnTypeForFunction('e'), 'int'],
+        ];
+    }
+
+    /**
+     * @dataProvider toStringProvider
+     */
+    public function testToString(
+        ReflectionNamedType|ReflectionUnionType|ReflectionIntersectionType $type,
+        string $expectedString,
+    ): void {
+        self::assertSame($expectedString, ReflectionTypeStringCast::toString($type));
+    }
+}

--- a/test/unit/SourceLocator/SourceStubber/PhpStormStubsSourceStubberTest.php
+++ b/test/unit/SourceLocator/SourceStubber/PhpStormStubsSourceStubberTest.php
@@ -862,11 +862,11 @@ class PhpStormStubsSourceStubberTest extends TestCase
             [DateInterval::class, 'f', 70099, false],
             [DateInterval::class, 'f', 70100, true],
             [PDOException::class, 'errorInfo', 80099, true],
-            [PDOException::class, 'errorInfo', 80100, true, 'array|null'],
+            [PDOException::class, 'errorInfo', 80100, true, '?array'],
             [DOMNode::class, 'nodeType', 80099, true],
             [DOMNode::class, 'nodeType', 80100, true, 'int'],
             [DOMNode::class, 'parentNode', 80099, true],
-            [DOMNode::class, 'parentNode', 80100, true, 'DOMNode|null'],
+            [DOMNode::class, 'parentNode', 80100, true, '?DOMNode'],
         ];
     }
 
@@ -910,7 +910,7 @@ class PhpStormStubsSourceStubberTest extends TestCase
             ['read_exif_data', 80000, false],
             ['spl_autoload_functions', 79999, true, 'array|false'],
             ['spl_autoload_functions', 80000, true, 'array'],
-            ['dom_import_simplexml', 70000, true, 'DOMElement|null'],
+            ['dom_import_simplexml', 70000, true, '?DOMElement'],
             ['dom_import_simplexml', 80000, true, 'DOMElement'],
             // Not core functions
             ['newrelic_add_custom_parameter', 40000, true, 'bool'],
@@ -944,7 +944,7 @@ class PhpStormStubsSourceStubberTest extends TestCase
             ['bcscale', 'scale', 70200, true, 'int', false],
             ['bcscale', 'scale', 70299, true, 'int', false],
             ['bcscale', 'scale', 70300, true, '?int', true],
-            ['bcscale', 'scale', 80000, true, 'int|null', true],
+            ['bcscale', 'scale', 80000, true, '?int', true],
             ['easter_date', 'mode', 79999, false],
             ['easter_date', 'mode', 80000, true, 'int', false],
             ['curl_version', 'age', 50200, false],

--- a/test/unit/SourceLocator/SourceStubber/PhpStormStubsSourceStubberTest.php
+++ b/test/unit/SourceLocator/SourceStubber/PhpStormStubsSourceStubberTest.php
@@ -761,12 +761,12 @@ class PhpStormStubsSourceStubberTest extends TestCase
             [CoreReflectionProperty::class, 'getType', 70300, false],
             [CoreReflectionProperty::class, 'getType', 70400, true],
             [CoreReflectionProperty::class, 'getType', 80000, true],
-            [CoreReflectionProperty::class, 'getType', 80100, true, null, '?ReflectionType'],
+            [CoreReflectionProperty::class, 'getType', 80100, true, null, 'ReflectionType|null'],
             [CoreReflectionClass::class, 'export', 70400, true],
             [CoreReflectionClass::class, 'export', 80000, false],
             [DatePeriod::class, 'getRecurrences', 70216, false],
             [DatePeriod::class, 'getRecurrences', 70217, true],
-            [DatePeriod::class, 'getRecurrences', 80100, true, null, '?int'],
+            [DatePeriod::class, 'getRecurrences', 80100, true, null, 'int|null'],
             [DateTimeInterface::class, 'getOffset', 79999, true],
             [DateTimeInterface::class, 'getOffset', 80000, true],
             [DateTimeInterface::class, 'getOffset', 80100, true, null, 'int'],
@@ -816,7 +816,7 @@ class PhpStormStubsSourceStubberTest extends TestCase
     {
         return [
             ['mysqli_stmt', 'execute', 'params', 80099, false],
-            ['mysqli_stmt', 'execute', 'params', 80100, true, '?array', true],
+            ['mysqli_stmt', 'execute', 'params', 80100, true, 'array|null', true],
             ['PDOStatement', 'fetchAll', 'fetch_argument', 50299, false],
             ['PDOStatement', 'fetchAll', 'fetch_argument', 50300, true, null, true],
             ['PDOStatement', 'fetchAll', 'fetch_argument', 70499, true, null, true],
@@ -862,11 +862,11 @@ class PhpStormStubsSourceStubberTest extends TestCase
             [DateInterval::class, 'f', 70099, false],
             [DateInterval::class, 'f', 70100, true],
             [PDOException::class, 'errorInfo', 80099, true],
-            [PDOException::class, 'errorInfo', 80100, true, '?array'],
+            [PDOException::class, 'errorInfo', 80100, true, 'array|null'],
             [DOMNode::class, 'nodeType', 80099, true],
             [DOMNode::class, 'nodeType', 80100, true, 'int'],
             [DOMNode::class, 'parentNode', 80099, true],
-            [DOMNode::class, 'parentNode', 80100, true, '?DOMNode'],
+            [DOMNode::class, 'parentNode', 80100, true, 'DOMNode|null'],
         ];
     }
 
@@ -910,7 +910,7 @@ class PhpStormStubsSourceStubberTest extends TestCase
             ['read_exif_data', 80000, false],
             ['spl_autoload_functions', 79999, true, 'array|false'],
             ['spl_autoload_functions', 80000, true, 'array'],
-            ['dom_import_simplexml', 70000, true, '?DOMElement'],
+            ['dom_import_simplexml', 70000, true, 'DOMElement|null'],
             ['dom_import_simplexml', 80000, true, 'DOMElement'],
             // Not core functions
             ['newrelic_add_custom_parameter', 40000, true, 'bool'],
@@ -943,8 +943,8 @@ class PhpStormStubsSourceStubberTest extends TestCase
         return [
             ['bcscale', 'scale', 70200, true, 'int', false],
             ['bcscale', 'scale', 70299, true, 'int', false],
-            ['bcscale', 'scale', 70300, true, '?int', true],
-            ['bcscale', 'scale', 80000, true, '?int', true],
+            ['bcscale', 'scale', 70300, true, 'int|null', true],
+            ['bcscale', 'scale', 80000, true, 'int|null', true],
             ['easter_date', 'mode', 79999, false],
             ['easter_date', 'mode', 80000, true, 'int', false],
             ['curl_version', 'age', 50200, false],

--- a/test/unit/SourceLocator/SourceStubber/ReflectionSourceStubberTest.php
+++ b/test/unit/SourceLocator/SourceStubber/ReflectionSourceStubberTest.php
@@ -367,7 +367,11 @@ class ReflectionSourceStubberTest extends TestCase
 
         if (method_exists($original, 'hasTentativeReturnType')) {
             self::assertSame($original->hasTentativeReturnType(), $stubbed->hasTentativeReturnType(), $original->getName());
-            self::assertSame((string) $original->getTentativeReturnType(), (string) $stubbed->getTentativeReturnType(), $original->getName());
+            self::assertSame(
+                (string) $original->getTentativeReturnType(),
+                (string) ReflectionType::fromTypeOrNull($stubbed->getTentativeReturnType()),
+                $original->getName(),
+            );
         }
 
         self::assertSame($original->hasReturnType(), $stubbed->hasReturnType(), $original->getName());

--- a/test/unit/SourceLocator/SourceStubber/ReflectionSourceStubberTest.php
+++ b/test/unit/SourceLocator/SourceStubber/ReflectionSourceStubberTest.php
@@ -11,6 +11,7 @@ use ReflectionException;
 use ReflectionFunction as CoreReflectionFunction;
 use ReflectionMethod as CoreReflectionMethod;
 use ReflectionParameter as CoreReflectionParameter;
+use Roave\BetterReflection\Reflection\Adapter\ReflectionType;
 use Roave\BetterReflection\Reflection\ReflectionClass;
 use Roave\BetterReflection\Reflection\ReflectionMethod;
 use Roave\BetterReflection\Reflection\ReflectionParameter;
@@ -370,7 +371,11 @@ class ReflectionSourceStubberTest extends TestCase
         }
 
         self::assertSame($original->hasReturnType(), $stubbed->hasReturnType(), $original->getName());
-        self::assertSame((string) $original->getReturnType(), (string) $stubbed->getReturnType(), $original->getName());
+        self::assertSame(
+            (string) $original->getReturnType(),
+            (string) ReflectionType::fromTypeOrNull($stubbed->getReturnType()),
+            $original->getName(),
+        );
     }
 
     private function assertSameParameterAttributes(
@@ -442,10 +447,16 @@ class ReflectionSourceStubberTest extends TestCase
 
         if (method_exists($originalReflection, 'hasTentativeReturnType') && $originalReflection->hasTentativeReturnType()) {
             self::assertSame($originalReflection->hasTentativeReturnType(), $stubbedReflection->hasTentativeReturnType());
-            self::assertSame((string) $originalReflection->getTentativeReturnType(), (string) $stubbedReflection->getTentativeReturnType());
+            self::assertSame(
+                (string) $originalReflection->getTentativeReturnType(),
+                (string) ReflectionType::fromTypeOrNull($stubbedReflection->getTentativeReturnType()),
+            );
         } else {
             self::assertSame($originalReflection->hasReturnType(), $stubbedReflection->hasReturnType());
-            self::assertSame((string) $originalReflection->getReturnType(), (string) $stubbedReflection->getReturnType());
+            self::assertSame(
+                (string) $originalReflection->getReturnType(),
+                (string) ReflectionType::fromTypeOrNull($stubbedReflection->getReturnType()),
+            );
         }
     }
 


### PR DESCRIPTION

Fixes #901

## Context

Currently, when running reflection on an `A|null` type, BetterReflection produces a `Roave\BetterReflection\Reflection\ReflectionUnionType`:

```php
var_dump(
    get_class(
        (new DefaultReflector(new StringSourceLocator(
            <<<'PHP'
<?php
interface A {}
final class AClass {
    private A|null $typed;
}
PHP
            ,
            (new BetterReflection())->astLocator()
        )))
            ->reflectClass('AClass')
            ->getProperty('typed')
            ->getType()
    )
);
```

produces

```
string(53) "Roave\BetterReflection\Reflection\ReflectionUnionType"
```

In PHP-SRC, this behavior is different: https://3v4l.org/gMA4T#v8.1rc3

```php
<?php

interface A {}
interface B {}

class Implementation
{
    function foo(A|null $param) { throw new Exception(); }
    function bar(A|B|null $param) { throw new Exception(); }
}

var_dump((new ReflectionParameter([Implementation::class, 'foo'], 0))->getType());
var_dump((new ReflectionParameter([Implementation::class, 'bar'], 0))->getType());
```

produces:

```
object(ReflectionNamedType)#2 (0) {
}
object(ReflectionUnionType)#1 (0) {
}
```

This means that a `UnionType` AST node composed of just `null` plus another type should be converted into
a `ReflectionNamedType`, for the sake of compatibility with upstream (this patch does that).

This is ugly, but will (for now) avoid some bad issues in downstream handling (presently blocking https://github.com/Roave/BackwardCompatibilityCheck/pull/324 )