### PR TITLE
Bump vimeo/psalm to 4.14.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
         "doctrine/coding-standard": "^9.0.0",
         "phpstan/phpstan": "^1.2.0",
         "phpunit/phpunit": "^9.5.9",
-        "vimeo/psalm": "^4.13.1",
+        "vimeo/psalm": "^4.14.0",
         "roave/infection-static-analysis-plugin": "^1.12.0"
     },
     "autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2c808292bc67bc7fa11a7bd66a10e71d",
+    "content-hash": "c5e259a0d8d68a19de761710e0abd5de",
     "packages": [
         {
             "name": "jetbrains/phpstorm-stubs",
@@ -5015,16 +5015,16 @@
         },
         {
             "name": "vimeo/psalm",
-            "version": "4.13.1",
+            "version": "v4.14.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vimeo/psalm.git",
-                "reference": "5cf660f63b548ccd4a56f62d916ee4d6028e01a3"
+                "reference": "14dcbc908ab2625cd7a74258ee6c740cbecc6140"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vimeo/psalm/zipball/5cf660f63b548ccd4a56f62d916ee4d6028e01a3",
-                "reference": "5cf660f63b548ccd4a56f62d916ee4d6028e01a3",
+                "url": "https://api.github.com/repos/vimeo/psalm/zipball/14dcbc908ab2625cd7a74258ee6c740cbecc6140",
+                "reference": "14dcbc908ab2625cd7a74258ee6c740cbecc6140",
                 "shasum": ""
             },
             "require": {
@@ -5115,9 +5115,9 @@
             ],
             "support": {
                 "issues": "https://github.com/vimeo/psalm/issues",
-                "source": "https://github.com/vimeo/psalm/tree/4.13.1"
+                "source": "https://github.com/vimeo/psalm/tree/v4.14.0"
             },
-            "time": "2021-11-23T23:52:49+00:00"
+            "time": "2021-12-04T17:49:24+00:00"
         },
         {
             "name": "webmozart/path-util",

--- a/src/SourceLocator/Type/DirectoriesSourceLocator.php
+++ b/src/SourceLocator/Type/DirectoriesSourceLocator.php
@@ -15,7 +15,6 @@ use Roave\BetterReflection\SourceLocator\Exception\InvalidDirectory;
 use Roave\BetterReflection\SourceLocator\Exception\InvalidFileInfo;
 
 use function array_map;
-use function array_values;
 use function is_dir;
 
 /**
@@ -33,7 +32,7 @@ class DirectoriesSourceLocator implements SourceLocator
      */
     public function __construct(array $directories, Locator $astLocator)
     {
-        $this->aggregateSourceLocator = new AggregateSourceLocator(array_values(array_map(
+        $this->aggregateSourceLocator = new AggregateSourceLocator(array_map(
             static function (string $directory) use ($astLocator): FileIteratorSourceLocator {
                 if (! is_dir($directory)) {
                     throw InvalidDirectory::fromNonDirectory($directory);
@@ -48,7 +47,7 @@ class DirectoriesSourceLocator implements SourceLocator
                 );
             },
             $directories,
-        )));
+        ));
     }
 
     public function locateIdentifier(Reflector $reflector, Identifier $identifier): ?Reflection


### PR DESCRIPTION
`array_values` call removed because of:

```
ERROR: RedundantCast - src/SourceLocator/Type/DirectoriesSourceLocator.php:36:68 - The call to array_values is unnecessary, list<Roave\BetterReflection\SourceLocator\Type\FileIteratorSourceLocator> is already a list (see https://psalm.dev/262)
        $this->aggregateSourceLocator = new AggregateSourceLocator(array_values(array_map(
```        