### PR TITLE
Support `resource` as constant value, make `STDIN`, `STDOUT` and `STDERR` stubs actual `resource`s

### DIFF
--- a/src/NodeCompiler/CompileNodeToValue.php
+++ b/src/NodeCompiler/CompileNodeToValue.php
@@ -113,6 +113,17 @@ class CompileNodeToValue
                 return '';
             }
 
+            if (
+                $node instanceof Node\Expr\FuncCall
+                && $node->name instanceof Node\Name
+                && $node->name->toLowerString() === 'constant'
+                && $node->args[0] instanceof Node\Arg
+                && $node->args[0]->value instanceof Node\Scalar\String_
+                && defined($node->args[0]->value->value)
+            ) {
+                return constant($node->args[0]->value->value);
+            }
+
             throw Exception\UnableToCompileNode::forUnRecognizedExpressionInContext($node, $context);
         });
 

--- a/src/NodeCompiler/CompileNodeToValue.php
+++ b/src/NodeCompiler/CompileNodeToValue.php
@@ -51,7 +51,7 @@ class CompileNodeToValue
             $constantName = $this->resolveClassConstantName($node, $context);
         }
 
-        $constExprEvaluator = new ConstExprEvaluator(function (Node\Expr $node) use ($context, $constantName): string|int|float|bool|array|null {
+        $constExprEvaluator = new ConstExprEvaluator(function (Node\Expr $node) use ($context, $constantName): mixed {
             if ($node instanceof Node\Expr\ConstFetch) {
                 return $this->getConstantValue($node, $constantName, $context);
             }

--- a/src/NodeCompiler/CompiledValue.php
+++ b/src/NodeCompiler/CompiledValue.php
@@ -9,10 +9,7 @@ namespace Roave\BetterReflection\NodeCompiler;
  */
 class CompiledValue
 {
-    /**
-     * @param scalar|array<scalar>|null $value
-     */
-    public function __construct(public string|int|float|bool|array|null $value, public ?string $constantName = null)
+    public function __construct(public mixed $value, public ?string $constantName = null)
     {
     }
 }

--- a/src/Reflection/Adapter/ReflectionClass.php
+++ b/src/Reflection/Adapter/ReflectionClass.php
@@ -169,7 +169,7 @@ final class ReflectionClass extends CoreReflectionClass
     }
 
     /**
-     * @return array<string, mixed|null>
+     * @return array<string, mixed>
      */
     public function getConstants(?int $filter = null): array
     {

--- a/src/Reflection/Adapter/ReflectionObject.php
+++ b/src/Reflection/Adapter/ReflectionObject.php
@@ -166,7 +166,7 @@ final class ReflectionObject extends CoreReflectionObject
         }
 
         return array_map(
-            static fn (BetterReflectionClassConstant $betterConstant) => $betterConstant->getValue(),
+            static fn (BetterReflectionClassConstant $betterConstant): mixed => $betterConstant->getValue(),
             $reflectionConstants,
         );
     }

--- a/src/Reflection/ReflectionClass.php
+++ b/src/Reflection/ReflectionClass.php
@@ -569,22 +569,22 @@ class ReflectionClass implements Reflection
      * Get an associative array of only the constants for this specific class (i.e. do not search
      * up parent classes etc.), with keys as constant names and values as constant values.
      *
-     * @return array<string, scalar|array<scalar>|null>
+     * @return array<string, mixed>
      */
     public function getImmediateConstants(): array
     {
-        return array_map(static fn (ReflectionClassConstant $classConstant) => $classConstant->getValue(), $this->getImmediateReflectionConstants());
+        return array_map(static fn (ReflectionClassConstant $classConstant): mixed => $classConstant->getValue(), $this->getImmediateReflectionConstants());
     }
 
     /**
      * Get an associative array of the defined constants in this class,
      * with keys as constant names and values as constant values.
      *
-     * @return array<string, scalar|array<scalar>|null>
+     * @return array<string, mixed>
      */
     public function getConstants(): array
     {
-        return array_map(static fn (ReflectionClassConstant $classConstant) => $classConstant->getValue(), $this->getReflectionConstants());
+        return array_map(static fn (ReflectionClassConstant $classConstant): mixed => $classConstant->getValue(), $this->getReflectionConstants());
     }
 
     /**

--- a/src/Reflection/ReflectionClassConstant.php
+++ b/src/Reflection/ReflectionClassConstant.php
@@ -60,10 +60,8 @@ class ReflectionClassConstant
 
     /**
      * Returns constant value
-     *
-     * @return scalar|array<scalar>|null
      */
-    public function getValue(): string|int|float|bool|array|null
+    public function getValue(): mixed
     {
         if ($this->compiledValue === null) {
             $this->compiledValue = (new CompileNodeToValue())->__invoke(

--- a/src/Reflection/ReflectionConstant.php
+++ b/src/Reflection/ReflectionConstant.php
@@ -204,10 +204,8 @@ class ReflectionConstant implements Reflection
 
     /**
      * Returns constant value
-     *
-     * @return scalar|array<scalar>|null
      */
-    public function getValue(): string|int|float|bool|array|null
+    public function getValue(): mixed
     {
         if ($this->compiledValue !== null) {
             return $this->compiledValue->value;

--- a/src/SourceLocator/SourceStubber/PhpStormStubsSourceStubber.php
+++ b/src/SourceLocator/SourceStubber/PhpStormStubsSourceStubber.php
@@ -23,6 +23,7 @@ use Traversable;
 use function array_change_key_case;
 use function array_key_exists;
 use function array_map;
+use function array_merge;
 use function assert;
 use function explode;
 use function file_get_contents;
@@ -189,7 +190,13 @@ final class PhpStormStubsSourceStubber implements SourceStubber
         /** @psalm-suppress PropertyTypeCoercion */
         self::$functionMap = array_change_key_case(PhpStormStubsMap::FUNCTIONS);
         /** @psalm-suppress PropertyTypeCoercion */
-        self::$constantMap     = array_change_key_case(PhpStormStubsMap::CONSTANTS);
+        self::$constantMap = array_merge(array_change_key_case(PhpStormStubsMap::CONSTANTS), [
+            // Funny thing - The script used by Jetbrains to generate the map was originally developed in this repository - so the script throws away constants with resource value
+            'stdin' => 'Core/Core_d.php',
+            'stdout' => 'Core/Core_d.php',
+            'stderr' => 'Core/Core_d.php',
+        ]);
+
         self::$mapsInitialized = true;
     }
 

--- a/src/SourceLocator/SourceStubber/ReflectionSourceStubber.php
+++ b/src/SourceLocator/SourceStubber/ReflectionSourceStubber.php
@@ -48,6 +48,7 @@ use function implode;
 use function in_array;
 use function interface_exists;
 use function is_array;
+use function is_resource;
 use function method_exists;
 use function preg_replace;
 use function sprintf;
@@ -164,11 +165,6 @@ final class ReflectionSourceStubber implements SourceStubber
 
     public function generateConstantStub(string $constantName): ?StubData
     {
-        // Not supported because of resource as value
-        if (in_array($constantName, ['STDIN', 'STDOUT', 'STDERR'], true)) {
-            return null;
-        }
-
         $constantData = $this->findConstantData($constantName);
 
         if ($constantData === null) {
@@ -176,6 +172,10 @@ final class ReflectionSourceStubber implements SourceStubber
         }
 
         [$constantValue, $extensionName] = $constantData;
+
+        if (is_resource($constantValue)) {
+            $constantValue = $this->builderFactory->funcCall('constant', [$constantName]);
+        }
 
         $constantNode = $this->builderFactory->funcCall('define', [$constantName, $constantValue]);
 

--- a/src/Util/ConstantNodeChecker.php
+++ b/src/Util/ConstantNodeChecker.php
@@ -42,7 +42,7 @@ final class ConstantNodeChecker
 
         $valueNode = $node->args[1]->value;
 
-        if ($valueNode instanceof Node\Expr\FuncCall) {
+        if ($valueNode instanceof Node\Expr\FuncCall && ! ($valueNode->name instanceof Node\Name && $valueNode->name->toLowerString() === 'constant')) {
             throw InvalidConstantNode::create($node);
         }
 

--- a/test/unit/NodeCompiler/CompileNodeToValueTest.php
+++ b/test/unit/NodeCompiler/CompileNodeToValueTest.php
@@ -201,6 +201,15 @@ class CompileNodeToValueTest extends TestCase
         self::assertSame($expectedValue, $compiledValue->value);
     }
 
+    public function testResource(): void
+    {
+        $node = $this->parseCode('STDIN');
+
+        $compiledValue = (new CompileNodeToValue())->__invoke($node, $this->getDummyContext());
+
+        self::assertIsResource($compiledValue->value);
+    }
+
     public function testExceptionThrownWhenInvalidNodeGiven(): void
     {
         $this->expectException(UnableToCompileNode::class);

--- a/test/unit/NodeCompiler/CompileNodeToValueTest.php
+++ b/test/unit/NodeCompiler/CompileNodeToValueTest.php
@@ -210,6 +210,15 @@ class CompileNodeToValueTest extends TestCase
         self::assertIsResource($compiledValue->value);
     }
 
+    public function testConstantFunctionCall(): void
+    {
+        $node = new Node\Expr\FuncCall(new Node\Name('constant'), [new Node\Arg(new Node\Scalar\String_('PHP_VERSION_ID'))]);
+
+        $compiledValue = (new CompileNodeToValue())->__invoke($node, $this->getDummyContext());
+
+        self::assertSame(PHP_VERSION_ID, $compiledValue->value);
+    }
+
     public function testExceptionThrownWhenInvalidNodeGiven(): void
     {
         $this->expectException(UnableToCompileNode::class);

--- a/test/unit/SourceLocator/SourceStubber/PhpStormStubsSourceStubberTest.php
+++ b/test/unit/SourceLocator/SourceStubber/PhpStormStubsSourceStubberTest.php
@@ -371,11 +371,6 @@ class PhpStormStubsSourceStubberTest extends TestCase
             }
 
             foreach ($extensionConstants as $constantName => $constantValue) {
-                // Not supported because of resource as value
-                if (in_array($constantName, ['STDIN', 'STDOUT', 'STDERR'], true)) {
-                    continue;
-                }
-
                 $provider[] = [$constantName, $constantValue, $extensionName];
             }
         }

--- a/test/unit/SourceLocator/SourceStubber/ReflectionSourceStubberTest.php
+++ b/test/unit/SourceLocator/SourceStubber/ReflectionSourceStubberTest.php
@@ -16,7 +16,6 @@ use Roave\BetterReflection\Reflection\ReflectionClass;
 use Roave\BetterReflection\Reflection\ReflectionMethod;
 use Roave\BetterReflection\Reflection\ReflectionParameter;
 use Roave\BetterReflection\Reflector\DefaultReflector;
-use Roave\BetterReflection\Reflector\Exception\IdentifierNotFound;
 use Roave\BetterReflection\Reflector\Reflector;
 use Roave\BetterReflection\SourceLocator\SourceStubber\ReflectionSourceStubber;
 use Roave\BetterReflection\SourceLocator\Type\PhpInternalSourceLocator;
@@ -534,24 +533,5 @@ class ReflectionSourceStubberTest extends TestCase
     public function testUnknownConstant(): void
     {
         self::assertNull($this->stubber->generateConstantStub('SOME_CONSTANT'));
-    }
-
-    public function unsupportedConstants(): array
-    {
-        return [
-            ['STDIN'],
-            ['STDOUT'],
-            ['STDERR'],
-        ];
-    }
-
-    /**
-     * @dataProvider unsupportedConstants
-     */
-    public function testUnsupportedConstants(string $constantName): void
-    {
-        self::expectException(IdentifierNotFound::class);
-
-        $this->reflector->reflectConstant($constantName);
     }
 }

--- a/test/unit/SourceLocator/Type/PhpInternalSourceLocatorTest.php
+++ b/test/unit/SourceLocator/Type/PhpInternalSourceLocatorTest.php
@@ -30,7 +30,6 @@ use function get_declared_interfaces;
 use function get_declared_traits;
 use function get_defined_constants;
 use function get_defined_functions;
-use function in_array;
 use function sprintf;
 
 use const ARRAY_FILTER_USE_KEY;
@@ -176,15 +175,12 @@ class PhpInternalSourceLocatorTest extends TestCase
 
         return array_map(
             static fn (string $symbol): array => [$symbol],
-            array_filter(
-                array_keys(
-                    array_merge(
-                        ...array_values(
-                            array_filter($allSymbols, static fn (string $extensionName): bool => $extensionName !== 'user', ARRAY_FILTER_USE_KEY),
-                        ),
+            array_keys(
+                array_merge(
+                    ...array_values(
+                        array_filter($allSymbols, static fn (string $extensionName): bool => $extensionName !== 'user', ARRAY_FILTER_USE_KEY),
                     ),
                 ),
-                static fn (string $constantName): bool => ! in_array($constantName, ['STDIN', 'STDOUT', 'STDERR'], true),
             ),
         );
     }

--- a/test/unit/Util/ConstantNodeCheckerTest.php
+++ b/test/unit/Util/ConstantNodeCheckerTest.php
@@ -103,6 +103,7 @@ class ConstantNodeCheckerTest extends TestCase
             [new Node\Expr\BinaryOp\BitwiseAnd(new Node\Scalar\LNumber(1), new Node\Scalar\LNumber(2))],
             [new Node\Expr\BinaryOp\BitwiseOr(new Node\Scalar\LNumber(1), new Node\Scalar\LNumber(2))],
             [new Node\Expr\AssignOp\Concat(new Node\Scalar\String_('foo'), new Node\Scalar\String_('boo'))],
+            [new Node\Expr\FuncCall(new Node\Name('constant'), [new Node\Arg(new Node\Scalar\String_('STDIN'))])],
         ];
     }
 


### PR DESCRIPTION
I used a little hack. I converted the `define` calls to this:

 `define('STDIN', constant('STDIN'))`
 
And this format can be supported in stubs and then in both source stubbers.