### PR TITLE
Revert "Removed support for PHP4 style constructors"

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -16,7 +16,6 @@ or backwards compatibility (BC) breakages occur.
 * Method `\Roave\BetterReflection\Identifier\IdentifierType::isMatchingReflector()` has been removed.
 * All adapters are `final`
 * `ClassReflector`, `FunctionReflector` and `ConstantReflector` have been removed. Use `DefaultReflector` to reflect all types.
-* Removed support for PHP4 style constructors
 * Adapters don't have `::export()` method anymore because these methods were removed from PHP. These methods have been removed:
   * `\Roave\BetterReflection\Reflection\Adapter\ReflectionClass::export()`
   * `\Roave\BetterReflection\Reflection\Adapter\ReflectionFunction::export()`

--- a/src/Reflection/ReflectionMethod.php
+++ b/src/Reflection/ReflectionMethod.php
@@ -260,7 +260,16 @@ class ReflectionMethod
      */
     public function isConstructor(): bool
     {
-        return strtolower($this->getName()) === '__construct';
+        if (strtolower($this->getName()) === '__construct') {
+            return true;
+        }
+
+        $declaringClass = $this->getDeclaringClass();
+        if ($declaringClass->inNamespace()) {
+            return false;
+        }
+
+        return strtolower($this->getName()) === strtolower($declaringClass->getShortName());
     }
 
     /**

--- a/test/unit/Fixture/Php4StyleCaseInsensitiveConstruct.php
+++ b/test/unit/Fixture/Php4StyleCaseInsensitiveConstruct.php
@@ -1,0 +1,8 @@
+<?php
+
+class Php4StyleCaseInsensitiveConstruct
+{
+    public function PHP4STYLECASEINSENSITIVECONSTRUCT()
+    {
+    }
+}

--- a/test/unit/Fixture/Php4StyleConstruct.php
+++ b/test/unit/Fixture/Php4StyleConstruct.php
@@ -1,0 +1,8 @@
+<?php
+
+class Php4StyleConstruct
+{
+    public function Php4StyleConstruct()
+    {
+    }
+}

--- a/test/unit/Fixture/Php4StyleConstructInNamespace.php
+++ b/test/unit/Fixture/Php4StyleConstructInNamespace.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Roave\BetterReflectionTest\Fixture;
+
+class Php4StyleConstructInNamespace
+{
+    public function Php4StyleConstructInNamespace()
+    {
+    }
+}

--- a/test/unit/Reflection/ReflectionClassTest.php
+++ b/test/unit/Reflection/ReflectionClassTest.php
@@ -9,6 +9,9 @@ use Bar;
 use Baz;
 use E;
 use Iterator;
+use OutOfBoundsException;
+use Php4StyleCaseInsensitiveConstruct;
+use Php4StyleConstruct;
 use PhpParser\Node\Stmt\Class_;
 use PHPUnit\Framework\TestCase;
 use Qux;
@@ -488,6 +491,44 @@ class ReflectionClassTest extends TestCase
     {
         $reflector   = new DefaultReflector($this->getComposerLocator());
         $classInfo   = $reflector->reflectClass(UpperCaseConstructDestruct::class);
+        $constructor = $classInfo->getConstructor();
+
+        self::assertInstanceOf(ReflectionMethod::class, $constructor);
+        self::assertTrue($constructor->isConstructor());
+    }
+
+    public function testGetConstructorWhenPhp4Style(): void
+    {
+        $classInfo = (new DefaultReflector(new SingleFileSourceLocator(
+            __DIR__ . '/../Fixture/Php4StyleConstruct.php',
+            $this->astLocator,
+        )))->reflectClass(Php4StyleConstruct::class);
+
+        $constructor = $classInfo->getConstructor();
+
+        self::assertInstanceOf(ReflectionMethod::class, $constructor);
+        self::assertTrue($constructor->isConstructor());
+    }
+
+    public function testGetConstructorWhenPhp4StyleInNamespace(): void
+    {
+        $this->expectException(OutOfBoundsException::class);
+
+        $classInfo = (new DefaultReflector(new SingleFileSourceLocator(
+            __DIR__ . '/../Fixture/Php4StyleConstructInNamespace.php',
+            $this->astLocator,
+        )))->reflectClass(Fixture\Php4StyleConstructInNamespace::class);
+
+        $classInfo->getConstructor();
+    }
+
+    public function testGetConstructorWhenPhp4StyleCaseInsensitive(): void
+    {
+        $classInfo = (new DefaultReflector(new SingleFileSourceLocator(
+            __DIR__ . '/../Fixture/Php4StyleCaseInsensitiveConstruct.php',
+            $this->astLocator,
+        )))->reflectClass(Php4StyleCaseInsensitiveConstruct::class);
+
         $constructor = $classInfo->getConstructor();
 
         self::assertInstanceOf(ReflectionMethod::class, $constructor);

--- a/test/unit/Reflection/ReflectionMethodTest.php
+++ b/test/unit/Reflection/ReflectionMethodTest.php
@@ -8,6 +8,8 @@ use A\Foo;
 use ClassWithMethodsAndTraitMethods;
 use Closure;
 use ExtendedClassWithMethodsAndTraitMethods;
+use Php4StyleCaseInsensitiveConstruct;
+use Php4StyleConstruct;
 use PHPUnit\Framework\TestCase;
 use Reflection;
 use ReflectionClass;
@@ -36,6 +38,7 @@ use Roave\BetterReflectionTest\Fixture\ClassWithStaticMethod;
 use Roave\BetterReflectionTest\Fixture\ExampleClass;
 use Roave\BetterReflectionTest\Fixture\InterfaceWithMethod;
 use Roave\BetterReflectionTest\Fixture\Methods;
+use Roave\BetterReflectionTest\Fixture\Php4StyleConstructInNamespace;
 use Roave\BetterReflectionTest\Fixture\TraitWithStaticMethod;
 use Roave\BetterReflectionTest\Fixture\TraitWithStaticMethodToUse;
 use Roave\BetterReflectionTest\Fixture\UpperCaseConstructDestruct;
@@ -159,6 +162,33 @@ class ReflectionMethodTest extends TestCase
 
         $method = $classInfo->getMethod('__DESTRUCT');
         self::assertTrue($method->isDestructor());
+    }
+
+    public function testIsConstructorWhenPhp4Style(): void
+    {
+        $reflector = new DefaultReflector(new SingleFileSourceLocator(__DIR__ . '/../Fixture/Php4StyleConstruct.php', $this->astLocator));
+        $classInfo = $reflector->reflectClass(Php4StyleConstruct::class);
+
+        $method = $classInfo->getMethod('Php4StyleConstruct');
+        self::assertTrue($method->isConstructor());
+    }
+
+    public function testsIsConstructorWhenPhp4StyleInNamespace(): void
+    {
+        $reflector = new DefaultReflector(new SingleFileSourceLocator(__DIR__ . '/../Fixture/Php4StyleConstructInNamespace.php', $this->astLocator));
+        $classInfo = $reflector->reflectClass(Php4StyleConstructInNamespace::class);
+
+        $method = $classInfo->getMethod('Php4StyleConstructInNamespace');
+        self::assertFalse($method->isConstructor());
+    }
+
+    public function testIsConstructorWhenPhp4StyleCaseInsensitive(): void
+    {
+        $reflector = new DefaultReflector(new SingleFileSourceLocator(__DIR__ . '/../Fixture/Php4StyleCaseInsensitiveConstruct.php', $this->astLocator));
+        $classInfo = $reflector->reflectClass(Php4StyleCaseInsensitiveConstruct::class);
+
+        $method = $classInfo->getMethod('PHP4STYLECASEINSENSITIVECONSTRUCT');
+        self::assertTrue($method->isConstructor());
     }
 
     public function testGetParameters(): void


### PR DESCRIPTION
This reverts commit 8c02766b0098fdaea0ca0773379289dd2c67d89d.