### PR TITLE
Added `false` to types considered by `ReflectionNamedType#isBuiltIn()` logic

### DIFF
--- a/src/Reflection/ReflectionNamedType.php
+++ b/src/Reflection/ReflectionNamedType.php
@@ -32,6 +32,7 @@ class ReflectionNamedType extends ReflectionType
         'static'   => null,
         'null'     => null,
         'never'    => null,
+        'false'    => null,
     ];
 
     private string $name;

--- a/test/unit/Reflection/ReflectionNamedTypeTest.php
+++ b/test/unit/Reflection/ReflectionNamedTypeTest.php
@@ -66,6 +66,7 @@ class ReflectionNamedTypeTest extends TestCase
         yield ['iterable'];
         yield ['mixed'];
         yield ['never'];
+        yield ['false'];
     }
 
     /**


### PR DESCRIPTION
`ReflectionNamedType::isBuiltIn()` was missing `false` type as built-in type.

Here it's proof with original reflections:

https://3v4l.org/OjBF8