### PR TITLE
Fix missing properties for `UnitEnum` and `BackedEnum` interfaces

### DIFF
--- a/test/unit/Reflection/ReflectionClassTest.php
+++ b/test/unit/Reflection/ReflectionClassTest.php
@@ -580,6 +580,14 @@ class ReflectionClassTest extends TestCase
                 IntEnum::class,
                 ['name' => 'string', 'value' => 'int'],
             ],
+            [
+                UnitEnum::class,
+                ['name' => 'string'],
+            ],
+            [
+                BackedEnum::class,
+                ['name' => 'string', 'value' => 'int|string'],
+            ],
         ];
     }
 
@@ -596,7 +604,7 @@ class ReflectionClassTest extends TestCase
         ]));
 
         $classInfo  = $reflector->reflectClass($className);
-        $properties = $classInfo->getImmediateProperties();
+        $properties = $classInfo->getProperties();
 
         foreach ($propertiesData as $propertyName => $propertyType) {
             $fullPropertyName = sprintf('%s::$%s', $className, $propertyName);

--- a/test/unit/Reflection/ReflectionPropertyTest.php
+++ b/test/unit/Reflection/ReflectionPropertyTest.php
@@ -136,7 +136,7 @@ class ReflectionPropertyTest extends TestCase
     public function testGetDocCommentBetweenComments(): void
     {
         $php       = '<?php
-            class Bar implements Foo {
+            class Bar {
                 /* A comment  */
                 /** Property description */
                 /* An another comment */


### PR DESCRIPTION
Phew, interfaces with properties...

This one actually fixes a couple of problems:

1) When reflecting UnitEnum and BackedEnum, which aren't actually enums, just plain interfaces, BackedEnum didn't know about the "name" property because ReflectionClass code didn't inherit properties from interfaces (understandably).
2) jetbrains/phpstorm-stubs 2021.3 have several bugs in enum stubs - the properties aren't readonly, and the BackedEnum value property has wrong type. Relevant PRs: https://github.com/JetBrains/phpstorm-stubs/pull/1316 + https://github.com/JetBrains/phpstorm-stubs/pull/1278