### PR TITLE
Added `ReflectionType::getOwner()`

### DIFF
--- a/src/Reflection/ReflectionType.php
+++ b/src/Reflection/ReflectionType.php
@@ -53,6 +53,14 @@ abstract class ReflectionType
     }
 
     /**
+     * @internal
+     */
+    public function getOwner(): ReflectionParameter|ReflectionMethod|ReflectionFunction|ReflectionEnum|ReflectionProperty
+    {
+        return $this->owner;
+    }
+
+    /**
      * Does the type allow null?
      */
     abstract public function allowsNull(): bool;

--- a/test/unit/Reflection/ReflectionIntersectionTypeTest.php
+++ b/test/unit/Reflection/ReflectionIntersectionTypeTest.php
@@ -45,5 +45,6 @@ class ReflectionIntersectionTypeTest extends TestCase
         self::assertContainsOnlyInstancesOf(ReflectionNamedType::class, $typeReflection->getTypes());
         self::assertSame($expectedString, $typeReflection->__toString());
         self::assertFalse($typeReflection->allowsNull());
+        self::assertSame($this->owner, $typeReflection->getOwner());
     }
 }

--- a/test/unit/Reflection/ReflectionNamedTypeTest.php
+++ b/test/unit/Reflection/ReflectionNamedTypeTest.php
@@ -43,6 +43,7 @@ class ReflectionNamedTypeTest extends TestCase
 
         self::assertInstanceOf(ReflectionNamedType::class, $typeInfo);
         self::assertSame('string', $typeInfo->getName());
+        self::assertSame($this->owner, $typeInfo->getOwner());
     }
 
     public function testAllowsNull(): void

--- a/test/unit/Reflection/ReflectionTypeTest.php
+++ b/test/unit/Reflection/ReflectionTypeTest.php
@@ -79,5 +79,6 @@ class ReflectionTypeTest extends TestCase
 
         self::assertInstanceOf($expectedReflectionClass, $reflectionType);
         self::assertSame($expectedAllowsNull, $reflectionType->allowsNull());
+        self::assertSame($this->owner, $reflectionType->getOwner());
     }
 }

--- a/test/unit/Reflection/ReflectionUnionTypeTest.php
+++ b/test/unit/Reflection/ReflectionUnionTypeTest.php
@@ -45,5 +45,6 @@ class ReflectionUnionTypeTest extends TestCase
         self::assertContainsOnlyInstancesOf(ReflectionNamedType::class, $typeReflection->getTypes());
         self::assertSame($expectedString, $typeReflection->__toString());
         self::assertSame($expectedNullable, $typeReflection->allowsNull());
+        self::assertSame($this->owner, $typeReflection->getOwner());
     }
 }


### PR DESCRIPTION
The method is not really necessary it should just kill some mutants: https://dashboard.stryker-mutator.io/reports/github.com/Roave/BetterReflection/5.1.x#mutant/Reflection/ReflectionUnionType.php

The constructor in `ReflectionType` is useless but I don't think we can remove it because it would be BC break...