### PR TITLE
Refactor - introduce `psalm-type` alias for composer `autoload` array shape

### DIFF
--- a/src/SourceLocator/Type/Composer/Factory/MakeLocatorForComposerJson.php
+++ b/src/SourceLocator/Type/Composer/Factory/MakeLocatorForComposerJson.php
@@ -26,6 +26,9 @@ use function is_file;
 use function json_decode;
 use function realpath;
 
+/**
+ * @psalm-type AutoloadMapping array{psr-0?: array<string, string|string[]>, psr-4?: array<string, string|string[]>, classmap?: list<string>, files?: list<string>, exclude-from-classmap?: list<string>}
+ */
 final class MakeLocatorForComposerJson
 {
     public function __invoke(string $installationPath, Locator $astLocator): SourceLocator
@@ -42,7 +45,7 @@ final class MakeLocatorForComposerJson
             throw MissingComposerJson::inProjectPath($installationPath);
         }
 
-        /** @psalm-var array{autoload: array{classmap: list<string>, files: list<string>, psr-4: array<string, list<string>|string>, psr-0: array<string, list<string>|string>}}|null $composer */
+        /** @psalm-var array{autoload: AutoloadMapping}|null $composer */
         $composer = json_decode((string) file_get_contents($composerJsonPath), true);
 
         if (! is_array($composer)) {
@@ -76,7 +79,7 @@ final class MakeLocatorForComposerJson
     }
 
     /**
-     * @param array{autoload: array{classmap?: list<string>, files?: list<string>, psr-4?: array<string, list<string>|string>, psr-0?: array<string, list<string>|string>}} $package
+     * @param array{autoload: AutoloadMapping} $package
      *
      * @return array<string, list<string>>
      */
@@ -86,7 +89,7 @@ final class MakeLocatorForComposerJson
     }
 
     /**
-     * @param array{autoload: array{classmap?: list<string>, files?: list<string>, psr-4?: array<string, list<string>|string>, psr-0?: array<string, list<string>|string>}} $package
+     * @param array{autoload: AutoloadMapping} $package
      *
      * @return array<string, list<string>>
      */
@@ -96,7 +99,7 @@ final class MakeLocatorForComposerJson
     }
 
     /**
-     * @param array{autoload: array{classmap?: list<string>, files?: list<string>, psr-4?: array<string, list<string>|string>, psr-0?: array<string, list<string>|string>}} $package
+     * @param array{autoload: AutoloadMapping} $package
      *
      * @return list<string>
      */
@@ -106,7 +109,7 @@ final class MakeLocatorForComposerJson
     }
 
     /**
-     * @param array{autoload: array{classmap?: list<string>, files?: list<string>, psr-4?: array<string, list<string>|string>, psr-0?: array<string, list<string>|string>}} $package
+     * @param array{autoload: AutoloadMapping} $package
      *
      * @return list<string>
      */

--- a/src/SourceLocator/Type/Composer/Factory/MakeLocatorForComposerJson.php
+++ b/src/SourceLocator/Type/Composer/Factory/MakeLocatorForComposerJson.php
@@ -27,7 +27,13 @@ use function json_decode;
 use function realpath;
 
 /**
- * @psalm-type AutoloadMapping array{psr-0?: array<string, string|string[]>, psr-4?: array<string, string|string[]>, classmap?: list<string>, files?: list<string>, exclude-from-classmap?: list<string>}
+ * @psalm-type AutoloadMapping array{
+ *  psr-0?: array<string, string|string[]>,
+ *  psr-4?: array<string, string|string[]>,
+ *  classmap?: list<string>,
+ *  files?: list<string>,
+ *  exclude-from-classmap?: list<string>
+ * }
  */
 final class MakeLocatorForComposerJson
 {

--- a/src/SourceLocator/Type/Composer/Factory/MakeLocatorForComposerJson.php
+++ b/src/SourceLocator/Type/Composer/Factory/MakeLocatorForComposerJson.php
@@ -27,7 +27,7 @@ use function json_decode;
 use function realpath;
 
 /**
- * @psalm-type AutoloadMapping array{
+ * @psalm-type ComposerAudoload array{
  *  psr-0?: array<string, string|string[]>,
  *  psr-4?: array<string, string|string[]>,
  *  classmap?: list<string>,
@@ -51,7 +51,7 @@ final class MakeLocatorForComposerJson
             throw MissingComposerJson::inProjectPath($installationPath);
         }
 
-        /** @psalm-var array{autoload: AutoloadMapping}|null $composer */
+        /** @psalm-var array{autoload: ComposerAudoload}|null $composer */
         $composer = json_decode((string) file_get_contents($composerJsonPath), true);
 
         if (! is_array($composer)) {
@@ -85,7 +85,7 @@ final class MakeLocatorForComposerJson
     }
 
     /**
-     * @param array{autoload: AutoloadMapping} $package
+     * @param array{autoload: ComposerAudoload} $package
      *
      * @return array<string, list<string>>
      */
@@ -95,7 +95,7 @@ final class MakeLocatorForComposerJson
     }
 
     /**
-     * @param array{autoload: AutoloadMapping} $package
+     * @param array{autoload: ComposerAudoload} $package
      *
      * @return array<string, list<string>>
      */
@@ -105,7 +105,7 @@ final class MakeLocatorForComposerJson
     }
 
     /**
-     * @param array{autoload: AutoloadMapping} $package
+     * @param array{autoload: ComposerAudoload} $package
      *
      * @return list<string>
      */
@@ -115,7 +115,7 @@ final class MakeLocatorForComposerJson
     }
 
     /**
-     * @param array{autoload: AutoloadMapping} $package
+     * @param array{autoload: ComposerAudoload} $package
      *
      * @return list<string>
      */

--- a/src/SourceLocator/Type/Composer/Factory/MakeLocatorForComposerJsonAndInstalledJson.php
+++ b/src/SourceLocator/Type/Composer/Factory/MakeLocatorForComposerJsonAndInstalledJson.php
@@ -31,7 +31,7 @@ use function realpath;
 use function rtrim;
 
 /**
- * @psalm-import-type AutoloadMapping from MakeLocatorForComposerJson
+ * @psalm-import-type ComposerAudoload from MakeLocatorForComposerJson
  */
 final class MakeLocatorForComposerJsonAndInstalledJson
 {
@@ -50,7 +50,7 @@ final class MakeLocatorForComposerJsonAndInstalledJson
         }
 
         /**
-         * @psalm-var array{autoload: AutoloadMapping, config: array{vendor-dir?: string}}|null $composer
+         * @psalm-var array{autoload: ComposerAudoload, config: array{vendor-dir?: string}}|null $composer
          */
         $composer  = json_decode((string) file_get_contents($composerJsonPath), true);
         $vendorDir = $composer['config']['vendor-dir'] ?? 'vendor';
@@ -73,7 +73,7 @@ final class MakeLocatorForComposerJsonAndInstalledJson
             throw FailedToParseJson::inFile($installedJsonPath);
         }
 
-        /** @psalm-var list<array{name: string, autoload: AutoloadMapping}> $installed */
+        /** @psalm-var list<array{name: string, autoload: ComposerAudoload}> $installed */
         $installed = $installedJson['packages'] ?? $installedJson;
 
         $classMapPaths       = array_merge(
@@ -126,7 +126,7 @@ final class MakeLocatorForComposerJsonAndInstalledJson
     }
 
     /**
-     * @param array{autoload: AutoloadMapping} $package
+     * @param array{autoload: ComposerAudoload} $package
      *
      * @return array<string, list<string>>
      */
@@ -136,7 +136,7 @@ final class MakeLocatorForComposerJsonAndInstalledJson
     }
 
     /**
-     * @param array{autoload: AutoloadMapping} $package
+     * @param array{autoload: ComposerAudoload} $package
      *
      * @return array<string, list<string>>
      */
@@ -146,7 +146,7 @@ final class MakeLocatorForComposerJsonAndInstalledJson
     }
 
     /**
-     * @param array{autoload: AutoloadMapping} $package
+     * @param array{autoload: ComposerAudoload} $package
      *
      * @return list<string>
      */
@@ -156,7 +156,7 @@ final class MakeLocatorForComposerJsonAndInstalledJson
     }
 
     /**
-     * @param array{autoload: AutoloadMapping} $package
+     * @param array{autoload: ComposerAudoload} $package
      *
      * @return list<string>
      */

--- a/src/SourceLocator/Type/Composer/Factory/MakeLocatorForComposerJsonAndInstalledJson.php
+++ b/src/SourceLocator/Type/Composer/Factory/MakeLocatorForComposerJsonAndInstalledJson.php
@@ -30,6 +30,9 @@ use function json_decode;
 use function realpath;
 use function rtrim;
 
+/**
+ * @psalm-import-type AutoloadMapping from MakeLocatorForComposerJson
+ */
 final class MakeLocatorForComposerJsonAndInstalledJson
 {
     public function __invoke(string $installationPath, Locator $astLocator): SourceLocator
@@ -47,10 +50,7 @@ final class MakeLocatorForComposerJsonAndInstalledJson
         }
 
         /**
-         * @psalm-var array{
-         * autoload: array{classmap: list<string>, files: list<string>, psr-4: array<string, list<string>|string>, psr-0: array<string, list<string>|string>},
-         * config: array{vendor-dir?: string}
-         * }|null $composer
+         * @psalm-var array{autoload: AutoloadMapping, config: array{vendor-dir?: string}}|null $composer
          */
         $composer  = json_decode((string) file_get_contents($composerJsonPath), true);
         $vendorDir = $composer['config']['vendor-dir'] ?? 'vendor';
@@ -73,7 +73,7 @@ final class MakeLocatorForComposerJsonAndInstalledJson
             throw FailedToParseJson::inFile($installedJsonPath);
         }
 
-        /** @psalm-var list<array{name: string, autoload: array{classmap: list<string>, files: list<string>, psr-4: array<string, list<string>|string>, psr-0: array<string, list<string>|string>}}> $installed */
+        /** @psalm-var list<array{name: string, autoload: AutoloadMapping}> $installed */
         $installed = $installedJson['packages'] ?? $installedJson;
 
         $classMapPaths       = array_merge(
@@ -126,7 +126,7 @@ final class MakeLocatorForComposerJsonAndInstalledJson
     }
 
     /**
-     * @param array{autoload: array{classmap?: list<string>, files?: list<string>, psr-4?: array<string, list<string>|string>, psr-0?: array<string, list<string>|string>}} $package
+     * @param array{autoload: AutoloadMapping} $package
      *
      * @return array<string, list<string>>
      */
@@ -136,7 +136,7 @@ final class MakeLocatorForComposerJsonAndInstalledJson
     }
 
     /**
-     * @param array{autoload: array{classmap?: list<string>, files?: list<string>, psr-4?: array<string, list<string>|string>, psr-0?: array<string, list<string>|string>}} $package
+     * @param array{autoload: AutoloadMapping} $package
      *
      * @return array<string, list<string>>
      */
@@ -146,7 +146,7 @@ final class MakeLocatorForComposerJsonAndInstalledJson
     }
 
     /**
-     * @param array{autoload: array{classmap?: list<string>, files?: list<string>, psr-4?: array<string, list<string>|string>, psr-0?: array<string, list<string>|string>}} $package
+     * @param array{autoload: AutoloadMapping} $package
      *
      * @return list<string>
      */
@@ -156,7 +156,7 @@ final class MakeLocatorForComposerJsonAndInstalledJson
     }
 
     /**
-     * @param array{autoload: array{classmap?: list<string>, files?: list<string>, psr-4?: array<string, list<string>|string>, psr-0?: array<string, list<string>|string>}} $package
+     * @param array{autoload: AutoloadMapping} $package
      *
      * @return list<string>
      */

--- a/src/SourceLocator/Type/Composer/Factory/MakeLocatorForInstalledJson.php
+++ b/src/SourceLocator/Type/Composer/Factory/MakeLocatorForInstalledJson.php
@@ -31,7 +31,7 @@ use function realpath;
 use function rtrim;
 
 /**
- * @psalm-import-type AutoloadMapping from MakeLocatorForComposerJson
+ * @psalm-import-type ComposerAudoload from MakeLocatorForComposerJson
  */
 final class MakeLocatorForInstalledJson
 {
@@ -50,7 +50,7 @@ final class MakeLocatorForInstalledJson
         }
 
         /**
-         * @psalm-var array{autoload: AutoloadMapping, config: array{vendor-dir?: string}}|null $composer
+         * @psalm-var array{autoload: ComposerAudoload, config: array{vendor-dir?: string}}|null $composer
          */
         $composer  = json_decode((string) file_get_contents($composerJsonPath), true);
         $vendorDir = $composer['config']['vendor-dir'] ?? 'vendor';
@@ -122,7 +122,7 @@ final class MakeLocatorForInstalledJson
     }
 
     /**
-     * @param array{autoload: AutoloadMapping} $package
+     * @param array{autoload: ComposerAudoload} $package
      *
      * @return array<string, list<string>>
      */
@@ -132,7 +132,7 @@ final class MakeLocatorForInstalledJson
     }
 
     /**
-     * @param array{autoload: AutoloadMapping} $package
+     * @param array{autoload: ComposerAudoload} $package
      *
      * @return array<string, list<string>>
      */
@@ -142,7 +142,7 @@ final class MakeLocatorForInstalledJson
     }
 
     /**
-     * @param array{autoload: AutoloadMapping} $package
+     * @param array{autoload: ComposerAudoload} $package
      *
      * @return list<string>
      */
@@ -152,7 +152,7 @@ final class MakeLocatorForInstalledJson
     }
 
     /**
-     * @param array{autoload: AutoloadMapping} $package
+     * @param array{autoload: ComposerAudoload} $package
      *
      * @return list<string>
      */
@@ -162,7 +162,7 @@ final class MakeLocatorForInstalledJson
     }
 
     /**
-     * @param array{name: string, autoload: AutoloadMapping} $package
+     * @param array{name: string, autoload: ComposerAudoload} $package
      */
     private function packagePrefixPath(string $trimmedInstallationPath, array $package, string $vendorDir): string
     {
@@ -171,7 +171,7 @@ final class MakeLocatorForInstalledJson
 
     /**
      * @param array<int|string, array<string>>               $paths
-     * @param array{name: string, autoload: AutoloadMapping} $package
+     * @param array{name: string, autoload: ComposerAudoload} $package
      *
      * @return array<int|string, string|array<string>>
      */

--- a/src/SourceLocator/Type/Composer/Factory/MakeLocatorForInstalledJson.php
+++ b/src/SourceLocator/Type/Composer/Factory/MakeLocatorForInstalledJson.php
@@ -30,6 +30,9 @@ use function json_decode;
 use function realpath;
 use function rtrim;
 
+/**
+ * @psalm-import-type AutoloadMapping from MakeLocatorForComposerJson
+ */
 final class MakeLocatorForInstalledJson
 {
     public function __invoke(string $installationPath, Locator $astLocator): SourceLocator
@@ -47,10 +50,7 @@ final class MakeLocatorForInstalledJson
         }
 
         /**
-         * @psalm-var array{
-         * autoload: array{classmap: list<string>, files: list<string>, psr-4: array<string, list<string>|string>, psr-0: array<string, list<string>|string>},
-         * config: array{vendor-dir?: string}
-         * }|null $composer
+         * @psalm-var array{autoload: AutoloadMapping, config: array{vendor-dir?: string}}|null $composer
          */
         $composer  = json_decode((string) file_get_contents($composerJsonPath), true);
         $vendorDir = $composer['config']['vendor-dir'] ?? 'vendor';
@@ -122,7 +122,7 @@ final class MakeLocatorForInstalledJson
     }
 
     /**
-     * @param array{autoload: array{classmap?: list<string>, files?: list<string>, psr-4?: array<string, list<string>|string>, psr-0?: array<string, list<string>|string>}} $package
+     * @param array{autoload: AutoloadMapping} $package
      *
      * @return array<string, list<string>>
      */
@@ -132,7 +132,7 @@ final class MakeLocatorForInstalledJson
     }
 
     /**
-     * @param array{autoload: array{classmap?: list<string>, files?: list<string>, psr-4?: array<string, list<string>|string>, psr-0?: array<string, list<string>|string>}} $package
+     * @param array{autoload: AutoloadMapping} $package
      *
      * @return array<string, list<string>>
      */
@@ -142,7 +142,7 @@ final class MakeLocatorForInstalledJson
     }
 
     /**
-     * @param array{autoload: array{classmap?: list<string>, files?: list<string>, psr-4?: array<string, list<string>|string>, psr-0?: array<string, list<string>|string>}} $package
+     * @param array{autoload: AutoloadMapping} $package
      *
      * @return list<string>
      */
@@ -152,7 +152,7 @@ final class MakeLocatorForInstalledJson
     }
 
     /**
-     * @param array{autoload: array{classmap?: list<string>, files?: list<string>, psr-4?: array<string, list<string>|string>, psr-0?: array<string, list<string>|string>}} $package
+     * @param array{autoload: AutoloadMapping} $package
      *
      * @return list<string>
      */
@@ -162,7 +162,7 @@ final class MakeLocatorForInstalledJson
     }
 
     /**
-     * @param array{name: string, autoload: array{classmap?: list<string>, files?: list<string>, psr-4?: array<string, list<string>|string>, psr-0?: array<string, list<string>|string>}} $package
+     * @param array{name: string, autoload: AutoloadMapping} $package
      */
     private function packagePrefixPath(string $trimmedInstallationPath, array $package, string $vendorDir): string
     {
@@ -170,8 +170,8 @@ final class MakeLocatorForInstalledJson
     }
 
     /**
-     * @param array<int|string, array<string>>                                                                                                                                            $paths
-     * @param array{name: string, autoload: array{classmap?: list<string>, files?: list<string>, psr-4?: array<string, list<string>|string>, psr-0?: array<string, list<string>|string>}} $package
+     * @param array<int|string, array<string>>               $paths
+     * @param array{name: string, autoload: AutoloadMapping} $package
      *
      * @return array<int|string, string|array<string>>
      */

--- a/src/SourceLocator/Type/Composer/Factory/MakeLocatorForInstalledJson.php
+++ b/src/SourceLocator/Type/Composer/Factory/MakeLocatorForInstalledJson.php
@@ -170,7 +170,7 @@ final class MakeLocatorForInstalledJson
     }
 
     /**
-     * @param array<int|string, array<string>>               $paths
+     * @param array<int|string, array<string>>                $paths
      * @param array{name: string, autoload: ComposerAudoload} $package
      *
      * @return array<int|string, string|array<string>>


### PR DESCRIPTION
please see https://github.com/composer/composer/pull/10516.
At moment, I'm on proposing introduce AutoloadMapping type to composer iteself.

I'm not sure installed.json's autoload mapping is same as composer.json schema. installed.json does not have schema(maybe)
https://github.com/composer/composer/tree/main/res
But it seems mostly same of composer.json's.

About phpstan, over 0.12.84 also supports "type". So we can use it.
https://github.com/phpstan/phpstan/discussions/4878