### PR TITLE
Mini optimization of `CompileNodeToValue`

### DIFF
--- a/src/NodeCompiler/CompileNodeToValue.php
+++ b/src/NodeCompiler/CompileNodeToValue.php
@@ -201,7 +201,8 @@ class CompileNodeToValue
             return $className;
         }
 
-        $classReflection = $context->getReflector()->reflectClass($className);
+        $classContext    = $context->getClass();
+        $classReflection = $classContext !== null && $classContext->getName() === $className ? $classContext : $context->getReflector()->reflectClass($className);
 
         $reflectionConstant = $classReflection->getReflectionConstant($constantName);
 


### PR DESCRIPTION
We can use the already known class - there's no need to reflect it again.