### PR TITLE
remove `$` from bash block in installation documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Be sure to read more in the [feature documentation](docs/features.md).
 Require using composer:
 
 ```shell
-$ composer require roave/better-reflection
+composer require roave/better-reflection
 ```
 
 ## Usage


### PR DESCRIPTION
so cut-and-paste works properly