### PR TITLE
Fix #1043 - make `CompileNodeToValue` filesystem-agnostic

### DIFF
--- a/src/NodeCompiler/CompileNodeToValue.php
+++ b/src/NodeCompiler/CompileNodeToValue.php
@@ -17,7 +17,6 @@ use function defined;
 use function dirname;
 use function explode;
 use function in_array;
-use function realpath;
 use function sprintf;
 
 /**

--- a/src/NodeCompiler/CompileNodeToValue.php
+++ b/src/NodeCompiler/CompileNodeToValue.php
@@ -224,7 +224,7 @@ class CompileNodeToValue
             throw Exception\UnableToCompileNode::becauseOfMissingFileName($context, $node);
         }
 
-        return dirname(FileHelper::normalizeWindowsPath(realpath($fileName)));
+        return dirname(FileHelper::normalizeWindowsPath($fileName));
     }
 
     /**
@@ -238,7 +238,7 @@ class CompileNodeToValue
             throw Exception\UnableToCompileNode::becauseOfMissingFileName($context, $node);
         }
 
-        return FileHelper::normalizeWindowsPath(realpath($fileName));
+        return FileHelper::normalizeWindowsPath($fileName);
     }
 
     /**


### PR DESCRIPTION
With this change, `CompileNodeToValue` will honor the source location given by the source locator, and will not use the local filesystem to identify `__DIR__` nor `__FILE__`.

Note: as it currently is, this patch is just a stub of the final wished result, as some cleanup is still necessary.

Also, this should remove some filesystem calls that could happen deep inside `roave/better-reflection`'s core, potentially speeding up the whole thing :D 

Fixes #1043