### PR TITLE
RFC: Reflector to reflect on all attributes

### DIFF
--- a/src/Identifier/IdentifierType.php
+++ b/src/Identifier/IdentifierType.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Roave\BetterReflection\Identifier;
 
 use InvalidArgumentException;
+use Roave\BetterReflection\Reflection\ReflectionAttribute;
 use Roave\BetterReflection\Reflection\ReflectionClass;
 use Roave\BetterReflection\Reflection\ReflectionConstant;
 use Roave\BetterReflection\Reflection\ReflectionFunction;
@@ -12,23 +13,23 @@ use Roave\BetterReflection\Reflection\ReflectionFunction;
 use function array_key_exists;
 use function sprintf;
 
-class IdentifierType
-{
-    public const IDENTIFIER_CLASS    = ReflectionClass::class;
+class IdentifierType {
+    public const IDENTIFIER_CLASS = ReflectionClass::class;
     public const IDENTIFIER_FUNCTION = ReflectionFunction::class;
     public const IDENTIFIER_CONSTANT = ReflectionConstant::class;
+    public const IDENTIFIER_ATTRIBUTE = ReflectionAttribute::class;
 
     private const VALID_TYPES = [
-        self::IDENTIFIER_CLASS    => null,
+        self::IDENTIFIER_CLASS => null,
         self::IDENTIFIER_FUNCTION => null,
         self::IDENTIFIER_CONSTANT => null,
+        self::IDENTIFIER_ATTRIBUTE => null,
     ];
 
     private string $name;
 
-    public function __construct(string $type = self::IDENTIFIER_CLASS)
-    {
-        if (! array_key_exists($type, self::VALID_TYPES)) {
+    public function __construct(string $type = self::IDENTIFIER_CLASS) {
+        if (!array_key_exists($type, self::VALID_TYPES)) {
             throw new InvalidArgumentException(sprintf(
                 '%s is not a valid identifier type',
                 $type,
@@ -38,23 +39,25 @@ class IdentifierType
         $this->name = $type;
     }
 
-    public function getName(): string
-    {
+    public function getName(): string {
         return $this->name;
     }
 
-    public function isClass(): bool
-    {
+    public function isClass(): bool {
         return $this->name === self::IDENTIFIER_CLASS;
     }
 
-    public function isFunction(): bool
-    {
+    public function isFunction(): bool {
         return $this->name === self::IDENTIFIER_FUNCTION;
     }
 
-    public function isConstant(): bool
-    {
+    public function isConstant(): bool {
         return $this->name === self::IDENTIFIER_CONSTANT;
     }
+
+    public function isAttribute(): bool
+    {
+        return $this->name === self::IDENTIFIER_ATTRIBUTE;
+    }
+
 }

--- a/src/Identifier/IdentifierType.php
+++ b/src/Identifier/IdentifierType.php
@@ -28,7 +28,8 @@ class IdentifierType {
 
     private string $name;
 
-    public function __construct(string $type = self::IDENTIFIER_CLASS) {
+    public function __construct(string $type = self::IDENTIFIER_CLASS)
+    {
         if (!array_key_exists($type, self::VALID_TYPES)) {
             throw new InvalidArgumentException(sprintf(
                 '%s is not a valid identifier type',
@@ -39,19 +40,23 @@ class IdentifierType {
         $this->name = $type;
     }
 
-    public function getName(): string {
+    public function getName(): string
+    {
         return $this->name;
     }
 
-    public function isClass(): bool {
+    public function isClass(): bool
+    {
         return $this->name === self::IDENTIFIER_CLASS;
     }
 
-    public function isFunction(): bool {
+    public function isFunction(): bool
+    {
         return $this->name === self::IDENTIFIER_FUNCTION;
     }
 
-    public function isConstant(): bool {
+    public function isConstant(): bool
+    {
         return $this->name === self::IDENTIFIER_CONSTANT;
     }
 

--- a/src/Reflector/DefaultReflector.php
+++ b/src/Reflector/DefaultReflector.php
@@ -6,6 +6,7 @@ namespace Roave\BetterReflection\Reflector;
 
 use Roave\BetterReflection\Identifier\Identifier;
 use Roave\BetterReflection\Identifier\IdentifierType;
+use Roave\BetterReflection\Reflection\ReflectionAttribute;
 use Roave\BetterReflection\Reflection\ReflectionClass;
 use Roave\BetterReflection\Reflection\ReflectionConstant;
 use Roave\BetterReflection\Reflection\ReflectionFunction;
@@ -126,5 +127,19 @@ final class DefaultReflector implements Reflector
         );
 
         return $allConstants;
+    }
+
+    /**
+     * @return list<ReflectionAttribute>
+     */
+    public function reflectAllAttributes(): iterable
+    {
+        /** @var list<ReflectionAttribute> $allAttributes */
+        $allAttributes = $this->sourceLocator->locateIdentifiersByType(
+            $this,
+            new IdentifierType(IdentifierType::IDENTIFIER_ATTRIBUTE),
+        );
+
+        return $allAttributes;
     }
 }

--- a/src/Reflector/Reflector.php
+++ b/src/Reflector/Reflector.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Roave\BetterReflection\Reflector;
 
+use Roave\BetterReflection\Reflection\ReflectionAttribute;
 use Roave\BetterReflection\Reflection\ReflectionClass;
 use Roave\BetterReflection\Reflection\ReflectionConstant;
 use Roave\BetterReflection\Reflection\ReflectionFunction;
@@ -52,4 +53,11 @@ interface Reflector
      * @return list<ReflectionConstant>
      */
     public function reflectAllConstants(): iterable;
+
+    /**
+     * Get all attributes available in the scope specified by the SourceLocator.
+     *
+     * @return List<ReflectionAttribute>
+     */
+    public function reflectAllAttributes(): iterable;
 }

--- a/src/SourceLocator/Ast/FindReflectionsInTree.php
+++ b/src/SourceLocator/Ast/FindReflectionsInTree.php
@@ -9,6 +9,7 @@ use PhpParser\Node\Name;
 use PhpParser\Node\Stmt\Namespace_;
 use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitor\NameResolver;
+use PhpParser\NodeVisitor\ParentConnectingVisitor;
 use PhpParser\NodeVisitorAbstract;
 use Roave\BetterReflection\Identifier\IdentifierType;
 use Roave\BetterReflection\Reflection\Exception\InvalidConstantNode;
@@ -128,6 +129,9 @@ final class FindReflectionsInTree
                     $this->reflections[] = $this->astConversionStrategy->__invoke($this->reflector, $node, $this->locatedSource, $this->currentNamespace);
                 }
 
+                if ($this->identifierType->isAttribute() && $node instanceof Node\Attribute) {
+                    $this->reflections[] = $this->astConversionStrategy->__invoke($this->reflector, $node, $this->locatedSource, $this->currentNamespace);
+                }
                 return null;
             }
 
@@ -156,6 +160,7 @@ final class FindReflectionsInTree
 
         $nodeTraverser = new NodeTraverser();
         $nodeTraverser->addVisitor(new NameResolver());
+        $nodeTraverser->addVisitor(new ParentConnectingVisitor());
         $nodeTraverser->addVisitor($nodeVisitor);
         $nodeTraverser->traverse($ast);
 

--- a/src/SourceLocator/Ast/Strategy/AstConversionStrategy.php
+++ b/src/SourceLocator/Ast/Strategy/AstConversionStrategy.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Roave\BetterReflection\SourceLocator\Ast\Strategy;
 
 use PhpParser\Node;
+use Roave\BetterReflection\Reflection\ReflectionAttribute;
 use Roave\BetterReflection\Reflection\ReflectionClass;
 use Roave\BetterReflection\Reflection\ReflectionConstant;
 use Roave\BetterReflection\Reflection\ReflectionFunction;
@@ -22,9 +23,9 @@ interface AstConversionStrategy
      */
     public function __invoke(
         Reflector $reflector,
-        Node\Stmt\Class_|Node\Stmt\Interface_|Node\Stmt\Trait_|Node\Stmt\Enum_|Node\Stmt\Function_|Node\Expr\Closure|Node\Expr\ArrowFunction|Node\Stmt\Const_|Node\Expr\FuncCall $node,
+        Node\Stmt\Class_|Node\Stmt\Interface_|Node\Stmt\Trait_|Node\Stmt\Enum_|Node\Stmt\Function_|Node\Expr\Closure|Node\Expr\ArrowFunction|Node\Stmt\Const_|Node\Expr\FuncCall|Node\Attribute $node,
         LocatedSource $locatedSource,
         ?Node\Stmt\Namespace_ $namespace,
         ?int $positionInNode = null,
-    ): ReflectionClass|ReflectionConstant|ReflectionFunction;
+    ): ReflectionClass|ReflectionConstant|ReflectionFunction|ReflectionAttribute;
 }

--- a/src/SourceLocator/Ast/Strategy/NodeToReflection.php
+++ b/src/SourceLocator/Ast/Strategy/NodeToReflection.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Roave\BetterReflection\SourceLocator\Ast\Strategy;
 
 use PhpParser\Node;
+use Roave\BetterReflection\Reflection\ReflectionAttribute;
 use Roave\BetterReflection\Reflection\ReflectionClass;
 use Roave\BetterReflection\Reflection\ReflectionConstant;
 use Roave\BetterReflection\Reflection\ReflectionEnum;
@@ -23,11 +24,11 @@ class NodeToReflection implements AstConversionStrategy
      */
     public function __invoke(
         Reflector $reflector,
-        Node\Stmt\Class_|Node\Stmt\Interface_|Node\Stmt\Trait_|Node\Stmt\Enum_|Node\Stmt\Function_|Node\Expr\Closure|Node\Expr\ArrowFunction|Node\Stmt\Const_|Node\Expr\FuncCall $node,
+        Node\Stmt\Class_|Node\Stmt\Interface_|Node\Stmt\Trait_|Node\Stmt\Enum_|Node\Stmt\Function_|Node\Expr\Closure|Node\Expr\ArrowFunction|Node\Stmt\Const_|Node\Expr\FuncCall|Node\Attribute $node,
         LocatedSource $locatedSource,
         ?Node\Stmt\Namespace_ $namespace,
         ?int $positionInNode = null,
-    ): ReflectionClass|ReflectionConstant|ReflectionFunction {
+    ): ReflectionClass|ReflectionConstant|ReflectionFunction|ReflectionAttribute {
         if ($node instanceof Node\Stmt\Enum_) {
             return ReflectionEnum::createFromNode(
                 $reflector,
@@ -61,6 +62,10 @@ class NodeToReflection implements AstConversionStrategy
 
         if ($node instanceof Node\Stmt\Const_) {
             return ReflectionConstant::createFromNode($reflector, $node, $locatedSource, $namespace, $positionInNode);
+        }
+
+        if ($node instanceof Node\Attribute) {
+            return ReflectionAttribute::createFromNode($reflector, $node, $locatedSource, $namespace);
         }
 
         return ReflectionConstant::createFromNode($reflector, $node, $locatedSource);

--- a/test/unit/Reflector/DefaultReflectorTest.php
+++ b/test/unit/Reflector/DefaultReflectorTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Roave\BetterReflectionTest\Reflector;
 
 use PHPUnit\Framework\TestCase;
+use Roave\BetterReflection\Reflection\ReflectionAttribute;
 use Roave\BetterReflection\Reflection\ReflectionClass;
 use Roave\BetterReflection\Reflection\ReflectionConstant;
 use Roave\BetterReflection\Reflection\ReflectionFunction;
@@ -127,5 +128,15 @@ class DefaultReflectorTest extends TestCase
 
         self::assertContainsOnlyInstancesOf(ReflectionConstant::class, $constants);
         self::assertCount(5, $constants);
+    }
+
+    public function testReflectAllAttributes(): void
+    {
+        $attributes = (new DefaultReflector(
+            new SingleFileSourceLocator(__DIR__ . '/../Fixture/Attributes.php', $this->astLocator),
+        ))->reflectAllAttributes();
+
+        self::assertContainsOnlyInstancesOf(ReflectionAttribute::class, $attributes);
+        self::assertCount(24, $attributes);
     }
 }


### PR DESCRIPTION
A bare-minimum, proof-of-concept implementation for gathering all ReflectionAttributes from a given source. This PR updates the Reflector interface and DefaultReflector implementation to include a reflectAllAttributes() method that will return a list of ReflectionAttribute. Additionally, several type-hints on parameters and method returns have been updated to include Node\Attribute and ReflectionAttribute where appropriate.

This implementation is not meant to represent something fully working or ready to be merged in but to spark a conversation on the desired feature.

---

Hi! Thanks for the awesome library! I have a use case for statically analyzing Attributes in a PHP codebase. To facilitate this I added a `Reflector::reflectAllAttributes()` method that will return a list of ReflectionAttribute instances. Before I continued with this work I wanted to get the maintainers feedback to:

1. See if this feature is even desired by the team and would be open to merging in to the codebase.
2. Collaborate on possible concerns with the implementation and to solidify the changes to the Reflector API.

## Todo

1. Finish testing and implementing the `ReflectionAttribute::createFromNode` method to construct the correct reflection for the node that owns the attribute.
2. Introduce additional methods on the `Reflector` interface for narrowing the ReflectionAttributes returned.
