### PR TITLE
Calling `setAccessible()` has no effect since PHP 8.1 - all methods/properties are accessible by default

### DIFF
--- a/src/Reflection/Adapter/ReflectionClass.php
+++ b/src/Reflection/Adapter/ReflectionClass.php
@@ -403,10 +403,6 @@ final class ReflectionClass extends CoreReflectionClass
 
         $property = new ReflectionProperty($betterReflectionProperty);
 
-        if (! $property->isAccessible()) {
-            throw new CoreReflectionException(sprintf('Property "%s" is not accessible', $name));
-        }
-
         if (! $property->isStatic()) {
             throw new CoreReflectionException(sprintf('Property "%s" is not static', $name));
         }
@@ -423,10 +419,6 @@ final class ReflectionClass extends CoreReflectionClass
         }
 
         $property = new ReflectionProperty($betterReflectionProperty);
-
-        if (! $property->isAccessible()) {
-            throw new CoreReflectionException(sprintf('Property "%s" is not accessible', $name));
-        }
 
         if (! $property->isStatic()) {
             throw new CoreReflectionException(sprintf('Property "%s" is not static', $name));

--- a/src/Reflection/Adapter/ReflectionMethod.php
+++ b/src/Reflection/Adapter/ReflectionMethod.php
@@ -24,8 +24,6 @@ use function array_map;
 
 final class ReflectionMethod extends CoreReflectionMethod
 {
-    private bool $accessible = false;
-
     public function __construct(private BetterReflectionMethod $betterReflectionMethod)
     {
     }
@@ -235,10 +233,6 @@ final class ReflectionMethod extends CoreReflectionMethod
 
     public function invoke(?object $object = null, mixed ...$args): mixed
     {
-        if (! $this->isAccessible()) {
-            throw new CoreReflectionException('Method not accessible');
-        }
-
         try {
             return $this->betterReflectionMethod->invoke($object, ...$args);
         } catch (NoObjectProvided | TypeError) {
@@ -253,10 +247,6 @@ final class ReflectionMethod extends CoreReflectionMethod
      */
     public function invokeArgs(?object $object = null, array $args = []): mixed
     {
-        if (! $this->isAccessible()) {
-            throw new CoreReflectionException('Method not accessible');
-        }
-
         try {
             return $this->betterReflectionMethod->invokeArgs($object, $args);
         } catch (NoObjectProvided | TypeError) {
@@ -276,14 +266,12 @@ final class ReflectionMethod extends CoreReflectionMethod
         return new self($this->betterReflectionMethod->getPrototype());
     }
 
+    /**
+     * @codeCoverageIgnore
+     * @infection-ignore-all
+     */
     public function setAccessible(bool $accessible): void
     {
-        $this->accessible = true;
-    }
-
-    private function isAccessible(): bool
-    {
-        return $this->accessible || $this->isPublic();
     }
 
     /**

--- a/src/Reflection/Adapter/ReflectionObject.php
+++ b/src/Reflection/Adapter/ReflectionObject.php
@@ -346,10 +346,6 @@ final class ReflectionObject extends CoreReflectionObject
 
         $property = new ReflectionProperty($betterReflectionProperty);
 
-        if (! $property->isAccessible()) {
-            throw new CoreReflectionException(sprintf('Property "%s" is not accessible', $name));
-        }
-
         if (! $property->isStatic()) {
             throw new CoreReflectionException(sprintf('Property "%s" is not static', $name));
         }
@@ -366,10 +362,6 @@ final class ReflectionObject extends CoreReflectionObject
         }
 
         $property = new ReflectionProperty($betterReflectionProperty);
-
-        if (! $property->isAccessible()) {
-            throw new CoreReflectionException(sprintf('Property "%s" is not accessible', $name));
-        }
 
         if (! $property->isStatic()) {
             throw new CoreReflectionException(sprintf('Property "%s" is not static', $name));

--- a/src/Reflection/Adapter/ReflectionProperty.php
+++ b/src/Reflection/Adapter/ReflectionProperty.php
@@ -21,8 +21,6 @@ use function sprintf;
 
 final class ReflectionProperty extends CoreReflectionProperty
 {
-    private bool $accessible = false;
-
     public function __construct(private BetterReflectionProperty $betterReflectionProperty)
     {
     }
@@ -42,10 +40,6 @@ final class ReflectionProperty extends CoreReflectionProperty
      */
     public function getValue(?object $object = null): mixed
     {
-        if (! $this->isAccessible()) {
-            throw new CoreReflectionException('Property not accessible');
-        }
-
         try {
             return $this->betterReflectionProperty->getValue($object);
         } catch (NoObjectProvided | TypeError) {
@@ -60,10 +54,6 @@ final class ReflectionProperty extends CoreReflectionProperty
      */
     public function setValue(mixed $objectOrValue, mixed $value = null): void
     {
-        if (! $this->isAccessible()) {
-            throw new CoreReflectionException('Property not accessible');
-        }
-
         try {
             $this->betterReflectionProperty->setValue($objectOrValue, $value);
         } catch (NoObjectProvided) {
@@ -129,14 +119,21 @@ final class ReflectionProperty extends CoreReflectionProperty
         return $this->betterReflectionProperty->getDocComment() ?: false;
     }
 
+    /**
+     * @codeCoverageIgnore
+     * @infection-ignore-all
+     */
     public function setAccessible(bool $accessible): void
     {
-        $this->accessible = true;
     }
 
+    /**
+     * @codeCoverageIgnore
+     * @infection-ignore-all
+     */
     public function isAccessible(): bool
     {
-        return $this->accessible || $this->isPublic();
+        return true;
     }
 
     public function hasDefaultValue(): bool
@@ -151,10 +148,6 @@ final class ReflectionProperty extends CoreReflectionProperty
 
     public function isInitialized(?object $object = null): bool
     {
-        if (! $this->isAccessible()) {
-            throw new CoreReflectionException('Property not accessible');
-        }
-
         try {
             return $this->betterReflectionProperty->isInitialized($object);
         } catch (Throwable $e) {

--- a/test/unit/Reflection/Adapter/ReflectionClassTest.php
+++ b/test/unit/Reflection/Adapter/ReflectionClassTest.php
@@ -600,46 +600,6 @@ class ReflectionClassTest extends TestCase
         $reflectionClassAdapter->setStaticPropertyValue('foo', 123);
     }
 
-    public function testGetStaticPropertyValueThrowsExceptionWhenPropertyNotAccessible(): void
-    {
-        $betterReflectionProperty = $this->createMock(BetterReflectionProperty::class);
-        $betterReflectionProperty
-            ->method('isPublic')
-            ->willReturn(false);
-
-        $betterReflectionClass = $this->createMock(BetterReflectionClass::class);
-        $betterReflectionClass
-            ->method('getProperty')
-            ->with('foo')
-            ->willReturn($betterReflectionProperty);
-
-        $reflectionClassAdapter = new ReflectionClassAdapter($betterReflectionClass);
-
-        $this->expectException(CoreReflectionException::class);
-        $this->expectExceptionMessage('Property "foo" is not accessible');
-        $reflectionClassAdapter->getStaticPropertyValue('foo');
-    }
-
-    public function testSetStaticPropertyValueThrowsExceptionWhenPropertyNotAccessible(): void
-    {
-        $betterReflectionProperty = $this->createMock(BetterReflectionProperty::class);
-        $betterReflectionProperty
-            ->method('isPublic')
-            ->willReturn(false);
-
-        $betterReflectionClass = $this->createMock(BetterReflectionClass::class);
-        $betterReflectionClass
-            ->method('getProperty')
-            ->with('foo')
-            ->willReturn($betterReflectionProperty);
-
-        $reflectionClassAdapter = new ReflectionClassAdapter($betterReflectionClass);
-
-        $this->expectException(CoreReflectionException::class);
-        $this->expectExceptionMessage('Property "foo" is not accessible');
-        $reflectionClassAdapter->setStaticPropertyValue('foo', null);
-    }
-
     public function testGetStaticPropertyValueThrowsExceptionWhenPropertyDoesNotExist(): void
     {
         $betterReflectionClass = $this->createMock(BetterReflectionClass::class);

--- a/test/unit/Reflection/Adapter/ReflectionMethodTest.php
+++ b/test/unit/Reflection/Adapter/ReflectionMethodTest.php
@@ -361,48 +361,6 @@ class ReflectionMethodTest extends TestCase
         $reflectionMethodAdapter->invokeArgs(new stdClass(), []);
     }
 
-    public function testInvokeThrowsExceptionWhenPropertyNotAccessible(): void
-    {
-        $betterReflectionMethod = $this->createMock(BetterReflectionMethod::class);
-        $betterReflectionMethod
-            ->method('isPublic')
-            ->willReturn(false);
-
-        $reflectionMethodAdapter = new ReflectionMethodAdapter($betterReflectionMethod);
-
-        $this->expectException(CoreReflectionException::class);
-        $reflectionMethodAdapter->invoke();
-    }
-
-    public function testInvokeArgsThrowsExceptionWhenPropertyNotAccessible(): void
-    {
-        $betterReflectionMethod = $this->createMock(BetterReflectionMethod::class);
-        $betterReflectionMethod
-            ->method('isPublic')
-            ->willReturn(false);
-
-        $reflectionMethodAdapter = new ReflectionMethodAdapter($betterReflectionMethod);
-
-        $this->expectException(CoreReflectionException::class);
-        $reflectionMethodAdapter->invokeArgs();
-    }
-
-    public function testSetAccessibleAndInvoke(): void
-    {
-        $betterReflectionMethod = $this->createMock(BetterReflectionMethod::class);
-        $betterReflectionMethod
-            ->method('isPublic')
-            ->willReturn(false);
-        $betterReflectionMethod
-            ->method('invoke')
-            ->willReturn(123);
-
-        $reflectionMethodAdapter = new ReflectionMethodAdapter($betterReflectionMethod);
-        $reflectionMethodAdapter->setAccessible(true);
-
-        self::assertSame(123, $reflectionMethodAdapter->invoke());
-    }
-
     public function testGetAttributes(): void
     {
         $betterReflectionAttribute1 = $this->createMock(BetterReflectionAttribute::class);

--- a/test/unit/Reflection/Adapter/ReflectionObjectTest.php
+++ b/test/unit/Reflection/Adapter/ReflectionObjectTest.php
@@ -408,46 +408,6 @@ class ReflectionObjectTest extends TestCase
         $reflectionClassAdapter->setStaticPropertyValue('foo', 123);
     }
 
-    public function testGetStaticPropertyValueThrowsExceptionWhenPropertyNotAccessible(): void
-    {
-        $betterReflectionProperty = $this->createMock(BetterReflectionProperty::class);
-        $betterReflectionProperty
-            ->method('isPublic')
-            ->willReturn(false);
-
-        $betterReflectionObject = $this->createMock(BetterReflectionObject::class);
-        $betterReflectionObject
-            ->method('getProperty')
-            ->with('foo')
-            ->willReturn($betterReflectionProperty);
-
-        $reflectionObjectAdapter = new ReflectionObjectAdapter($betterReflectionObject);
-
-        $this->expectException(CoreReflectionException::class);
-        $this->expectExceptionMessage('Property "foo" is not accessible');
-        $reflectionObjectAdapter->getStaticPropertyValue('foo');
-    }
-
-    public function testSetStaticPropertyValueThrowsExceptionWhenPropertyNotAccessible(): void
-    {
-        $betterReflectionProperty = $this->createMock(BetterReflectionProperty::class);
-        $betterReflectionProperty
-            ->method('isPublic')
-            ->willReturn(false);
-
-        $betterReflectionObject = $this->createMock(BetterReflectionObject::class);
-        $betterReflectionObject
-            ->method('getProperty')
-            ->with('foo')
-            ->willReturn($betterReflectionProperty);
-
-        $reflectionObjectAdapter = new ReflectionObjectAdapter($betterReflectionObject);
-
-        $this->expectException(CoreReflectionException::class);
-        $this->expectExceptionMessage('Property "foo" is not accessible');
-        $reflectionObjectAdapter->setStaticPropertyValue('foo', null);
-    }
-
     public function testGetStaticPropertyValueThrowsExceptionWhenPropertyDoesNotExist(): void
     {
         $betterReflectionObject = $this->createMock(BetterReflectionObject::class);

--- a/test/unit/Reflection/Adapter/ReflectionPropertyTest.php
+++ b/test/unit/Reflection/Adapter/ReflectionPropertyTest.php
@@ -207,70 +207,6 @@ class ReflectionPropertyTest extends TestCase
         $reflectionPropertyAdapter->setValue('string');
     }
 
-    public function testGetValueThrowsExceptionWhenPropertyNotAccessible(): void
-    {
-        $betterReflectionProperty = $this->createMock(BetterReflectionProperty::class);
-        $betterReflectionProperty
-            ->method('isPublic')
-            ->willReturn(false);
-
-        $reflectionPropertyAdapter = new ReflectionPropertyAdapter($betterReflectionProperty);
-
-        $this->expectException(CoreReflectionException::class);
-        $reflectionPropertyAdapter->getValue(new stdClass());
-    }
-
-    public function testSetValueThrowsExceptionWhenPropertyNotAccessible(): void
-    {
-        $betterReflectionProperty = $this->createMock(BetterReflectionProperty::class);
-        $betterReflectionProperty
-            ->method('isPublic')
-            ->willReturn(false);
-
-        $reflectionPropertyAdapter = new ReflectionPropertyAdapter($betterReflectionProperty);
-
-        $this->expectException(CoreReflectionException::class);
-        $reflectionPropertyAdapter->setValue(new stdClass());
-    }
-
-    public function testSetAccessibleAndGetValue(): void
-    {
-        $betterReflectionProperty = $this->createMock(BetterReflectionProperty::class);
-        $betterReflectionProperty
-            ->method('isPublic')
-            ->willReturn(false);
-        $betterReflectionProperty
-            ->method('getValue')
-            ->willReturn(123);
-
-        $reflectionPropertyAdapter = new ReflectionPropertyAdapter($betterReflectionProperty);
-
-        $reflectionPropertyAdapter->setAccessible(true);
-
-        self::assertTrue($reflectionPropertyAdapter->isAccessible());
-        self::assertSame(123, $reflectionPropertyAdapter->getValue(new stdClass()));
-    }
-
-    public function testSetAccessibleAndSetValue(): void
-    {
-        $betterReflectionProperty = $this->createMock(BetterReflectionProperty::class);
-        $betterReflectionProperty
-            ->method('isPublic')
-            ->willReturn(false);
-        $betterReflectionProperty
-            ->expects($this->once())
-            ->method('setValue')
-            ->with(null, 123);
-
-        $reflectionPropertyAdapter = new ReflectionPropertyAdapter($betterReflectionProperty);
-
-        $reflectionPropertyAdapter->setAccessible(true);
-
-        self::assertTrue($reflectionPropertyAdapter->isAccessible());
-
-        $reflectionPropertyAdapter->setValue(null, 123);
-    }
-
     public function testGetValueThrowsExceptionWhenObjectNotInstanceOfClass(): void
     {
         $betterReflectionProperty = $this->createMock(BetterReflectionProperty::class);
@@ -301,38 +237,6 @@ class ReflectionPropertyTest extends TestCase
 
         $this->expectException(CoreReflectionException::class);
         $reflectionPropertyAdapter->setValue(new stdClass());
-    }
-
-    public function testIsInitializedThrowsExceptionWhenNotAccessible(): void
-    {
-        self::expectException(CoreReflectionException::class);
-
-        $betterReflectionProperty = $this->createMock(BetterReflectionProperty::class);
-        $betterReflectionProperty
-            ->method('isPublic')
-            ->willReturn(false);
-
-        $reflectionPropertyAdapter = new ReflectionPropertyAdapter($betterReflectionProperty);
-
-        $reflectionPropertyAdapter->isInitialized(new stdClass());
-    }
-
-    public function testIsInitializedWithSetAccessible(): void
-    {
-        $betterReflectionProperty = $this->createMock(BetterReflectionProperty::class);
-        $betterReflectionProperty
-            ->method('isPublic')
-            ->willReturn(false);
-        $betterReflectionProperty
-            ->method('isInitialized')
-            ->willReturn(true);
-
-        $reflectionPropertyAdapter = new ReflectionPropertyAdapter($betterReflectionProperty);
-
-        $reflectionPropertyAdapter->setAccessible(true);
-
-        self::assertTrue($reflectionPropertyAdapter->isAccessible());
-        self::assertTrue($reflectionPropertyAdapter->isInitialized(new stdClass()));
     }
 
     public function testIsInitializedThrowsExceptionWhenObjectNotInstanceOfClass(): void


### PR DESCRIPTION
Fixes https://github.com/Roave/BetterReflection/issues/1121