### PR TITLE
Added missing `true` type as `ReflectionNamedType#isBuiltIn()` value

### DIFF
--- a/src/Reflection/ReflectionNamedType.php
+++ b/src/Reflection/ReflectionNamedType.php
@@ -33,6 +33,7 @@ class ReflectionNamedType extends ReflectionType
         'null'     => null,
         'never'    => null,
         'false'    => null,
+        'true'    => null,
     ];
 
     private string $name;

--- a/test/unit/Reflection/ReflectionNamedTypeTest.php
+++ b/test/unit/Reflection/ReflectionNamedTypeTest.php
@@ -90,6 +90,8 @@ class ReflectionNamedTypeTest extends TestCase
         yield ['NEVER'];
         yield ['false'];
         yield ['FALSE'];
+        yield ['true'];
+        yield ['TRUE'];
     }
 
     /**


### PR DESCRIPTION
https://wiki.php.net/rfc/true-type

inspired by https://github.com/Roave/BetterReflection/commit/0f76eb13b72700f5f56099713bc6cf43f5a46973 I figured this might already be evertyhing required..?