### PR TITLE
PHP 8.2: Support for `readonly` classes

### DIFF
--- a/src/Reflection/Adapter/ReflectionClass.php
+++ b/src/Reflection/Adapter/ReflectionClass.php
@@ -308,6 +308,11 @@ final class ReflectionClass extends CoreReflectionClass
         return $this->betterReflectionClass->isFinal();
     }
 
+    public function isReadOnly(): bool
+    {
+        return $this->betterReflectionClass->isReadOnly();
+    }
+
     public function getModifiers(): int
     {
         return $this->betterReflectionClass->getModifiers();

--- a/src/Reflection/Adapter/ReflectionEnum.php
+++ b/src/Reflection/Adapter/ReflectionEnum.php
@@ -295,6 +295,11 @@ final class ReflectionEnum extends CoreReflectionEnum
         return $this->betterReflectionEnum->isFinal();
     }
 
+    public function isReadOnly(): bool
+    {
+        return $this->betterReflectionEnum->isReadOnly();
+    }
+
     public function getModifiers(): int
     {
         return $this->betterReflectionEnum->getModifiers();

--- a/src/Reflection/Adapter/ReflectionObject.php
+++ b/src/Reflection/Adapter/ReflectionObject.php
@@ -258,6 +258,11 @@ final class ReflectionObject extends CoreReflectionObject
         return $this->betterReflectionObject->isFinal();
     }
 
+    public function isReadOnly(): bool
+    {
+        return $this->betterReflectionObject->isReadOnly();
+    }
+
     public function getModifiers(): int
     {
         return $this->betterReflectionObject->getModifiers();

--- a/src/Reflection/ReflectionClass.php
+++ b/src/Reflection/ReflectionClass.php
@@ -62,6 +62,14 @@ use function strtolower;
 
 class ReflectionClass implements Reflection
 {
+    /**
+     * We cannot use CoreReflectionClass::IS_READONLY because it does not exist in PHP < 8.2.
+     * Constant is public, so we can use it in tests.
+     *
+     * @internal
+     */
+    public const IS_READONLY = 65536;
+
     public const ANONYMOUS_CLASS_NAME_PREFIX        = 'class@anonymous';
     public const ANONYMOUS_CLASS_NAME_PREFIX_REGEXP = '~^(?:class|[\w\\\\]+)@anonymous~';
     private const ANONYMOUS_CLASS_NAME_SUFFIX       = '@anonymous';
@@ -1055,6 +1063,11 @@ class ReflectionClass implements Reflection
         return $this->node instanceof ClassNode && $this->node->isFinal();
     }
 
+    public function isReadOnly(): bool
+    {
+        return $this->node instanceof ClassNode && $this->node->isReadonly();
+    }
+
     /**
      * Get the core-reflection-compatible modifier values.
      */
@@ -1062,6 +1075,7 @@ class ReflectionClass implements Reflection
     {
         $val  = $this->isAbstract() ? CoreReflectionClass::IS_EXPLICIT_ABSTRACT : 0;
         $val += $this->isFinal() ? CoreReflectionClass::IS_FINAL : 0;
+        $val += $this->isReadOnly() ? self::IS_READONLY : 0;
 
         return $val;
     }

--- a/src/Reflection/ReflectionObject.php
+++ b/src/Reflection/ReflectionObject.php
@@ -352,6 +352,11 @@ class ReflectionObject extends ReflectionClass
         return $this->reflectionClass->isFinal();
     }
 
+    public function isReadOnly(): bool
+    {
+        return $this->reflectionClass->isReadOnly();
+    }
+
     public function getModifiers(): int
     {
         return $this->reflectionClass->getModifiers();

--- a/test/unit/Fixture/ExampleClass.php
+++ b/test/unit/Fixture/ExampleClass.php
@@ -68,6 +68,10 @@ namespace Roave\BetterReflectionTest\Fixture {
     {
     }
 
+    readonly class ReadOnlyClass
+    {
+    }
+
     trait ExampleTrait
     {
     }

--- a/test/unit/Reflection/Adapter/ReflectionClassTest.php
+++ b/test/unit/Reflection/Adapter/ReflectionClassTest.php
@@ -98,6 +98,7 @@ class ReflectionClassTest extends TestCase
             ['isTrait', [], true, null, true, null],
             ['isAbstract', [], true, null, true, null],
             ['isFinal', [], true, null, true, null],
+            ['isReadOnly', [], true, null, true, null],
             ['getModifiers', [], 123, null, 123, null],
             ['isInstance', [new stdClass()], true, null, true, null],
             ['newInstance', [], null, NotImplemented::class, null, null],

--- a/test/unit/Reflection/Adapter/ReflectionEnumTest.php
+++ b/test/unit/Reflection/Adapter/ReflectionEnumTest.php
@@ -105,6 +105,7 @@ class ReflectionEnumTest extends TestCase
             ['isTrait', [], true, null, true, null],
             ['isAbstract', [], true, null, true, null],
             ['isFinal', [], true, null, true, null],
+            ['isReadOnly', [], true, null, true, null],
             ['getModifiers', [], 123, null, 123, null],
             ['isInstance', [new stdClass()], true, null, true, null],
             ['newInstance', [], null, NotImplemented::class, null, null],

--- a/test/unit/Reflection/Adapter/ReflectionObjectTest.php
+++ b/test/unit/Reflection/Adapter/ReflectionObjectTest.php
@@ -97,6 +97,7 @@ class ReflectionObjectTest extends TestCase
             ['isTrait', [], true, null, true, null],
             ['isAbstract', [], true, null, true, null],
             ['isFinal', [], true, null, true, null],
+            ['isReadOnly', [], true, null, true, null],
             ['getModifiers', [], 123, null, 123, null],
             ['isInstance', [new stdClass()], true, null, true, null],
             ['newInstance', [], null, NotImplemented::class, null, null],

--- a/test/unit/Reflector/DefaultReflectorTest.php
+++ b/test/unit/Reflector/DefaultReflectorTest.php
@@ -60,7 +60,7 @@ class DefaultReflectorTest extends TestCase
         ))->reflectAllClasses();
 
         self::assertContainsOnlyInstancesOf(ReflectionClass::class, $classes);
-        self::assertCount(10, $classes);
+        self::assertCount(11, $classes);
     }
 
     public function testReflectFunction(): void


### PR DESCRIPTION
It's easier to implement this first and then make green build on PHP 8.2.