### PR TITLE
Removed `ReflectionClass::getDeclaringNamespaceAst()` - we don't need to keep a reference to the namespace AST node

### DIFF
--- a/src/Reflection/ReflectionEnum.php
+++ b/src/Reflection/ReflectionEnum.php
@@ -9,7 +9,6 @@ use PhpParser\Node;
 use PhpParser\Node\Stmt\Class_ as ClassNode;
 use PhpParser\Node\Stmt\Enum_ as EnumNode;
 use PhpParser\Node\Stmt\Interface_ as InterfaceNode;
-use PhpParser\Node\Stmt\Namespace_ as NamespaceNode;
 use PhpParser\Node\Stmt\Trait_ as TraitNode;
 use Roave\BetterReflection\Reflector\Reflector;
 use Roave\BetterReflection\SourceLocator\Located\LocatedSource;
@@ -30,9 +29,9 @@ class ReflectionEnum extends ReflectionClass
         private Reflector $reflector,
         private EnumNode $node,
         LocatedSource $locatedSource,
-        NamespaceNode|null $declaringNamespace = null,
+        string|null $namespace = null,
     ) {
-        parent::__construct($reflector, $node, $locatedSource, $declaringNamespace);
+        parent::__construct($reflector, $node, $locatedSource, $namespace);
     }
 
     /**
@@ -46,7 +45,7 @@ class ReflectionEnum extends ReflectionClass
         Reflector $reflector,
         ClassNode|InterfaceNode|TraitNode|EnumNode $node,
         LocatedSource $locatedSource,
-        NamespaceNode|null $namespace = null,
+        string|null $namespace = null,
     ): self {
         return new self($reflector, $node, $locatedSource, $namespace);
     }

--- a/src/Reflection/ReflectionFunction.php
+++ b/src/Reflection/ReflectionFunction.php
@@ -6,7 +6,6 @@ namespace Roave\BetterReflection\Reflection;
 
 use Closure;
 use PhpParser\Node;
-use PhpParser\Node\Stmt\Namespace_ as NamespaceNode;
 use Roave\BetterReflection\BetterReflection;
 use Roave\BetterReflection\Reflection\Adapter\Exception\NotImplemented;
 use Roave\BetterReflection\Reflection\Exception\FunctionDoesNotExist;
@@ -33,7 +32,7 @@ class ReflectionFunction implements Reflection
         private Reflector $reflector,
         private Node\Stmt\ClassMethod|Node\Stmt\Function_|Node\Expr\Closure|Node\Expr\ArrowFunction $node,
         private LocatedSource $locatedSource,
-        private NamespaceNode|null $declaringNamespace = null,
+        private string|null $namespace = null,
     ) {
         assert($node instanceof Node\Stmt\Function_ || $node instanceof Node\Expr\Closure || $node instanceof Node\Expr\ArrowFunction);
 
@@ -67,9 +66,9 @@ class ReflectionFunction implements Reflection
         Reflector $reflector,
         Node\Stmt\Function_|Node\Expr\Closure|Node\Expr\ArrowFunction $node,
         LocatedSource $locatedSource,
-        NamespaceNode|null $namespaceNode = null,
+        string|null $namespace = null,
     ): self {
-        return new self($reflector, $node, $locatedSource, $namespaceNode);
+        return new self($reflector, $node, $locatedSource, $namespace);
     }
 
     public function getAst(): Node\Stmt\Function_|Node\Expr\Closure|Node\Expr\ArrowFunction

--- a/src/Reflection/ReflectionFunctionAbstract.php
+++ b/src/Reflection/ReflectionFunctionAbstract.php
@@ -51,7 +51,7 @@ trait ReflectionFunctionAbstract
      */
     public function getNamespaceName(): string
     {
-        return $this->declaringNamespace?->name?->toString() ?? '';
+        return $this->namespace ?? '';
     }
 
     /**
@@ -60,7 +60,7 @@ trait ReflectionFunctionAbstract
      */
     public function inNamespace(): bool
     {
-        return $this->declaringNamespace?->name !== null;
+        return $this->namespace !== null;
     }
 
     /**

--- a/src/Reflection/ReflectionMethod.php
+++ b/src/Reflection/ReflectionMethod.php
@@ -8,8 +8,6 @@ use Closure;
 use OutOfBoundsException;
 use PhpParser\Node;
 use PhpParser\Node\Stmt\ClassMethod as MethodNode;
-use PhpParser\Node\Stmt\Namespace_;
-use PhpParser\Node\Stmt\Namespace_ as NamespaceNode;
 use ReflectionException;
 use ReflectionMethod as CoreReflectionMethod;
 use Roave\BetterReflection\Reflection\Exception\ClassDoesNotExist;
@@ -35,7 +33,7 @@ class ReflectionMethod
         private Reflector $reflector,
         private MethodNode|Node\Stmt\Function_|Node\Expr\Closure|Node\Expr\ArrowFunction $node,
         private LocatedSource $locatedSource,
-        private NamespaceNode|null $declaringNamespace,
+        private string|null $namespace,
         private ReflectionClass $declaringClass,
         private ReflectionClass $implementingClass,
         private ReflectionClass $currentClass,
@@ -51,7 +49,7 @@ class ReflectionMethod
         Reflector $reflector,
         MethodNode $node,
         LocatedSource $locatedSource,
-        Namespace_|null $namespace,
+        string|null $namespace,
         ReflectionClass $declaringClass,
         ReflectionClass $implementingClass,
         ReflectionClass $currentClass,

--- a/src/Reflection/ReflectionObject.php
+++ b/src/Reflection/ReflectionObject.php
@@ -9,7 +9,6 @@ use PhpParser\Builder\Property as PropertyNodeBuilder;
 use PhpParser\Node\Stmt\Class_ as ClassNode;
 use PhpParser\Node\Stmt\Enum_ as EnumNode;
 use PhpParser\Node\Stmt\Interface_ as InterfaceNode;
-use PhpParser\Node\Stmt\Namespace_;
 use PhpParser\Node\Stmt\Property as PropertyNode;
 use PhpParser\Node\Stmt\Trait_ as TraitNode;
 use ReflectionException;
@@ -476,11 +475,6 @@ class ReflectionObject extends ReflectionClass
     public function getAst(): ClassNode|InterfaceNode|TraitNode|EnumNode
     {
         return $this->reflectionClass->getAst();
-    }
-
-    public function getDeclaringNamespaceAst(): Namespace_|null
-    {
-        return $this->reflectionClass->getDeclaringNamespaceAst();
     }
 
     /** @return list<ReflectionAttribute> */

--- a/src/SourceLocator/Ast/Strategy/NodeToReflection.php
+++ b/src/SourceLocator/Ast/Strategy/NodeToReflection.php
@@ -12,6 +12,8 @@ use Roave\BetterReflection\Reflection\ReflectionFunction;
 use Roave\BetterReflection\Reflector\Reflector;
 use Roave\BetterReflection\SourceLocator\Located\LocatedSource;
 
+use function implode;
+
 /** @internal */
 class NodeToReflection implements AstConversionStrategy
 {
@@ -26,12 +28,15 @@ class NodeToReflection implements AstConversionStrategy
         Node\Stmt\Namespace_|null $namespace,
         int|null $positionInNode = null,
     ): ReflectionClass|ReflectionConstant|ReflectionFunction {
+        /** @psalm-suppress PossiblyNullPropertyFetch, PossiblyNullArgument */
+        $namespaceName = $namespace?->name !== null ? implode('\\', $namespace->name->parts) : null;
+
         if ($node instanceof Node\Stmt\Enum_) {
             return ReflectionEnum::createFromNode(
                 $reflector,
                 $node,
                 $locatedSource,
-                $namespace,
+                $namespaceName,
             );
         }
 
@@ -40,7 +45,7 @@ class NodeToReflection implements AstConversionStrategy
                 $reflector,
                 $node,
                 $locatedSource,
-                $namespace,
+                $namespaceName,
             );
         }
 
@@ -53,12 +58,12 @@ class NodeToReflection implements AstConversionStrategy
                 $reflector,
                 $node,
                 $locatedSource,
-                $namespace,
+                $namespaceName,
             );
         }
 
         if ($node instanceof Node\Stmt\Const_) {
-            return ReflectionConstant::createFromNode($reflector, $node, $locatedSource, $namespace, $positionInNode);
+            return ReflectionConstant::createFromNode($reflector, $node, $locatedSource, $namespaceName, $positionInNode);
         }
 
         return ReflectionConstant::createFromNode($reflector, $node, $locatedSource);

--- a/test/unit/Reflection/ReflectionClassTest.php
+++ b/test/unit/Reflection/ReflectionClassTest.php
@@ -12,7 +12,6 @@ use Iterator;
 use OutOfBoundsException;
 use Php4StyleCaseInsensitiveConstruct;
 use Php4StyleConstruct;
-use PhpParser\Node;
 use PhpParser\Node\Stmt\Class_;
 use PHPUnit\Framework\TestCase;
 use Qux;
@@ -141,7 +140,6 @@ class ReflectionClassTest extends TestCase
         self::assertTrue($classInfo->inNamespace());
         self::assertSame(ExampleClass::class, $classInfo->getName());
         self::assertSame('Roave\BetterReflectionTest\Fixture', $classInfo->getNamespaceName());
-        self::assertInstanceOf(Node\Stmt\Namespace_::class, $classInfo->getDeclaringNamespaceAst());
         self::assertSame('ExampleClass', $classInfo->getShortName());
     }
 
@@ -155,7 +153,6 @@ class ReflectionClassTest extends TestCase
         self::assertFalse($classInfo->inNamespace());
         self::assertSame('ClassWithNoNamespace', $classInfo->getName());
         self::assertSame('', $classInfo->getNamespaceName());
-        self::assertNull($classInfo->getDeclaringNamespaceAst());
         self::assertSame('ClassWithNoNamespace', $classInfo->getShortName());
     }
 
@@ -169,7 +166,6 @@ class ReflectionClassTest extends TestCase
         self::assertFalse($classInfo->inNamespace());
         self::assertSame('ClassWithExplicitGlobalNamespace', $classInfo->getName());
         self::assertSame('', $classInfo->getNamespaceName());
-        self::assertInstanceOf(Node\Stmt\Namespace_::class, $classInfo->getDeclaringNamespaceAst());
         self::assertSame('ClassWithExplicitGlobalNamespace', $classInfo->getShortName());
     }
 

--- a/test/unit/Reflection/ReflectionObjectTest.php
+++ b/test/unit/Reflection/ReflectionObjectTest.php
@@ -286,7 +286,7 @@ class ReflectionObjectTest extends TestCase
         $mockReflectionClassNodeReflection->setAccessible(true);
         $mockReflectionClassNodeReflection->setValue($mockReflectionClass, $node);
 
-        $mockReflectionClassNodeReflection = $mockReflectionClassReflection->getProperty('declaringNamespace');
+        $mockReflectionClassNodeReflection = $mockReflectionClassReflection->getProperty('namespace');
         $mockReflectionClassNodeReflection->setAccessible(true);
         $mockReflectionClassNodeReflection->setValue($mockReflectionClass, null);
 


### PR DESCRIPTION
Part of https://github.com/Roave/BetterReflection/issues/1073