### PR TITLE
Removed `ReflectionParameter::getAst()` to prevent memory leaks

### DIFF
--- a/src/Reflection/Attribute/ReflectionAttributeHelper.php
+++ b/src/Reflection/Attribute/ReflectionAttributeHelper.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Roave\BetterReflection\Reflection\Attribute;
 
+use PhpParser\Node;
 use Roave\BetterReflection\Reflection\ReflectionAttribute;
 use Roave\BetterReflection\Reflection\ReflectionClass;
 use Roave\BetterReflection\Reflection\ReflectionClassConstant;
@@ -21,20 +22,25 @@ use function count;
 /** @internal */
 class ReflectionAttributeHelper
 {
-    /** @return list<ReflectionAttribute> */
+    /**
+     * @param Node\AttributeGroup[] $attrGroups
+     *
+     * @return list<ReflectionAttribute>
+     */
     public static function createAttributes(
         Reflector $reflector,
         ReflectionClass|ReflectionMethod|ReflectionFunction|ReflectionClassConstant|ReflectionEnumCase|ReflectionProperty|ReflectionParameter $reflection,
+        array $attrGroups,
     ) {
         $repeated = [];
-        foreach ($reflection->getAst()->attrGroups as $attributesGroupNode) {
+        foreach ($attrGroups as $attributesGroupNode) {
             foreach ($attributesGroupNode->attrs as $attributeNode) {
                 $repeated[$attributeNode->name->toLowerString()][] = $attributeNode;
             }
         }
 
         $attributes = [];
-        foreach ($reflection->getAst()->attrGroups as $attributesGroupNode) {
+        foreach ($attrGroups as $attributesGroupNode) {
             foreach ($attributesGroupNode->attrs as $attributeNode) {
                 $attributes[] = new ReflectionAttribute(
                     $reflector,

--- a/src/Reflection/ReflectionClass.php
+++ b/src/Reflection/ReflectionClass.php
@@ -1645,7 +1645,7 @@ class ReflectionClass implements Reflection
     /** @return list<ReflectionAttribute> */
     public function getAttributes(): array
     {
-        return ReflectionAttributeHelper::createAttributes($this->reflector, $this);
+        return ReflectionAttributeHelper::createAttributes($this->reflector, $this, $this->node->attrGroups);
     }
 
     /** @return list<ReflectionAttribute> */

--- a/src/Reflection/ReflectionClassConstant.php
+++ b/src/Reflection/ReflectionClassConstant.php
@@ -191,7 +191,7 @@ class ReflectionClassConstant
     /** @return list<ReflectionAttribute> */
     public function getAttributes(): array
     {
-        return ReflectionAttributeHelper::createAttributes($this->reflector, $this);
+        return ReflectionAttributeHelper::createAttributes($this->reflector, $this, $this->node->attrGroups);
     }
 
     /** @return list<ReflectionAttribute> */

--- a/src/Reflection/ReflectionEnumCase.php
+++ b/src/Reflection/ReflectionEnumCase.php
@@ -118,7 +118,7 @@ class ReflectionEnumCase
     /** @return list<ReflectionAttribute> */
     public function getAttributes(): array
     {
-        return ReflectionAttributeHelper::createAttributes($this->reflector, $this);
+        return ReflectionAttributeHelper::createAttributes($this->reflector, $this, $this->node->attrGroups);
     }
 
     /** @return list<ReflectionAttribute> */

--- a/src/Reflection/ReflectionFunctionAbstract.php
+++ b/src/Reflection/ReflectionFunctionAbstract.php
@@ -391,7 +391,7 @@ trait ReflectionFunctionAbstract
          * @psalm-var ReflectionMethod|ReflectionFunction $this
          * @phpstan-ignore-next-line
          */
-        return ReflectionAttributeHelper::createAttributes($this->reflector, $this);
+        return ReflectionAttributeHelper::createAttributes($this->reflector, $this, $this->node->attrGroups);
     }
 
     /** @return list<ReflectionAttribute> */

--- a/src/Reflection/ReflectionParameter.php
+++ b/src/Reflection/ReflectionParameter.php
@@ -424,7 +424,7 @@ class ReflectionParameter
     /** @return list<ReflectionAttribute> */
     public function getAttributes(): array
     {
-        return ReflectionAttributeHelper::createAttributes($this->reflector, $this);
+        return ReflectionAttributeHelper::createAttributes($this->reflector, $this, $this->node->attrGroups);
     }
 
     /** @return list<ReflectionAttribute> */

--- a/src/Reflection/ReflectionProperty.php
+++ b/src/Reflection/ReflectionProperty.php
@@ -304,7 +304,7 @@ class ReflectionProperty
     /** @return list<ReflectionAttribute> */
     public function getAttributes(): array
     {
-        return ReflectionAttributeHelper::createAttributes($this->reflector, $this);
+        return ReflectionAttributeHelper::createAttributes($this->reflector, $this, $this->node->attrGroups);
     }
 
     /** @return list<ReflectionAttribute> */

--- a/test/unit/Reflection/Attribute/ReflectionAttributeHelperTest.php
+++ b/test/unit/Reflection/Attribute/ReflectionAttributeHelperTest.php
@@ -26,13 +26,10 @@ class ReflectionAttributeHelperTest extends TestCase
         ];
 
         $reflection = $this->createMock(ReflectionClass::class);
-        $reflection
-            ->method('getAst')
-            ->willReturn($ast);
-
         $attributes = ReflectionAttributeHelper::createAttributes(
             $this->createMock(Reflector::class),
             $reflection,
+            $ast->attrGroups,
         );
 
         self::assertCount(3, $attributes);


### PR DESCRIPTION
Part of https://github.com/Roave/BetterReflection/issues/1073

Not sure about the solution of `getStartColumn()` and `getEndColumn()`. We need it because it's not possible to get columns for magically added methods:

https://github.com/Roave/BetterReflection/blob/5a6ccc032eab2aec577f1abde8d9de1a86bee518/src/Reflection/ReflectionClass.php#L513-L523