### PR TITLE
`Reflection*::getNamespaceName()` returns null when no namespace - namespace as empty string is implemented only in adapters

### DIFF
--- a/src/NodeCompiler/CompileNodeToValue.php
+++ b/src/NodeCompiler/CompileNodeToValue.php
@@ -79,7 +79,7 @@ class CompileNodeToValue
             }
 
             if ($node instanceof Node\Scalar\MagicConst\Namespace_) {
-                return $context->getNamespace();
+                return $context->getNamespace() ?? '';
             }
 
             if ($node instanceof Node\Scalar\MagicConst\Method) {
@@ -170,7 +170,7 @@ class CompileNodeToValue
     private function resolveConstantName(Node\Expr\ConstFetch $constNode, CompilerContext $context): string
     {
         $constantName = $constNode->name->toString();
-        $namespace    = $context->getNamespace();
+        $namespace    = $context->getNamespace() ?? '';
 
         if ($constNode->name->isUnqualified()) {
             $namespacedConstantName = sprintf('%s\\%s', $namespace, $constantName);

--- a/src/NodeCompiler/CompilerContext.php
+++ b/src/NodeCompiler/CompilerContext.php
@@ -38,14 +38,14 @@ class CompilerContext
         return $this->getClass()?->getFileName() ?? $this->getFunction()?->getFileName();
     }
 
-    public function getNamespace(): string
+    public function getNamespace(): string|null
     {
         if ($this->contextReflection instanceof ReflectionConstant) {
             return $this->contextReflection->getNamespaceName();
         }
 
         // @infection-ignore-all Coalesce: There's no difference
-        return $this->getClass()?->getNamespaceName() ?? $this->getFunction()?->getNamespaceName() ?? '';
+        return $this->getClass()?->getNamespaceName() ?? $this->getFunction()?->getNamespaceName();
     }
 
     public function getClass(): ReflectionClass|null

--- a/src/NodeCompiler/Exception/UnableToCompileNode.php
+++ b/src/NodeCompiler/Exception/UnableToCompileNode.php
@@ -137,7 +137,7 @@ class UnableToCompileNode extends LogicException
         }
 
         $namespace = $fetchContext->getNamespace();
-        if ($namespace !== '') {
+        if ($namespace !== null) {
             return sprintf('namespace %s', $namespace);
         }
 

--- a/src/Reflection/Adapter/ReflectionClass.php
+++ b/src/Reflection/Adapter/ReflectionClass.php
@@ -460,7 +460,7 @@ final class ReflectionClass extends CoreReflectionClass
 
     public function getNamespaceName(): string
     {
-        return $this->betterReflectionClass->getNamespaceName();
+        return $this->betterReflectionClass->getNamespaceName() ?? '';
     }
 
     public function getShortName(): string

--- a/src/Reflection/Adapter/ReflectionEnum.php
+++ b/src/Reflection/Adapter/ReflectionEnum.php
@@ -413,7 +413,7 @@ final class ReflectionEnum extends CoreReflectionEnum
 
     public function getNamespaceName(): string
     {
-        return $this->betterReflectionEnum->getNamespaceName();
+        return $this->betterReflectionEnum->getNamespaceName() ?? '';
     }
 
     public function getShortName(): string

--- a/src/Reflection/Adapter/ReflectionFunction.php
+++ b/src/Reflection/Adapter/ReflectionFunction.php
@@ -115,7 +115,7 @@ final class ReflectionFunction extends CoreReflectionFunction
 
     public function getNamespaceName(): string
     {
-        return $this->betterReflectionFunction->getNamespaceName();
+        return $this->betterReflectionFunction->getNamespaceName() ?? '';
     }
 
     public function getNumberOfParameters(): int

--- a/src/Reflection/Adapter/ReflectionMethod.php
+++ b/src/Reflection/Adapter/ReflectionMethod.php
@@ -118,7 +118,7 @@ final class ReflectionMethod extends CoreReflectionMethod
 
     public function getNamespaceName(): string
     {
-        return $this->betterReflectionMethod->getNamespaceName();
+        return $this->betterReflectionMethod->getNamespaceName() ?? '';
     }
 
     public function getNumberOfParameters(): int

--- a/src/Reflection/Adapter/ReflectionObject.php
+++ b/src/Reflection/Adapter/ReflectionObject.php
@@ -410,7 +410,7 @@ final class ReflectionObject extends CoreReflectionObject
 
     public function getNamespaceName(): string
     {
-        return $this->betterReflectionObject->getNamespaceName();
+        return $this->betterReflectionObject->getNamespaceName() ?? '';
     }
 
     public function getShortName(): string

--- a/src/Reflection/ReflectionClass.php
+++ b/src/Reflection/ReflectionClass.php
@@ -208,9 +208,9 @@ class ReflectionClass implements Reflection
      * Get the "namespace" name of the class (e.g. for A\B\Foo, this will
      * return "A\B").
      */
-    public function getNamespaceName(): string
+    public function getNamespaceName(): string|null
     {
-        return $this->namespace ?? '';
+        return $this->namespace;
     }
 
     /**

--- a/src/Reflection/ReflectionConstant.php
+++ b/src/Reflection/ReflectionConstant.php
@@ -173,9 +173,9 @@ class ReflectionConstant implements Reflection
      * Get the "namespace" name of the constant (e.g. for A\B\FOO, this will
      * return "A\B").
      */
-    public function getNamespaceName(): string
+    public function getNamespaceName(): string|null
     {
-        return $this->namespace ?? '';
+        return $this->namespace;
     }
 
     /**

--- a/src/Reflection/ReflectionFunctionAbstract.php
+++ b/src/Reflection/ReflectionFunctionAbstract.php
@@ -38,20 +38,22 @@ trait ReflectionFunctionAbstract
      */
     public function getName(): string
     {
-        if (! $this->inNamespace()) {
+        $namespace = $this->getNamespaceName();
+
+        if ($namespace === null) {
             return $this->getShortName();
         }
 
-        return $this->getNamespaceName() . '\\' . $this->getShortName();
+        return $namespace . '\\' . $this->getShortName();
     }
 
     /**
      * Get the "namespace" name of the function (e.g. for A\B\foo, this will
      * return "A\B").
      */
-    public function getNamespaceName(): string
+    public function getNamespaceName(): string|null
     {
-        return $this->namespace ?? '';
+        return $this->namespace;
     }
 
     /**

--- a/src/Reflection/ReflectionMethod.php
+++ b/src/Reflection/ReflectionMethod.php
@@ -193,9 +193,9 @@ class ReflectionMethod
         return false;
     }
 
-    public function getNamespaceName(): string
+    public function getNamespaceName(): string|null
     {
-        return '';
+        return null;
     }
 
     public function isClosure(): bool

--- a/src/Reflection/ReflectionObject.php
+++ b/src/Reflection/ReflectionObject.php
@@ -129,7 +129,7 @@ class ReflectionObject extends ReflectionClass
         return $this->reflectionClass->getName();
     }
 
-    public function getNamespaceName(): string
+    public function getNamespaceName(): string|null
     {
         return $this->reflectionClass->getNamespaceName();
     }

--- a/test/unit/NodeCompiler/CompilerContextTest.php
+++ b/test/unit/NodeCompiler/CompilerContextTest.php
@@ -244,6 +244,6 @@ PHP;
 
         $context = new CompilerContext($reflector, $constant);
 
-        self::assertSame('', $context->getNamespace());
+        self::assertNull($context->getNamespace());
     }
 }

--- a/test/unit/Reflection/ReflectionClassTest.php
+++ b/test/unit/Reflection/ReflectionClassTest.php
@@ -152,7 +152,7 @@ class ReflectionClassTest extends TestCase
 
         self::assertFalse($classInfo->inNamespace());
         self::assertSame('ClassWithNoNamespace', $classInfo->getName());
-        self::assertSame('', $classInfo->getNamespaceName());
+        self::assertNull($classInfo->getNamespaceName());
         self::assertSame('ClassWithNoNamespace', $classInfo->getShortName());
     }
 
@@ -165,7 +165,7 @@ class ReflectionClassTest extends TestCase
 
         self::assertFalse($classInfo->inNamespace());
         self::assertSame('ClassWithExplicitGlobalNamespace', $classInfo->getName());
-        self::assertSame('', $classInfo->getNamespaceName());
+        self::assertNull($classInfo->getNamespaceName());
         self::assertSame('ClassWithExplicitGlobalNamespace', $classInfo->getShortName());
     }
 

--- a/test/unit/Reflection/ReflectionConstantTest.php
+++ b/test/unit/Reflection/ReflectionConstantTest.php
@@ -49,7 +49,7 @@ class ReflectionConstantTest extends TestCase
 
         self::assertFalse($reflection->inNamespace());
         self::assertSame('FOO', $reflection->getName());
-        self::assertSame('', $reflection->getNamespaceName());
+        self::assertNull($reflection->getNamespaceName());
         self::assertSame('FOO', $reflection->getShortName());
     }
 
@@ -62,7 +62,7 @@ class ReflectionConstantTest extends TestCase
 
         self::assertFalse($reflection->inNamespace());
         self::assertSame('FOO', $reflection->getName());
-        self::assertSame('', $reflection->getNamespaceName());
+        self::assertNull($reflection->getNamespaceName());
         self::assertSame('FOO', $reflection->getShortName());
     }
 
@@ -101,7 +101,7 @@ class ReflectionConstantTest extends TestCase
 
         self::assertFalse($reflection->inNamespace());
         self::assertSame('FOO', $reflection->getName());
-        self::assertSame('', $reflection->getNamespaceName());
+        self::assertNull($reflection->getNamespaceName());
         self::assertSame('FOO', $reflection->getShortName());
     }
 

--- a/test/unit/Reflection/ReflectionFunctionAbstractTest.php
+++ b/test/unit/Reflection/ReflectionFunctionAbstractTest.php
@@ -72,7 +72,7 @@ class ReflectionFunctionAbstractTest extends TestCase
 
         self::assertSame('foo', $functionInfo->getName());
         self::assertFalse($functionInfo->inNamespace());
-        self::assertSame('', $functionInfo->getNamespaceName());
+        self::assertNull($functionInfo->getNamespaceName());
         self::assertSame('foo', $functionInfo->getShortName());
     }
 
@@ -85,7 +85,7 @@ class ReflectionFunctionAbstractTest extends TestCase
 
         self::assertSame('foo', $functionInfo->getName());
         self::assertFalse($functionInfo->inNamespace());
-        self::assertSame('', $functionInfo->getNamespaceName());
+        self::assertNull($functionInfo->getNamespaceName());
         self::assertSame('foo', $functionInfo->getShortName());
     }
 

--- a/test/unit/Reflection/ReflectionFunctionTest.php
+++ b/test/unit/Reflection/ReflectionFunctionTest.php
@@ -45,7 +45,7 @@ class ReflectionFunctionTest extends TestCase
 
         self::assertFalse($function->inNamespace());
         self::assertSame('foo', $function->getName());
-        self::assertSame('', $function->getNamespaceName());
+        self::assertNull($function->getNamespaceName());
         self::assertSame('foo', $function->getShortName());
     }
 
@@ -71,7 +71,7 @@ class ReflectionFunctionTest extends TestCase
 
         self::assertFalse($function->inNamespace());
         self::assertSame('foo', $function->getName());
-        self::assertSame('', $function->getNamespaceName());
+        self::assertNull($function->getNamespaceName());
         self::assertSame('foo', $function->getShortName());
     }
 

--- a/test/unit/Reflection/ReflectionMethodTest.php
+++ b/test/unit/Reflection/ReflectionMethodTest.php
@@ -239,7 +239,7 @@ class ReflectionMethodTest extends TestCase
 
         self::assertFalse($methodInfo->inNamespace());
         self::assertSame('someMethod', $methodInfo->getName());
-        self::assertSame('', $methodInfo->getNamespaceName());
+        self::assertNull($methodInfo->getNamespaceName());
         self::assertSame('someMethod', $methodInfo->getShortName());
     }
 
@@ -251,7 +251,7 @@ class ReflectionMethodTest extends TestCase
 
         self::assertFalse($methodInfo->inNamespace());
         self::assertSame('b_renamed', $methodInfo->getName());
-        self::assertSame('', $methodInfo->getNamespaceName());
+        self::assertNull($methodInfo->getNamespaceName());
         self::assertSame('b_renamed', $methodInfo->getShortName());
     }
 

--- a/test/unit/SourceLocator/SourceStubber/PhpStormStubsSourceStubberTest.php
+++ b/test/unit/SourceLocator/SourceStubber/PhpStormStubsSourceStubberTest.php
@@ -371,7 +371,7 @@ class PhpStormStubsSourceStubberTest extends TestCase
         self::assertSame($constantName, $constantReflection->getName());
         self::assertSame($constantName, $constantReflection->getShortName());
 
-        self::assertNotNull($constantReflection->getNamespaceName());
+        self::assertNull($constantReflection->getNamespaceName());
         self::assertFalse($constantReflection->inNamespace());
         self::assertTrue($constantReflection->isInternal());
         self::assertFalse($constantReflection->isUserDefined());

--- a/test/unit/SourceLocator/SourceStubber/ReflectionSourceStubberTest.php
+++ b/test/unit/SourceLocator/SourceStubber/ReflectionSourceStubberTest.php
@@ -534,7 +534,7 @@ class ReflectionSourceStubberTest extends TestCase
         self::assertSame($constantName, $constantReflection->getName());
         self::assertSame($constantName, $constantReflection->getShortName());
 
-        self::assertNotNull($constantReflection->getNamespaceName());
+        self::assertNull($constantReflection->getNamespaceName());
         self::assertFalse($constantReflection->inNamespace());
         self::assertTrue($constantReflection->isInternal());
         self::assertFalse($constantReflection->isUserDefined());

--- a/test/unit/SourceLocator/Type/ClosureSourceLocatorTest.php
+++ b/test/unit/SourceLocator/Type/ClosureSourceLocatorTest.php
@@ -39,7 +39,7 @@ class ClosureSourceLocatorTest extends TestCase
         $this->reflector = $this->createMock(Reflector::class);
     }
 
-    /** @return list<array{0: Closure, 1: string, 2: string, 3: int, 4: int}> */
+    /** @return list<array{0: Closure, 1: string|null, 2: string, 3: int, 4: int}> */
     public function closuresProvider(): array
     {
         $fileWithClosureInNamespace       = FileHelper::normalizeWindowsPath(realpath(__DIR__ . '/../../Fixture/ClosureInNamespace.php'));
@@ -49,14 +49,14 @@ class ClosureSourceLocatorTest extends TestCase
 
         return [
             [require $fileWithClosureInNamespace, 'Roave\BetterReflectionTest\Fixture', $fileWithClosureInNamespace, 5, 8],
-            [require $fileWithClosureNoNamespace, '', $fileWithClosureNoNamespace, 3, 6],
+            [require $fileWithClosureNoNamespace, null, $fileWithClosureNoNamespace, 3, 6],
             [require $fileWithArrowFunctionInNamespace, 'Roave\BetterReflectionTest\Fixture', $fileWithArrowFunctionInNamespace, 5, 5],
-            [require $fileWithArrowFunctionNoNamespace, '', $fileWithArrowFunctionNoNamespace, 3, 3],
+            [require $fileWithArrowFunctionNoNamespace, null, $fileWithArrowFunctionNoNamespace, 3, 3],
         ];
     }
 
     /** @dataProvider closuresProvider */
-    public function testLocateIdentifier(Closure $closure, string $namespace, string $file, int $startLine, int $endLine): void
+    public function testLocateIdentifier(Closure $closure, string|null $namespace, string $file, int $startLine, int $endLine): void
     {
         $locator = new ClosureSourceLocator($closure, $this->parser);
 
@@ -97,7 +97,7 @@ class ClosureSourceLocatorTest extends TestCase
     }
 
     /** @dataProvider closuresProvider */
-    public function testLocateIdentifiersByType(Closure $closure, string $namespace, string $file, int $startLine, int $endLine): void
+    public function testLocateIdentifiersByType(Closure $closure, string|null $namespace, string $file, int $startLine, int $endLine): void
     {
         /** @var list<ReflectionFunction> $reflections */
         $reflections = (new ClosureSourceLocator($closure, $this->parser))->locateIdentifiersByType(


### PR DESCRIPTION
I think the compatibility can be only in adapters.