### PR TITLE
`ReflectionClass::getConstant()`, `getConstants()` and `getImmediateConstants()` more consistent with methods and properties methods

### DIFF
--- a/src/NodeCompiler/CompileNodeToValue.php
+++ b/src/NodeCompiler/CompileNodeToValue.php
@@ -240,7 +240,7 @@ class CompileNodeToValue
         $classContext    = $context->getClass();
         $classReflection = $classContext !== null && $classContext->getName() === $className ? $classContext : $context->getReflector()->reflectClass($className);
 
-        $reflectionConstant = $classReflection->getReflectionConstant($constantName);
+        $reflectionConstant = $classReflection->getConstant($constantName);
 
         if (! $reflectionConstant instanceof ReflectionClassConstant) {
             throw Exception\UnableToCompileNode::becauseOfNotFoundClassConstantReference($context, $classReflection, $node);

--- a/src/Reflection/Adapter/ReflectionClass.php
+++ b/src/Reflection/Adapter/ReflectionClass.php
@@ -205,7 +205,7 @@ final class ReflectionClass extends CoreReflectionClass
             }
         }
 
-        $betterReflectionConstant = $this->betterReflectionClass->getReflectionConstant($name);
+        $betterReflectionConstant = $this->betterReflectionClass->getConstant($name);
         if ($betterReflectionConstant === null) {
             return false;
         }
@@ -225,11 +225,11 @@ final class ReflectionClass extends CoreReflectionClass
     /** @return array<string, BetterReflectionClassConstant|BetterReflectionEnumCase> */
     private function filterBetterReflectionClassConstants(int|null $filter): array
     {
-        $reflectionConstants = $this->betterReflectionClass->getReflectionConstants();
+        $reflectionConstants = $this->betterReflectionClass->getConstants();
 
         if ($filter !== null) {
             $reflectionConstants = array_filter(
-                $this->betterReflectionClass->getReflectionConstants(),
+                $this->betterReflectionClass->getConstants(),
                 static fn (BetterReflectionClassConstant $betterConstant): bool => (bool) ($betterConstant->getModifiers() & $filter),
             );
         }

--- a/src/Reflection/Adapter/ReflectionClass.php
+++ b/src/Reflection/Adapter/ReflectionClass.php
@@ -20,7 +20,6 @@ use Roave\BetterReflection\Util\FileHelper;
 use ValueError;
 
 use function array_combine;
-use function array_filter;
 use function array_map;
 use function array_values;
 use function constant;
@@ -225,14 +224,7 @@ final class ReflectionClass extends CoreReflectionClass
     /** @return array<string, BetterReflectionClassConstant|BetterReflectionEnumCase> */
     private function filterBetterReflectionClassConstants(int|null $filter): array
     {
-        $reflectionConstants = $this->betterReflectionClass->getConstants();
-
-        if ($filter !== null) {
-            $reflectionConstants = array_filter(
-                $this->betterReflectionClass->getConstants(),
-                static fn (BetterReflectionClassConstant $betterConstant): bool => (bool) ($betterConstant->getModifiers() & $filter),
-            );
-        }
+        $reflectionConstants = $this->betterReflectionClass->getConstants($filter);
 
         if (
             $this->betterReflectionClass instanceof BetterReflectionEnum

--- a/src/Reflection/Adapter/ReflectionEnum.php
+++ b/src/Reflection/Adapter/ReflectionEnum.php
@@ -192,7 +192,8 @@ final class ReflectionEnum extends CoreReflectionEnum
 
     public function getReflectionConstant(string $name): ReflectionClassConstant|false
     {
-        $betterReflectionConstantOrEnumCase = $this->betterReflectionEnum->getCase($name) ?? $this->betterReflectionEnum->getReflectionConstant($name);
+        // @infection-ignore-all Coalesce: There's no difference
+        $betterReflectionConstantOrEnumCase = $this->betterReflectionEnum->getCase($name) ?? $this->betterReflectionEnum->getConstant($name);
         if ($betterReflectionConstantOrEnumCase === null) {
             return false;
         }
@@ -212,11 +213,11 @@ final class ReflectionEnum extends CoreReflectionEnum
     /** @return array<string, BetterReflectionClassConstant|BetterReflectionEnumCase> */
     private function filterBetterReflectionClassConstants(int|null $filter): array
     {
-        $reflectionConstants = $this->betterReflectionEnum->getReflectionConstants();
+        $reflectionConstants = $this->betterReflectionEnum->getConstants();
 
         if ($filter !== null) {
             $reflectionConstants = array_filter(
-                $this->betterReflectionEnum->getReflectionConstants(),
+                $this->betterReflectionEnum->getConstants(),
                 static fn (BetterReflectionClassConstant $betterConstant): bool => (bool) ($betterConstant->getModifiers() & $filter),
             );
         }

--- a/src/Reflection/Adapter/ReflectionObject.php
+++ b/src/Reflection/Adapter/ReflectionObject.php
@@ -159,7 +159,7 @@ final class ReflectionObject extends CoreReflectionObject
     /** @return array<string, mixed> */
     public function getConstants(int|null $filter = null): array
     {
-        $reflectionConstants = $this->betterReflectionObject->getReflectionConstants();
+        $reflectionConstants = $this->betterReflectionObject->getConstants();
 
         if ($filter !== null) {
             $reflectionConstants = array_filter(
@@ -181,7 +181,7 @@ final class ReflectionObject extends CoreReflectionObject
 
     public function getReflectionConstant(string $name): ReflectionClassConstant|false
     {
-        $betterReflectionConstant = $this->betterReflectionObject->getReflectionConstant($name);
+        $betterReflectionConstant = $this->betterReflectionObject->getConstant($name);
 
         if ($betterReflectionConstant === null) {
             return false;
@@ -195,7 +195,7 @@ final class ReflectionObject extends CoreReflectionObject
     {
         return array_values(array_map(
             static fn (BetterReflectionClassConstant $betterConstant): ReflectionClassConstant => new ReflectionClassConstant($betterConstant),
-            $this->betterReflectionObject->getReflectionConstants(),
+            $this->betterReflectionObject->getConstants(),
         ));
     }
 

--- a/src/Reflection/ReflectionClass.php
+++ b/src/Reflection/ReflectionClass.php
@@ -637,9 +637,16 @@ class ReflectionClass implements Reflection
      *
      * @return array<string, ReflectionClassConstant> indexed by name
      */
-    public function getImmediateConstants(): array
+    public function getImmediateConstants(int|null $filter = null): array
     {
-        return $this->immediateConstants;
+        if ($filter === null) {
+            return $this->immediateConstants;
+        }
+
+        return array_filter(
+            $this->immediateConstants,
+            static fn (ReflectionClassConstant $constant): bool => (bool) ($filter & $constant->getModifiers()),
+        );
     }
 
     /**
@@ -683,7 +690,7 @@ class ReflectionClass implements Reflection
      *
      * @return array<string, ReflectionClassConstant> indexed by name
      */
-    public function getConstants(): array
+    public function getConstants(int|null $filter = null): array
     {
         // Note: constants are not merged via their name as array index, since internal PHP constant
         //       sorting does not follow `\array_merge()` semantics
@@ -725,7 +732,14 @@ class ReflectionClass implements Reflection
             $reflectionConstants[$constantName] = $constant;
         }
 
-        return $reflectionConstants;
+        if ($filter === null) {
+            return $reflectionConstants;
+        }
+
+        return array_filter(
+            $reflectionConstants,
+            static fn (ReflectionClassConstant $constant): bool => (bool) ($filter & $constant->getModifiers()),
+        );
     }
 
     /**

--- a/src/Reflection/ReflectionClass.php
+++ b/src/Reflection/ReflectionClass.php
@@ -633,45 +633,13 @@ class ReflectionClass implements Reflection
 
     /**
      * Get an associative array of only the constants for this specific class (i.e. do not search
-     * up parent classes etc.), with keys as constant names and values as constant values.
+     * up parent classes etc.), with keys as constant names and values as {@see ReflectionClassConstant} objects.
      *
-     * @return array<string, mixed>
+     * @return array<string, ReflectionClassConstant> indexed by name
      */
     public function getImmediateConstants(): array
     {
-        return array_map(static fn (ReflectionClassConstant $classConstant): mixed => $classConstant->getValue(), $this->getImmediateReflectionConstants());
-    }
-
-    /**
-     * Get an associative array of the defined constants in this class,
-     * with keys as constant names and values as constant values.
-     *
-     * @return array<string, mixed>
-     */
-    public function getConstants(): array
-    {
-        return array_map(static fn (ReflectionClassConstant $classConstant): mixed => $classConstant->getValue(), $this->getReflectionConstants());
-    }
-
-    /**
-     * Get the value of the specified class constant.
-     *
-     * Returns null if not specified.
-     *
-     * @return scalar|array<scalar>|null
-     */
-    public function getConstant(string $name): string|int|float|bool|array|null
-    {
-        $reflectionConstant = $this->getReflectionConstant($name);
-
-        if ($reflectionConstant === null) {
-            return null;
-        }
-
-        /** @psalm-var scalar|array<scalar>|null $constantValue */
-        $constantValue = $reflectionConstant->getValue();
-
-        return $constantValue;
+        return $this->immediateConstants;
     }
 
     /**
@@ -679,7 +647,7 @@ class ReflectionClass implements Reflection
      */
     public function hasConstant(string $name): bool
     {
-        return $this->getReflectionConstant($name) !== null;
+        return $this->getConstant($name) !== null;
     }
 
     /**
@@ -687,20 +655,9 @@ class ReflectionClass implements Reflection
      *
      * Returns null if not specified.
      */
-    public function getReflectionConstant(string $name): ReflectionClassConstant|null
+    public function getConstant(string $name): ReflectionClassConstant|null
     {
-        return $this->getReflectionConstants()[$name] ?? null;
-    }
-
-    /**
-     * Get an associative array of only the constants for this specific class (i.e. do not search
-     * up parent classes etc.), with keys as constant names and values as {@see ReflectionClassConstant} objects.
-     *
-     * @return array<string, ReflectionClassConstant> indexed by name
-     */
-    public function getImmediateReflectionConstants(): array
-    {
-        return $this->immediateConstants;
+        return $this->getConstants()[$name] ?? null;
     }
 
     /** @return array<string, ReflectionClassConstant> */
@@ -726,16 +683,16 @@ class ReflectionClass implements Reflection
      *
      * @return array<string, ReflectionClassConstant> indexed by name
      */
-    public function getReflectionConstants(): array
+    public function getConstants(): array
     {
         // Note: constants are not merged via their name as array index, since internal PHP constant
         //       sorting does not follow `\array_merge()` semantics
         $allReflectionConstants = array_merge(
-            array_values($this->getImmediateReflectionConstants()),
+            array_values($this->getImmediateConstants()),
             ...array_map(
                 static function (ReflectionClass $ancestor): array {
                     return array_values(array_filter(
-                        $ancestor->getReflectionConstants(),
+                        $ancestor->getConstants(),
                         static fn (ReflectionClassConstant $classConstant): bool => ! $classConstant->isPrivate(),
                     ));
                 },
@@ -745,13 +702,13 @@ class ReflectionClass implements Reflection
                 function (ReflectionClass $trait) {
                     return array_map(
                         fn (ReflectionClassConstant $classConstant): ReflectionClassConstant => $classConstant->withImplementingClass($this),
-                        $trait->getReflectionConstants(),
+                        $trait->getConstants(),
                     );
                 },
                 $this->getTraits(),
             ),
             ...array_map(
-                static fn (ReflectionClass $interface): array => array_values($interface->getReflectionConstants()),
+                static fn (ReflectionClass $interface): array => array_values($interface->getConstants()),
                 array_values($this->getInterfaces()),
             ),
         );

--- a/src/Reflection/ReflectionObject.php
+++ b/src/Reflection/ReflectionObject.php
@@ -182,35 +182,14 @@ class ReflectionObject extends ReflectionClass
         return $this->reflectionClass->getConstants();
     }
 
-    public function getConstant(string $name): string|int|float|bool|array|null
-    {
-        return $this->reflectionClass->getConstant($name);
-    }
-
     public function hasConstant(string $name): bool
     {
         return $this->reflectionClass->hasConstant($name);
     }
 
-    public function getReflectionConstant(string $name): ReflectionClassConstant|null
+    public function getConstant(string $name): ReflectionClassConstant|null
     {
-        return $this->reflectionClass->getReflectionConstant($name);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getImmediateReflectionConstants(): array
-    {
-        return $this->reflectionClass->getImmediateReflectionConstants();
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getReflectionConstants(): array
-    {
-        return $this->reflectionClass->getReflectionConstants();
+        return $this->reflectionClass->getConstant($name);
     }
 
     public function getConstructor(): ReflectionMethod

--- a/src/Reflection/ReflectionObject.php
+++ b/src/Reflection/ReflectionObject.php
@@ -169,17 +169,17 @@ class ReflectionObject extends ReflectionClass
     /**
      * {@inheritdoc}
      */
-    public function getImmediateConstants(): array
+    public function getImmediateConstants(int|null $filter = null): array
     {
-        return $this->reflectionClass->getImmediateConstants();
+        return $this->reflectionClass->getImmediateConstants($filter);
     }
 
     /**
      * {@inheritdoc}
      */
-    public function getConstants(): array
+    public function getConstants(int|null $filter = null): array
     {
-        return $this->reflectionClass->getConstants();
+        return $this->reflectionClass->getConstants($filter);
     }
 
     public function hasConstant(string $name): bool

--- a/src/Reflection/StringCast/ReflectionClassStringCast.php
+++ b/src/Reflection/StringCast/ReflectionClassStringCast.php
@@ -43,7 +43,7 @@ final class ReflectionClassStringCast
 
         $type = self::typeToString($classReflection);
 
-        $constants         = $classReflection->getReflectionConstants();
+        $constants         = $classReflection->getConstants();
         $enumCases         = $classReflection instanceof ReflectionEnum ? $classReflection->getCases() : [];
         $staticProperties  = self::getStaticProperties($classReflection);
         $staticMethods     = self::getStaticMethods($classReflection);

--- a/test/unit/NodeCompiler/CompileNodeToValueTest.php
+++ b/test/unit/NodeCompiler/CompileNodeToValueTest.php
@@ -418,11 +418,11 @@ PHP;
         $reflector = new DefaultReflector(new StringSourceLocator($phpCode, $this->astLocator));
         $classInfo = $reflector->reflectClass('Bar\Foo');
 
-        self::assertSame(1, $classInfo->getReflectionConstant('SECOND')->getValue());
-        self::assertSame(60, $classInfo->getReflectionConstant('MINUTE')->getValue());
-        self::assertSame(3600, $classInfo->getReflectionConstant('HOUR')->getValue());
-        self::assertSame(86400, $classInfo->getReflectionConstant('DAY')->getValue());
-        self::assertSame(604800, $classInfo->getReflectionConstant('WEEK')->getValue());
+        self::assertSame(1, $classInfo->getConstant('SECOND')->getValue());
+        self::assertSame(60, $classInfo->getConstant('MINUTE')->getValue());
+        self::assertSame(3600, $classInfo->getConstant('HOUR')->getValue());
+        self::assertSame(86400, $classInfo->getConstant('DAY')->getValue());
+        self::assertSame(604800, $classInfo->getConstant('WEEK')->getValue());
     }
 
     public function testClassConstantResolutionExternalForMethod(): void
@@ -475,7 +475,7 @@ PHP;
 
         $reflector = new DefaultReflector(new StringSourceLocator($phpCode, $this->astLocator));
         $classInfo = $reflector->reflectClass('Bat');
-        self::assertSame('Foo', $classInfo->getConstant('QUX'));
+        self::assertSame('Foo', $classInfo->getConstant('QUX')?->getValue());
     }
 
     public function testClassConstantClassNameNamespaceResolution(): void
@@ -492,7 +492,7 @@ PHP;
 
         $reflector = new DefaultReflector(new StringSourceLocator($phpCode, $this->astLocator));
         $classInfo = $reflector->reflectClass('Bar\Bat');
-        self::assertSame('Bar\Foo', $classInfo->getConstant('QUX'));
+        self::assertSame('Bar\Foo', $classInfo->getConstant('QUX')?->getValue());
     }
 
     public function testClassConstantClassNameOutOfScopeResolution(): void
@@ -509,7 +509,7 @@ PHP;
 
         $reflector = new DefaultReflector(new StringSourceLocator($phpCode, $this->astLocator));
         $classInfo = $reflector->reflectClass('Bar\Bat');
-        self::assertSame('My\Awesome\Foo', $classInfo->getConstant('QUX'));
+        self::assertSame('My\Awesome\Foo', $classInfo->getConstant('QUX')?->getValue());
     }
 
     public function testClassConstantClassNameAliasedResolution(): void
@@ -526,7 +526,7 @@ PHP;
 
         $reflector = new DefaultReflector(new StringSourceLocator($phpCode, $this->astLocator));
         $classInfo = $reflector->reflectClass('Bar\Bat');
-        self::assertSame('My\Awesome\Foo', $classInfo->getConstant('QUX'));
+        self::assertSame('My\Awesome\Foo', $classInfo->getConstant('QUX')?->getValue());
     }
 
     public function testClassConstantResolutionFromParent(): void
@@ -669,7 +669,7 @@ PHP;
             new PhpInternalSourceLocator($this->astLocator, $this->sourceStubber),
         ]));
         $classInfo = $reflector->reflectClass('Bat');
-        self::assertSame($expectedPropertyValue, $classInfo->getConstant('ONE_VALUE'));
+        self::assertSame($expectedPropertyValue, $classInfo->getConstant('ONE_VALUE')?->getValue());
     }
 
     public function testEnumPropertyValueThrowsExceptionWhenNoEnum(): void
@@ -689,7 +689,7 @@ PHP;
         $classInfo = $reflector->reflectClass('Bat');
 
         self::expectException(UnableToCompileNode::class);
-        $classInfo->getConstant('ONE_VALUE');
+        $classInfo->getConstant('ONE_VALUE')->getValue();
     }
 
     public function testEnumPropertyValueThrowsExceptionWhenCaseDoesNotExist(): void
@@ -712,7 +712,7 @@ PHP;
         $classInfo = $reflector->reflectClass('Bat');
 
         self::expectException(UnableToCompileNode::class);
-        $classInfo->getConstant('TWO_VALUE');
+        $classInfo->getConstant('TWO_VALUE')->getValue();
     }
 
     public function testEnumPropertyValueThrowsExceptionWhenPropertyDoesNotExist(): void
@@ -735,7 +735,7 @@ PHP;
         $classInfo = $reflector->reflectClass('Bat');
 
         self::expectException(UnableToCompileNode::class);
-        $classInfo->getConstant('ONE_VALUE');
+        $classInfo->getConstant('ONE_VALUE')->getValue();
     }
 
     /** @return list<array{0: string, 1: mixed}> */

--- a/test/unit/NodeCompiler/CompilerContextTest.php
+++ b/test/unit/NodeCompiler/CompilerContextTest.php
@@ -92,7 +92,7 @@ PHP;
 
         $reflector     = new DefaultReflector(new StringSourceLocator($phpCode, $this->astLocator));
         $class         = $reflector->reflectClass('Foo\Boo');
-        $classConstant = $class->getReflectionConstant('BAZ');
+        $classConstant = $class->getConstant('BAZ');
 
         $context = new CompilerContext($reflector, $classConstant);
 

--- a/test/unit/Reflection/Adapter/ReflectionClassTest.php
+++ b/test/unit/Reflection/Adapter/ReflectionClassTest.php
@@ -86,9 +86,6 @@ class ReflectionClassTest extends TestCase
             ['getProperty', ['foo'], $mockProperty, null, null, ReflectionPropertyAdapter::class],
             ['getProperties', [], [$mockProperty], null, null, ReflectionPropertyAdapter::class],
             ['hasConstant', ['foo'], true, null, true, null],
-            ['getConstant', ['foo'], 'a', null, 'a', null],
-            ['getReflectionConstant', ['foo'], $mockConstant, null, null, ReflectionClassConstantAdapter::class],
-            ['getReflectionConstants', [], [$mockConstant], null, null, ReflectionClassConstantAdapter::class],
             ['getInterfaces', [], [$mockClassLike], null, null, ReflectionClassAdapter::class],
             ['getInterfaceNames', [], ['a', 'b'], null, ['a', 'b'], null],
             ['isInterface', [], true, null, true, null],
@@ -296,7 +293,7 @@ class ReflectionClassTest extends TestCase
             ->willReturn('protected constant');
 
         $betterReflectionClass
-            ->method('getReflectionConstants')
+            ->method('getConstants')
             ->willReturn([
                 $publicBetterReflectionClassConstant->getName() => $publicBetterReflectionClassConstant,
                 $privateBetterReflectionClassConstant->getName() => $privateBetterReflectionClassConstant,
@@ -367,7 +364,7 @@ class ReflectionClassTest extends TestCase
             ->willReturn('protected constant');
 
         $betterReflectionClass
-            ->method('getReflectionConstants')
+            ->method('getConstants')
             ->willReturn([
                 $publicBetterReflectionClassConstant->getName() => $publicBetterReflectionClassConstant,
                 $privateBetterReflectionClassConstant->getName() => $privateBetterReflectionClassConstant,
@@ -718,11 +715,24 @@ class ReflectionClassTest extends TestCase
         self::assertNull($reflectionClassAdapter->getConstructor());
     }
 
+    public function testGetReflectionConstant(): void
+    {
+        $betterReflectionClass = $this->createMock(BetterReflectionClass::class);
+        $betterReflectionClass
+            ->method('getConstant')
+            ->with('FOO')
+            ->willReturn($this->createMock(BetterReflectionClassConstant::class));
+
+        $reflectionClassAdapter = new ReflectionClassAdapter($betterReflectionClass);
+
+        self::assertInstanceOf(ReflectionClassConstantAdapter::class, $reflectionClassAdapter->getReflectionConstant('FOO'));
+    }
+
     public function testGetReflectionConstantReturnsFalseWhenConstantDoesNotExist(): void
     {
         $betterReflectionClass = $this->createMock(BetterReflectionClass::class);
         $betterReflectionClass
-            ->method('getReflectionConstant')
+            ->method('getConstant')
             ->with('FOO')
             ->willReturn(null);
 
@@ -1012,7 +1022,7 @@ class ReflectionClassTest extends TestCase
             ->willReturn(['enum_case' => $betterReflectionEnumCase]);
 
         $betterReflectionEnum
-            ->method('getReflectionConstants')
+            ->method('getConstants')
             ->willReturn([
                 'public' => $publicBetterReflectionClassConstant,
                 'private' => $privateBetterReflectionClassConstant,

--- a/test/unit/Reflection/Adapter/ReflectionClassTest.php
+++ b/test/unit/Reflection/Adapter/ReflectionClassTest.php
@@ -257,10 +257,6 @@ class ReflectionClassTest extends TestCase
         $protectedBetterReflectionClassConstant = $this->createMock(BetterReflectionClassConstant::class);
 
         $publicBetterReflectionClassConstant
-            ->method('getModifiers')
-            ->willReturn(CoreReflectionProperty::IS_PUBLIC);
-
-        $publicBetterReflectionClassConstant
             ->method('getName')
             ->willReturn('PUBLIC_CONSTANT');
 
@@ -269,20 +265,12 @@ class ReflectionClassTest extends TestCase
             ->willReturn('public constant');
 
         $privateBetterReflectionClassConstant
-            ->method('getModifiers')
-            ->willReturn(CoreReflectionProperty::IS_PRIVATE);
-
-        $privateBetterReflectionClassConstant
             ->method('getName')
             ->willReturn('PRIVATE_CONSTANT');
 
         $privateBetterReflectionClassConstant
             ->method('getValue')
             ->willReturn('private constant');
-
-        $protectedBetterReflectionClassConstant
-            ->method('getModifiers')
-            ->willReturn(CoreReflectionProperty::IS_PROTECTED);
 
         $protectedBetterReflectionClassConstant
             ->method('getName')
@@ -294,11 +282,16 @@ class ReflectionClassTest extends TestCase
 
         $betterReflectionClass
             ->method('getConstants')
-            ->willReturn([
-                $publicBetterReflectionClassConstant->getName() => $publicBetterReflectionClassConstant,
-                $privateBetterReflectionClassConstant->getName() => $privateBetterReflectionClassConstant,
-                $protectedBetterReflectionClassConstant->getName() => $protectedBetterReflectionClassConstant,
-            ]);
+            ->willReturnOnConsecutiveCalls(
+                [
+                    $publicBetterReflectionClassConstant->getName() => $publicBetterReflectionClassConstant,
+                    $privateBetterReflectionClassConstant->getName() => $privateBetterReflectionClassConstant,
+                    $protectedBetterReflectionClassConstant->getName() => $protectedBetterReflectionClassConstant,
+                ],
+                [$publicBetterReflectionClassConstant->getName() => $publicBetterReflectionClassConstant],
+                [$privateBetterReflectionClassConstant->getName() => $privateBetterReflectionClassConstant],
+                [$protectedBetterReflectionClassConstant->getName() => $protectedBetterReflectionClassConstant],
+            );
 
         $reflectionClassAdapter = new ReflectionClassAdapter($betterReflectionClass);
 
@@ -328,10 +321,6 @@ class ReflectionClassTest extends TestCase
         $protectedBetterReflectionClassConstant = $this->createMock(BetterReflectionClassConstant::class);
 
         $publicBetterReflectionClassConstant
-            ->method('getModifiers')
-            ->willReturn(CoreReflectionProperty::IS_PUBLIC);
-
-        $publicBetterReflectionClassConstant
             ->method('getName')
             ->willReturn('PUBLIC_CONSTANT');
 
@@ -340,20 +329,12 @@ class ReflectionClassTest extends TestCase
             ->willReturn('public constant');
 
         $privateBetterReflectionClassConstant
-            ->method('getModifiers')
-            ->willReturn(CoreReflectionProperty::IS_PRIVATE);
-
-        $privateBetterReflectionClassConstant
             ->method('getName')
             ->willReturn('PRIVATE_CONSTANT');
 
         $privateBetterReflectionClassConstant
             ->method('getValue')
             ->willReturn('private constant');
-
-        $protectedBetterReflectionClassConstant
-            ->method('getModifiers')
-            ->willReturn(CoreReflectionProperty::IS_PROTECTED);
 
         $protectedBetterReflectionClassConstant
             ->method('getName')
@@ -365,11 +346,16 @@ class ReflectionClassTest extends TestCase
 
         $betterReflectionClass
             ->method('getConstants')
-            ->willReturn([
-                $publicBetterReflectionClassConstant->getName() => $publicBetterReflectionClassConstant,
-                $privateBetterReflectionClassConstant->getName() => $privateBetterReflectionClassConstant,
-                $protectedBetterReflectionClassConstant->getName() => $protectedBetterReflectionClassConstant,
-            ]);
+            ->willReturnOnConsecutiveCalls(
+                [
+                    $publicBetterReflectionClassConstant->getName() => $publicBetterReflectionClassConstant,
+                    $privateBetterReflectionClassConstant->getName() => $privateBetterReflectionClassConstant,
+                    $protectedBetterReflectionClassConstant->getName() => $protectedBetterReflectionClassConstant,
+                ],
+                [$publicBetterReflectionClassConstant->getName() => $publicBetterReflectionClassConstant],
+                [$privateBetterReflectionClassConstant->getName() => $privateBetterReflectionClassConstant],
+                [$protectedBetterReflectionClassConstant->getName() => $protectedBetterReflectionClassConstant],
+            );
 
         $reflectionClassAdapter = new ReflectionClassAdapter($betterReflectionClass);
 
@@ -1006,16 +992,16 @@ class ReflectionClassTest extends TestCase
         $protectedBetterReflectionClassConstant = $this->createMock(BetterReflectionClassConstant::class);
 
         $publicBetterReflectionClassConstant
-            ->method('getModifiers')
-            ->willReturn(CoreReflectionProperty::IS_PUBLIC);
+            ->method('getName')
+            ->willReturn('PUBLIC_CONSTANT');
 
         $privateBetterReflectionClassConstant
-            ->method('getModifiers')
-            ->willReturn(CoreReflectionProperty::IS_PRIVATE);
+            ->method('getName')
+            ->willReturn('PRIVATE_CONSTANT');
 
         $protectedBetterReflectionClassConstant
-            ->method('getModifiers')
-            ->willReturn(CoreReflectionProperty::IS_PROTECTED);
+            ->method('getName')
+            ->willReturn('PROTECTED_CONSTANT');
 
         $betterReflectionEnum
             ->method('getCases')
@@ -1023,11 +1009,16 @@ class ReflectionClassTest extends TestCase
 
         $betterReflectionEnum
             ->method('getConstants')
-            ->willReturn([
-                'public' => $publicBetterReflectionClassConstant,
-                'private' => $privateBetterReflectionClassConstant,
-                'protected' => $protectedBetterReflectionClassConstant,
-            ]);
+            ->willReturnOnConsecutiveCalls(
+                [
+                    $publicBetterReflectionClassConstant->getName() => $publicBetterReflectionClassConstant,
+                    $privateBetterReflectionClassConstant->getName() => $privateBetterReflectionClassConstant,
+                    $protectedBetterReflectionClassConstant->getName() => $protectedBetterReflectionClassConstant,
+                ],
+                [$publicBetterReflectionClassConstant->getName() => $publicBetterReflectionClassConstant],
+                [$privateBetterReflectionClassConstant->getName() => $privateBetterReflectionClassConstant],
+                [$protectedBetterReflectionClassConstant->getName() => $protectedBetterReflectionClassConstant],
+            );
 
         $reflectionClassAdapter = new ReflectionClassAdapter($betterReflectionEnum);
 

--- a/test/unit/Reflection/Adapter/ReflectionEnumTest.php
+++ b/test/unit/Reflection/Adapter/ReflectionEnumTest.php
@@ -93,9 +93,6 @@ class ReflectionEnumTest extends TestCase
             ['getProperty', ['foo'], $mockProperty, null, null, ReflectionPropertyAdapter::class],
             ['getProperties', [], [$mockProperty], null, null, ReflectionPropertyAdapter::class],
             ['hasConstant', ['foo'], true, null, true, null],
-            ['getConstant', ['foo'], 'a', null, 'a', null],
-            ['getReflectionConstant', ['foo'], $mockConstant, null, null, ReflectionClassConstantAdapter::class],
-            ['getReflectionConstants', [], [$mockConstant], null, null, ReflectionClassConstantAdapter::class],
             ['getInterfaces', [], [$mockClassLike], null, null, ReflectionClassAdapter::class],
             ['getInterfaceNames', [], ['a', 'b'], null, ['a', 'b'], null],
             ['isInterface', [], true, null, true, null],
@@ -307,7 +304,7 @@ class ReflectionEnumTest extends TestCase
             ->willReturn('protected constant');
 
         $betterReflectionEnum
-            ->method('getReflectionConstants')
+            ->method('getConstants')
             ->willReturn([
                 $publicBetterReflectionClassConstant->getName() => $publicBetterReflectionClassConstant,
                 $privateBetterReflectionClassConstant->getName() => $privateBetterReflectionClassConstant,
@@ -333,11 +330,24 @@ class ReflectionEnumTest extends TestCase
         self::assertEquals([$protectedBetterReflectionClassConstant->getName() => $protectedBetterReflectionClassConstant->getValue()], $protectedConstants);
     }
 
+    public function testGetReflectionConstant(): void
+    {
+        $betterReflectionEnum = $this->createMock(BetterReflectionEnum::class);
+        $betterReflectionEnum
+            ->method('getConstant')
+            ->with('FOO')
+            ->willReturn($this->createMock(BetterReflectionClassConstant::class));
+
+        $reflectionEnumAdapter = new ReflectionEnumAdapter($betterReflectionEnum);
+
+        self::assertInstanceOf(ReflectionClassConstantAdapter::class, $reflectionEnumAdapter->getReflectionConstant('FOO'));
+    }
+
     public function testGetReflectionConstantReturnsFalseWhenConstantDoesNotExist(): void
     {
         $betterReflectionEnum = $this->createMock(BetterReflectionEnum::class);
         $betterReflectionEnum
-            ->method('getReflectionConstant')
+            ->method('getConstant')
             ->with('FOO')
             ->willReturn(null);
 
@@ -756,7 +766,7 @@ class ReflectionEnumTest extends TestCase
             ->willReturn(['enum_case' => $betterReflectionEnumCase]);
 
         $betterReflectionEnum
-            ->method('getReflectionConstants')
+            ->method('getConstants')
             ->willReturn([
                 'public' => $publicBetterReflectionClassConstant,
                 'private' => $privateBetterReflectionClassConstant,

--- a/test/unit/Reflection/Adapter/ReflectionObjectTest.php
+++ b/test/unit/Reflection/Adapter/ReflectionObjectTest.php
@@ -85,9 +85,6 @@ class ReflectionObjectTest extends TestCase
             ['getProperty', ['foo'], $mockProperty, null, null, ReflectionPropertyAdapter::class],
             ['getProperties', [], [$mockProperty], null, null, ReflectionPropertyAdapter::class],
             ['hasConstant', ['foo'], true, null, true, null],
-            ['getConstant', ['foo'], 'a', null, 'a', null],
-            ['getReflectionConstant', ['foo'], $mockConstant, null, null, ReflectionClassConstantAdapter::class],
-            ['getReflectionConstants', [], [$mockConstant], null, null, ReflectionClassConstantAdapter::class],
             ['getInterfaces', [], [$mockClassLike], null, null, ReflectionClassAdapter::class],
             ['getInterfaceNames', [], ['a', 'b'], null, ['a', 'b'], null],
             ['isInterface', [], true, null, true, null],
@@ -556,7 +553,7 @@ class ReflectionObjectTest extends TestCase
             ->willReturn('protected constant');
 
         $betterReflectionObject
-            ->method('getReflectionConstants')
+            ->method('getConstants')
             ->willReturn([
                 $publicBetterReflectionClassConstant->getName() => $publicBetterReflectionClassConstant,
                 $privateBetterReflectionClassConstant->getName() => $privateBetterReflectionClassConstant,
@@ -582,13 +579,28 @@ class ReflectionObjectTest extends TestCase
         self::assertEquals([$protectedBetterReflectionClassConstant->getName() => $protectedBetterReflectionClassConstant->getValue()], $protectedConstants);
     }
 
+    public function testGetReflectionConstant(): void
+    {
+        $betterReflectionObject = $this->createMock(BetterReflectionObject::class);
+
+        $betterReflectionObject
+            ->expects($this->once())
+            ->method('getConstant')
+            ->with('FOO')
+            ->willReturn($this->createMock(BetterReflectionClassConstant::class));
+
+        $reflectionObjectAdapter = new ReflectionObjectAdapter($betterReflectionObject);
+
+        self::assertInstanceOf(ReflectionClassConstantAdapter::class, $reflectionObjectAdapter->getReflectionConstant('FOO'));
+    }
+
     public function testGetReflectionConstantReturnsFalseWhenConstantDoesNotExist(): void
     {
         $betterReflectionObject = $this->createMock(BetterReflectionObject::class);
 
         $betterReflectionObject
             ->expects($this->once())
-            ->method('getReflectionConstant')
+            ->method('getConstant')
             ->with('NON_EXISTENT_CONSTANT')
             ->willReturn(null);
 
@@ -604,7 +616,7 @@ class ReflectionObjectTest extends TestCase
 
         $betterReflectionObject
             ->expects($this->once())
-            ->method('getReflectionConstant')
+            ->method('getConstant')
             ->with('SOME_CONSTANT')
             ->willReturn($betterReflectionClassConstant);
 
@@ -613,14 +625,14 @@ class ReflectionObjectTest extends TestCase
         self::assertInstanceOf(ReflectionClassConstantAdapter::class, $reflectionObjectAdapter->getReflectionConstant('SOME_CONSTANT'));
     }
 
-    public function testGetReflectionConstantsReturnsClassConstantAdapter(): void
+    public function testGetConstantsReturnsClassConstantAdapter(): void
     {
         $betterReflectionObject        = $this->createMock(BetterReflectionObject::class);
         $betterReflectionClassConstant = $this->createMock(BetterReflectionClassConstant::class);
 
         $betterReflectionObject
             ->expects($this->once())
-            ->method('getReflectionConstants')
+            ->method('getConstants')
             ->willReturn([$betterReflectionClassConstant]);
 
         $reflectionObjectAdapter = new ReflectionObjectAdapter($betterReflectionObject);

--- a/test/unit/Reflection/ReflectionAttributeTest.php
+++ b/test/unit/Reflection/ReflectionAttributeTest.php
@@ -133,7 +133,7 @@ class ReflectionAttributeTest extends TestCase
     public function testGetTargetWithClassConstant(): void
     {
         $classReflection    = $this->reflector->reflectClass(ClassWithAttributes::class);
-        $constantReflection = $classReflection->getReflectionConstant('CONSTANT_WITH_ATTRIBUTES');
+        $constantReflection = $classReflection->getConstant('CONSTANT_WITH_ATTRIBUTES');
         $attributes         = $constantReflection->getAttributes();
 
         self::assertNotEmpty($attributes);

--- a/test/unit/Reflection/ReflectionClassConstantTest.php
+++ b/test/unit/Reflection/ReflectionClassConstantTest.php
@@ -50,7 +50,7 @@ class ReflectionClassConstantTest extends TestCase
         $reflector = new DefaultReflector($this->getComposerLocator());
         $classInfo = $reflector->reflectClass(ExampleClass::class);
 
-        return $classInfo->getReflectionConstant($name);
+        return $classInfo->getConstant($name);
     }
 
     public function testDefaultVisibility(): void
@@ -143,7 +143,7 @@ class ReflectionClassConstantTest extends TestCase
     {
         $reflector = new DefaultReflector($this->getComposerLocator());
         $classInfo = $reflector->reflectClass(ExampleClass::class);
-        $const     = $classInfo->getReflectionConstant('MY_CONST_1');
+        $const     = $classInfo->getConstant('MY_CONST_1');
         self::assertSame($classInfo, $const->getDeclaringClass());
     }
 
@@ -156,7 +156,7 @@ class ReflectionClassConstantTest extends TestCase
     {
         $reflector       = new DefaultReflector(new StringSourceLocator($php, $this->astLocator));
         $classReflection = $reflector->reflectClass('\T');
-        $constReflection = $classReflection->getReflectionConstant('TEST');
+        $constReflection = $classReflection->getConstant('TEST');
         self::assertEquals($startLine, $constReflection->getStartLine());
         self::assertEquals($endLine, $constReflection->getEndLine());
     }
@@ -191,7 +191,7 @@ class ReflectionClassConstantTest extends TestCase
     {
         $reflector          = new DefaultReflector(new StringSourceLocator($php, $this->astLocator));
         $classReflection    = $reflector->reflectClass('T');
-        $constantReflection = $classReflection->getReflectionConstant('TEST');
+        $constantReflection = $classReflection->getConstant('TEST');
 
         self::assertEquals($startColumn, $constantReflection->getStartColumn());
         self::assertEquals($endColumn, $constantReflection->getEndColumn());
@@ -215,7 +215,7 @@ class ReflectionClassConstantTest extends TestCase
     {
         $reflector          = new DefaultReflector(new SingleFileSourceLocator(__DIR__ . '/../Fixture/ClassesWithConstants.php', $this->astLocator));
         $classReflection    = $reflector->reflectClass($currentClassName);
-        $constantReflection = $classReflection->getReflectionConstant($constantName);
+        $constantReflection = $classReflection->getConstant($constantName);
 
         self::assertSame($declaringClassName, $constantReflection->getDeclaringClass()->getName());
         self::assertSame($implementingClassName, $constantReflection->getImplementingClass()->getName());
@@ -255,7 +255,7 @@ class ReflectionClassConstantTest extends TestCase
 
         $reflector          = new DefaultReflector(new StringSourceLocator($php, BetterReflectionSingleton::instance()->astLocator()));
         $classReflection    = $reflector->reflectClass('Foo');
-        $constantReflection = $classReflection->getReflectionConstant('FOO');
+        $constantReflection = $classReflection->getConstant('FOO');
 
         self::assertSame($isDeprecated, $constantReflection->isDeprecated());
     }
@@ -264,7 +264,7 @@ class ReflectionClassConstantTest extends TestCase
     {
         $reflector          = new DefaultReflector(new SingleFileSourceLocator(__DIR__ . '/../Fixture/ExampleClass.php', $this->astLocator));
         $classReflection    = $reflector->reflectClass(ExampleClass::class);
-        $constantReflection = $classReflection->getReflectionConstant('MY_CONST_1');
+        $constantReflection = $classReflection->getConstant('MY_CONST_1');
         $attributes         = $constantReflection->getAttributes();
 
         self::assertCount(0, $attributes);
@@ -274,7 +274,7 @@ class ReflectionClassConstantTest extends TestCase
     {
         $reflector          = new DefaultReflector(new SingleFileSourceLocator(__DIR__ . '/../Fixture/Attributes.php', $this->astLocator));
         $classReflection    = $reflector->reflectClass(ClassWithAttributes::class);
-        $constantReflection = $classReflection->getReflectionConstant('CONSTANT_WITH_ATTRIBUTES');
+        $constantReflection = $classReflection->getConstant('CONSTANT_WITH_ATTRIBUTES');
         $attributes         = $constantReflection->getAttributes();
 
         self::assertCount(2, $attributes);
@@ -284,7 +284,7 @@ class ReflectionClassConstantTest extends TestCase
     {
         $reflector          = new DefaultReflector(new SingleFileSourceLocator(__DIR__ . '/../Fixture/Attributes.php', $this->astLocator));
         $classReflection    = $reflector->reflectClass(ClassWithAttributes::class);
-        $constantReflection = $classReflection->getReflectionConstant('CONSTANT_WITH_ATTRIBUTES');
+        $constantReflection = $classReflection->getConstant('CONSTANT_WITH_ATTRIBUTES');
         $attributes         = $constantReflection->getAttributesByName(Attr::class);
 
         self::assertCount(1, $attributes);
@@ -294,7 +294,7 @@ class ReflectionClassConstantTest extends TestCase
     {
         $reflector          = new DefaultReflector(new SingleFileSourceLocator(__DIR__ . '/../Fixture/Attributes.php', $this->astLocator));
         $classReflection    = $reflector->reflectClass(ClassWithAttributes::class);
-        $constantReflection = $classReflection->getReflectionConstant('CONSTANT_WITH_ATTRIBUTES');
+        $constantReflection = $classReflection->getConstant('CONSTANT_WITH_ATTRIBUTES');
         $attributes         = $constantReflection->getAttributesByInstance(Attr::class);
 
         self::assertCount(2, $attributes);
@@ -304,7 +304,7 @@ class ReflectionClassConstantTest extends TestCase
     {
         $reflector          = new DefaultReflector(new SingleFileSourceLocator(__DIR__ . '/../Fixture/Attributes.php', $this->astLocator));
         $classReflection    = $reflector->reflectClass(ClassWithAttributes::class);
-        $constantReflection = $classReflection->getReflectionConstant('CONSTANT_WITH_ATTRIBUTES');
+        $constantReflection = $classReflection->getConstant('CONSTANT_WITH_ATTRIBUTES');
         $attributes         = $constantReflection->getAttributes();
 
         self::assertCount(2, $attributes);

--- a/test/unit/Reflection/ReflectionClassTest.php
+++ b/test/unit/Reflection/ReflectionClassTest.php
@@ -17,6 +17,7 @@ use PhpParser\Node\Stmt\Class_;
 use PHPUnit\Framework\TestCase;
 use Qux;
 use ReflectionClass as CoreReflectionClass;
+use ReflectionClassConstant as CoreReflectionClassConstant;
 use ReflectionMethod as CoreReflectionMethod;
 use ReflectionProperty as CoreReflectionProperty;
 use Roave\BetterReflection\Reflection\Exception\NotAClassReflection;
@@ -2072,6 +2073,34 @@ PHP;
         self::assertArrayHasKey('F', $reflectionConstants);
         self::assertInstanceOf(ReflectionClassConstant::class, $reflectionConstants['F']);
         self::assertSame('ff', $reflectionConstants['F']->getValue());
+    }
+
+    /** @return list<array{0: int, 1: int}> */
+    public function getConstantsWithFilterDataProvider(): array
+    {
+        return [
+            [ReflectionClassConstant::IS_FINAL, 2],
+            [CoreReflectionClassConstant::IS_PUBLIC, 4],
+            [CoreReflectionClassConstant::IS_PROTECTED, 2],
+            [CoreReflectionClassConstant::IS_PRIVATE, 1],
+            [
+                ReflectionClassConstant::IS_FINAL |
+                CoreReflectionClassConstant::IS_PUBLIC |
+                CoreReflectionClassConstant::IS_PROTECTED |
+                CoreReflectionClassConstant::IS_PRIVATE,
+                7,
+            ],
+        ];
+    }
+
+    /** @dataProvider getConstantsWithFilterDataProvider */
+    public function testGetConstantsWithFilter(int $filter, int $count): void
+    {
+        $reflector = new DefaultReflector($this->getComposerLocator());
+        $classInfo = $reflector->reflectClass(ExampleClass::class);
+
+        self::assertCount($count, $classInfo->getConstants($filter));
+        self::assertCount($count, $classInfo->getImmediateConstants($filter));
     }
 
     public function testGetConstantsDeclaredWithOneKeyword(): void

--- a/test/unit/Reflection/ReflectionClassTest.php
+++ b/test/unit/Reflection/ReflectionClassTest.php
@@ -422,47 +422,20 @@ class ReflectionClassTest extends TestCase
     {
         $reflector = new DefaultReflector($this->getComposerLocator());
         $classInfo = $reflector->reflectClass(ExampleClass::class);
-        self::assertSame([
-            'MY_CONST_1' => 123,
-            'MY_CONST_2' => 234,
-            'MY_CONST_3' => 345,
-            'MY_CONST_4' => 456,
-            'MY_CONST_5' => 567,
-            'MY_CONST_6' => 678,
-            'MY_CONST_7' => 789,
-        ], $classInfo->getConstants());
+        self::assertCount(7, $classInfo->getConstants());
     }
 
     public function testGetConstant(): void
     {
         $reflector = new DefaultReflector($this->getComposerLocator());
         $classInfo = $reflector->reflectClass(ExampleClass::class);
-        self::assertSame(123, $classInfo->getConstant('MY_CONST_1'));
-        self::assertSame(234, $classInfo->getConstant('MY_CONST_2'));
-        self::assertSame(345, $classInfo->getConstant('MY_CONST_3'));
-        self::assertSame(456, $classInfo->getConstant('MY_CONST_4'));
-        self::assertSame(567, $classInfo->getConstant('MY_CONST_5'));
-        self::assertNull($classInfo->getConstant('NON_EXISTENT_CONSTANT'));
-    }
-
-    public function testGetReflectionConstants(): void
-    {
-        $reflector = new DefaultReflector($this->getComposerLocator());
-        $classInfo = $reflector->reflectClass(ExampleClass::class);
-        self::assertCount(7, $classInfo->getReflectionConstants());
-    }
-
-    public function testGetReflectionConstant(): void
-    {
-        $reflector = new DefaultReflector($this->getComposerLocator());
-        $classInfo = $reflector->reflectClass(ExampleClass::class);
-        self::assertSame(123, $classInfo->getReflectionConstant('MY_CONST_1')->getValue());
-        self::assertSame(234, $classInfo->getReflectionConstant('MY_CONST_2')->getValue());
-        self::assertSame(345, $classInfo->getReflectionConstant('MY_CONST_3')->getValue());
-        self::assertSame(456, $classInfo->getReflectionConstant('MY_CONST_4')->getValue());
-        self::assertSame(567, $classInfo->getReflectionConstant('MY_CONST_5')->getValue());
-        self::assertSame(678, $classInfo->getReflectionConstant('MY_CONST_6')->getValue());
-        self::assertSame(789, $classInfo->getReflectionConstant('MY_CONST_7')->getValue());
+        self::assertSame(123, $classInfo->getConstant('MY_CONST_1')->getValue());
+        self::assertSame(234, $classInfo->getConstant('MY_CONST_2')->getValue());
+        self::assertSame(345, $classInfo->getConstant('MY_CONST_3')->getValue());
+        self::assertSame(456, $classInfo->getConstant('MY_CONST_4')->getValue());
+        self::assertSame(567, $classInfo->getConstant('MY_CONST_5')->getValue());
+        self::assertSame(678, $classInfo->getConstant('MY_CONST_6')->getValue());
+        self::assertSame(789, $classInfo->getConstant('MY_CONST_7')->getValue());
         self::assertNull($classInfo->getConstant('NON_EXISTENT_CONSTANT'));
     }
 
@@ -2037,7 +2010,7 @@ PHP;
             'BAR_DEFAULT' => 4,
         ];
 
-        self::assertSame($expectedConstants, $reflection->getConstants());
+        self::assertSame(array_keys($expectedConstants), array_keys($reflection->getConstants()));
 
         array_walk(
             $expectedConstants,
@@ -2045,7 +2018,7 @@ PHP;
                 self::assertTrue($reflection->hasConstant($constantName), 'Constant ' . $constantName . ' not set');
                 self::assertSame(
                     $constantValue,
-                    $reflection->getConstant($constantName),
+                    $reflection->getConstant($constantName)?->getValue(),
                     'Constant value for ' . $constantName . ' does not match',
                 );
             },
@@ -2067,35 +2040,7 @@ PHP;
             'B' => 'b',
         ];
 
-        self::assertSame($expectedConstants, $classInfo->getConstants());
-    }
-
-    public function testGetImmediateConstants(): void
-    {
-        $classInfo = (new DefaultReflector(new SingleFileSourceLocator(
-            __DIR__ . '/../Fixture/InheritedClassConstants.php',
-            $this->astLocator,
-        )))->reflectClass('Next');
-
-        self::assertSame(['F' => 'ff'], $classInfo->getImmediateConstants());
-    }
-
-    public function testGetReflectionConstantsReturnsInheritedConstants(): void
-    {
-        $classInfo = (new DefaultReflector(new SingleFileSourceLocator(
-            __DIR__ . '/../Fixture/InheritedClassConstants.php',
-            $this->astLocator,
-        )))->reflectClass('Next');
-
-        $expectedConstants = [
-            'F' => 'ff',
-            'D' => 'dd',
-            'C' => 'c',
-            'A' => 'a',
-            'B' => 'b',
-        ];
-
-        $reflectionConstants = $classInfo->getReflectionConstants();
+        $reflectionConstants = $classInfo->getConstants();
 
         self::assertCount(5, $reflectionConstants);
         self::assertContainsOnlyInstancesOf(ReflectionClassConstant::class, $reflectionConstants);
@@ -2114,14 +2059,14 @@ PHP;
         );
     }
 
-    public function testGetImmediateReflectionConstants(): void
+    public function testGetImmediateConstants(): void
     {
         $classInfo = (new DefaultReflector(new SingleFileSourceLocator(
             __DIR__ . '/../Fixture/InheritedClassConstants.php',
             $this->astLocator,
         )))->reflectClass('Next');
 
-        $reflectionConstants = $classInfo->getImmediateReflectionConstants();
+        $reflectionConstants = $classInfo->getImmediateConstants();
 
         self::assertCount(1, $reflectionConstants);
         self::assertArrayHasKey('F', $reflectionConstants);
@@ -2141,8 +2086,8 @@ class Foo
 PHP;
 
         $expectedConstants = [
-            'A' => 0,
-            'B' => 1,
+            'A',
+            'B',
         ];
 
         $classInfo = (new DefaultReflector(new StringSourceLocator($php, $this->astLocator)))->reflectClass('Foo');
@@ -2150,7 +2095,7 @@ PHP;
         $constants = $classInfo->getConstants();
 
         self::assertCount(2, $constants);
-        self::assertSame($expectedConstants, $constants);
+        self::assertSame($expectedConstants, array_keys($constants));
     }
 
     public function testTraitRenamingMethodWithWrongCaseShouldStillWork(): void

--- a/test/unit/Reflection/StringCast/ReflectionClassConstantStringCastTest.php
+++ b/test/unit/Reflection/StringCast/ReflectionClassConstantStringCastTest.php
@@ -41,6 +41,6 @@ class ReflectionClassConstantStringCastTest extends TestCase
         $reflector       = new DefaultReflector(new SingleFileSourceLocator(__DIR__ . '/../../Fixture/StringCastClassConstants.php', $this->astLocator));
         $classReflection = $reflector->reflectClass(StringCastConstants::class);
 
-        self::assertSame($expectedString, (string) $classReflection->getReflectionConstant($constantName));
+        self::assertSame($expectedString, (string) $classReflection->getConstant($constantName));
     }
 }

--- a/test/unit/SourceLocator/SourceStubber/PhpStormStubsSourceStubberTest.php
+++ b/test/unit/SourceLocator/SourceStubber/PhpStormStubsSourceStubberTest.php
@@ -24,6 +24,7 @@ use ReflectionNamedType as CoreReflectionNamedType;
 use ReflectionParameter as CoreReflectionParameter;
 use ReflectionProperty as CoreReflectionProperty;
 use Roave\BetterReflection\Reflection\ReflectionClass;
+use Roave\BetterReflection\Reflection\ReflectionClassConstant;
 use Roave\BetterReflection\Reflection\ReflectionConstant;
 use Roave\BetterReflection\Reflection\ReflectionFunction;
 use Roave\BetterReflection\Reflection\ReflectionMethod;
@@ -181,7 +182,10 @@ class PhpStormStubsSourceStubberTest extends TestCase
             $this->assertSameMethodAttributes($method, $stubbed->getMethod($method->getName()));
         }
 
-        self::assertEquals($original->getConstants(), $stubbed->getConstants());
+        self::assertEquals(
+            $original->getConstants(),
+            array_map(static fn (ReflectionClassConstant $classConstant) => $classConstant->getValue(), $stubbed->getConstants()),
+        );
     }
 
     private function assertSameMethodAttributes(CoreReflectionMethod $original, ReflectionMethod $stubbed): void
@@ -1026,7 +1030,7 @@ class PhpStormStubsSourceStubberTest extends TestCase
         $reflector     = new DefaultReflector(new PhpInternalSourceLocator($this->astLocator, $sourceStubber));
 
         $classReflection    = $reflector->reflectClass($className);
-        $constantReflection = $classReflection->getReflectionConstant($constantName);
+        $constantReflection = $classReflection->getConstant($constantName);
 
         self::assertSame($isDeprecated, $constantReflection->isDeprecated());
     }

--- a/test/unit/SourceLocator/SourceStubber/ReflectionSourceStubberTest.php
+++ b/test/unit/SourceLocator/SourceStubber/ReflectionSourceStubberTest.php
@@ -13,6 +13,7 @@ use ReflectionMethod as CoreReflectionMethod;
 use ReflectionParameter as CoreReflectionParameter;
 use Roave\BetterReflection\Reflection\Adapter\ReflectionType;
 use Roave\BetterReflection\Reflection\ReflectionClass;
+use Roave\BetterReflection\Reflection\ReflectionClassConstant;
 use Roave\BetterReflection\Reflection\ReflectionConstant;
 use Roave\BetterReflection\Reflection\ReflectionMethod;
 use Roave\BetterReflection\Reflection\ReflectionParameter;
@@ -323,7 +324,10 @@ class ReflectionSourceStubberTest extends TestCase
             $this->assertSameMethodAttributes($method, $stubbed->getMethod($method->getName()));
         }
 
-        self::assertEquals($original->getConstants(), $stubbed->getConstants());
+        self::assertEquals(
+            $original->getConstants(),
+            array_map(static fn (ReflectionClassConstant $classConstant) => $classConstant->getValue(), $stubbed->getConstants()),
+        );
     }
 
     private function assertSameMethodAttributes(CoreReflectionMethod $original, ReflectionMethod $stubbed): void


### PR DESCRIPTION
- Return `ReflectionClassConstant` instances
- Have filter parameter