### PR TITLE
`ReflectionClass::getMethod()` returns null when method does not exist

### DIFF
--- a/src/Reflection/Adapter/ReflectionClass.php
+++ b/src/Reflection/Adapter/ReflectionClass.php
@@ -103,11 +103,13 @@ final class ReflectionClass extends CoreReflectionClass
 
     public function getConstructor(): CoreReflectionMethod|null
     {
-        try {
-            return new ReflectionMethod($this->betterReflectionClass->getConstructor());
-        } catch (OutOfBoundsException) {
+        $constructor = $this->betterReflectionClass->getConstructor();
+
+        if ($constructor === null) {
             return null;
         }
+
+        return new ReflectionMethod($constructor);
     }
 
     public function hasMethod(string $name): bool
@@ -117,7 +119,13 @@ final class ReflectionClass extends CoreReflectionClass
 
     public function getMethod(string $name): ReflectionMethod
     {
-        return new ReflectionMethod($this->betterReflectionClass->getMethod($name));
+        $method = $this->betterReflectionClass->getMethod($name);
+
+        if ($method === null) {
+            throw new OutOfBoundsException(sprintf('Could not find method: %s', $name));
+        }
+
+        return new ReflectionMethod($method);
     }
 
     /**

--- a/src/Reflection/Adapter/ReflectionEnum.php
+++ b/src/Reflection/Adapter/ReflectionEnum.php
@@ -104,11 +104,13 @@ final class ReflectionEnum extends CoreReflectionEnum
 
     public function getConstructor(): CoreReflectionMethod|null
     {
-        try {
-            return new ReflectionMethod($this->betterReflectionEnum->getConstructor());
-        } catch (OutOfBoundsException) {
+        $constructor = $this->betterReflectionEnum->getConstructor();
+
+        if ($constructor === null) {
             return null;
         }
+
+        return new ReflectionMethod($constructor);
     }
 
     public function hasMethod(string $name): bool
@@ -118,7 +120,13 @@ final class ReflectionEnum extends CoreReflectionEnum
 
     public function getMethod(string $name): ReflectionMethod
     {
-        return new ReflectionMethod($this->betterReflectionEnum->getMethod($name));
+        $method = $this->betterReflectionEnum->getMethod($name);
+
+        if ($method === null) {
+            throw new OutOfBoundsException(sprintf('Could not find method: %s', $name));
+        }
+
+        return new ReflectionMethod($method);
     }
 
     /**

--- a/src/Reflection/Adapter/ReflectionObject.php
+++ b/src/Reflection/Adapter/ReflectionObject.php
@@ -86,9 +86,15 @@ final class ReflectionObject extends CoreReflectionObject
         return $this->betterReflectionObject->getDocComment() ?? false;
     }
 
-    public function getConstructor(): ReflectionMethod
+    public function getConstructor(): ReflectionMethod|null
     {
-        return new ReflectionMethod($this->betterReflectionObject->getConstructor());
+        $constructor = $this->betterReflectionObject->getConstructor();
+
+        if ($constructor === null) {
+            return null;
+        }
+
+        return new ReflectionMethod($constructor);
     }
 
     public function hasMethod(string $name): bool
@@ -98,7 +104,13 @@ final class ReflectionObject extends CoreReflectionObject
 
     public function getMethod(string $name): ReflectionMethod
     {
-        return new ReflectionMethod($this->betterReflectionObject->getMethod($this->getMethodRealName($name)));
+        $method = $this->betterReflectionObject->getMethod($this->getMethodRealName($name));
+
+        if ($method === null) {
+            throw new OutOfBoundsException(sprintf('Could not find method: %s', $name));
+        }
+
+        return new ReflectionMethod($method);
     }
 
     private function getMethodRealName(string $name): string

--- a/src/Reflection/ReflectionMethod.php
+++ b/src/Reflection/ReflectionMethod.php
@@ -87,7 +87,13 @@ class ReflectionMethod
      */
     public static function createFromName(string $className, string $methodName): self
     {
-        return ReflectionClass::createFromName($className)->getMethod($methodName);
+        $method = ReflectionClass::createFromName($className)->getMethod($methodName);
+
+        if ($method === null) {
+            throw new OutOfBoundsException(sprintf('Could not find method: %s', $methodName));
+        }
+
+        return $method;
     }
 
     /**
@@ -99,7 +105,13 @@ class ReflectionMethod
      */
     public static function createFromInstance(object $instance, string $methodName): self
     {
-        return ReflectionClass::createFromInstance($instance)->getMethod($methodName);
+        $method = ReflectionClass::createFromInstance($instance)->getMethod($methodName);
+
+        if ($method === null) {
+            throw new OutOfBoundsException(sprintf('Could not find method: %s', $methodName));
+        }
+
+        return $method;
     }
 
     /**
@@ -170,8 +182,10 @@ class ReflectionMethod
 
         while ($currentClass) {
             foreach ($currentClass->getImmediateInterfaces() as $interface) {
-                if ($interface->hasMethod($this->getName())) {
-                    return $interface->getMethod($this->getName());
+                $interfaceMethod = $interface->getMethod($this->getName());
+
+                if ($interfaceMethod !== null) {
+                    return $interfaceMethod;
                 }
             }
 
@@ -182,9 +196,10 @@ class ReflectionMethod
                 break;
             }
 
-            $prototype = $currentClass->getMethod($this->getName())->findPrototype();
+            $prototype = $currentClass->getMethod($this->getName())?->findPrototype();
 
             if ($prototype === null) {
+                // @infection-ignore-all Break_: There's no difference between break and continue - break is just optimization
                 break;
             }
 

--- a/src/Reflection/ReflectionObject.php
+++ b/src/Reflection/ReflectionObject.php
@@ -156,7 +156,7 @@ class ReflectionObject extends ReflectionClass
         return $this->reflectionClass->getImmediateMethods($filter);
     }
 
-    public function getMethod(string $methodName): ReflectionMethod
+    public function getMethod(string $methodName): ReflectionMethod|null
     {
         return $this->reflectionClass->getMethod($methodName);
     }
@@ -192,7 +192,7 @@ class ReflectionObject extends ReflectionClass
         return $this->reflectionClass->getConstant($name);
     }
 
-    public function getConstructor(): ReflectionMethod
+    public function getConstructor(): ReflectionMethod|null
     {
         return $this->reflectionClass->getConstructor();
     }

--- a/src/Reflection/ReflectionParameter.php
+++ b/src/Reflection/ReflectionParameter.php
@@ -125,7 +125,7 @@ class ReflectionParameter
     ): self {
         $parameter = ReflectionClass::createFromName($className)
             ->getMethod($methodName)
-            ->getParameter($parameterName);
+            ?->getParameter($parameterName);
 
         if ($parameter === null) {
             throw new OutOfBoundsException(sprintf('Could not find parameter: %s', $parameterName));
@@ -146,7 +146,7 @@ class ReflectionParameter
     ): self {
         $parameter = ReflectionClass::createFromInstance($instance)
             ->getMethod($methodName)
-            ->getParameter($parameterName);
+            ?->getParameter($parameterName);
 
         if ($parameter === null) {
             throw new OutOfBoundsException(sprintf('Could not find parameter: %s', $parameterName));

--- a/test/unit/Reflection/Adapter/ReflectionClassTest.php
+++ b/test/unit/Reflection/Adapter/ReflectionClassTest.php
@@ -694,7 +694,7 @@ class ReflectionClassTest extends TestCase
         $betterReflectionClass = $this->createMock(BetterReflectionClass::class);
         $betterReflectionClass
             ->method('getConstructor')
-            ->willThrowException(new OutOfBoundsException());
+            ->willReturn(null);
 
         $reflectionClassAdapter = new ReflectionClassAdapter($betterReflectionClass);
 

--- a/test/unit/Reflection/Adapter/ReflectionEnumTest.php
+++ b/test/unit/Reflection/Adapter/ReflectionEnumTest.php
@@ -239,7 +239,7 @@ class ReflectionEnumTest extends TestCase
         $betterReflectionEnum = $this->createMock(BetterReflectionEnum::class);
         $betterReflectionEnum
             ->method('getConstructor')
-            ->willThrowException(new OutOfBoundsException());
+            ->willReturn(null);
 
         $reflectionEnumAdapter = new ReflectionEnumAdapter($betterReflectionEnum);
 

--- a/test/unit/Reflection/Adapter/ReflectionObjectTest.php
+++ b/test/unit/Reflection/Adapter/ReflectionObjectTest.php
@@ -77,7 +77,7 @@ class ReflectionObjectTest extends TestCase
             ['getStartLine', [], 123, null, 123, null],
             ['getEndLine', [], 123, null, 123, null],
             ['getDocComment', [], null, null, false, null],
-            ['getConstructor', [], $mockMethod, null, null, null],
+            ['getConstructor', [], $mockMethod, null, null, ReflectionMethodAdapter::class],
             ['hasMethod', ['foo'], true, null, true, null],
             ['getMethod', ['foo'], $mockMethod, null, null, ReflectionMethodAdapter::class],
             ['getMethods', [], [$mockMethod], null, null, ReflectionMethodAdapter::class],

--- a/test/unit/Reflection/ReflectionClassTest.php
+++ b/test/unit/Reflection/ReflectionClassTest.php
@@ -9,7 +9,6 @@ use Bar;
 use Baz;
 use E;
 use Iterator;
-use OutOfBoundsException;
 use Php4StyleCaseInsensitiveConstruct;
 use Php4StyleConstruct;
 use PhpParser\Node;
@@ -488,14 +487,12 @@ class ReflectionClassTest extends TestCase
 
     public function testGetConstructorWhenPhp4StyleInNamespace(): void
     {
-        $this->expectException(OutOfBoundsException::class);
-
         $classInfo = (new DefaultReflector(new SingleFileSourceLocator(
             __DIR__ . '/../Fixture/Php4StyleConstructInNamespace.php',
             $this->astLocator,
         )))->reflectClass(Fixture\Php4StyleConstructInNamespace::class);
 
-        $classInfo->getConstructor();
+        self::assertNull($classInfo->getConstructor());
     }
 
     public function testGetConstructorWhenPhp4StyleCaseInsensitive(): void

--- a/test/unit/Reflection/ReflectionMethodTest.php
+++ b/test/unit/Reflection/ReflectionMethodTest.php
@@ -7,6 +7,7 @@ namespace Roave\BetterReflectionTest\Reflection;
 use ClassWithMethodsAndTraitMethods;
 use Closure;
 use ExtendedClassWithMethodsAndTraitMethods;
+use OutOfBoundsException;
 use Php4StyleCaseInsensitiveConstruct;
 use Php4StyleConstruct;
 use PHPUnit\Framework\TestCase;
@@ -79,12 +80,26 @@ class ReflectionMethodTest extends TestCase
         self::assertSame('add', $method->getName());
     }
 
+    public function testCreateFromNameThrowsExceptionWhenMethodNotFound(): void
+    {
+        self::expectException(OutOfBoundsException::class);
+        self::expectExceptionMessage('Could not find method: notFound');
+        ReflectionMethod::createFromName(SplDoublyLinkedList::class, 'notFound');
+    }
+
     public function testCreateFromInstance(): void
     {
         $method = ReflectionMethod::createFromInstance(new SplDoublyLinkedList(), 'add');
 
         self::assertInstanceOf(ReflectionMethod::class, $method);
         self::assertSame('add', $method->getName());
+    }
+
+    public function testCreateFromInstanceThrowsExceptionWhenMethodNotFound(): void
+    {
+        self::expectException(OutOfBoundsException::class);
+        self::expectExceptionMessage('Could not find method: notFound');
+        ReflectionMethod::createFromInstance(new SplDoublyLinkedList(), 'notFound');
     }
 
     public function testIsClosure(): void


### PR DESCRIPTION
To make it consistent with `getProperty()`, `getConstant()` and `getCase()`