### PR TITLE
Detection of interface extends circular references

### DIFF
--- a/test/unit/Fixture/InvalidInterfaceParents.php
+++ b/test/unit/Fixture/InvalidInterfaceParents.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Roave\BetterReflectionTest\Fixture\InvalidInterfaceParents;
+
+interface InterfaceExtendsSelf extends InterfaceExtendsSelf {}
+
+interface Interface1 extends Interface2 {}
+interface Interface2 extends Interface1 {}
+interface Interface3 extends Interface2 {}

--- a/test/unit/Reflection/ReflectionClassTest.php
+++ b/test/unit/Reflection/ReflectionClassTest.php
@@ -1731,6 +1731,32 @@ PHP;
         }
     }
 
+    /** @return list<array{0: string}> */
+    public function interfaceExtendsCircularReferencesProvider(): array
+    {
+        return [
+            ['Roave\\BetterReflectionTest\\Fixture\\InvalidInterfaceParents\\InterfaceExtendsSelf'],
+            ['Roave\\BetterReflectionTest\\Fixture\\InvalidInterfaceParents\\Interface1'],
+            ['Roave\\BetterReflectionTest\\Fixture\\InvalidInterfaceParents\\Interface2'],
+            ['Roave\\BetterReflectionTest\\Fixture\\InvalidInterfaceParents\\Interface3'],
+        ];
+    }
+
+    /** @dataProvider interfaceExtendsCircularReferencesProvider */
+    public function testGetInterfacesFailsWithCircularReferences(string $className): void
+    {
+        $reflector = new DefaultReflector(new SingleFileSourceLocator(
+            __DIR__ . '/../Fixture/InvalidInterfaceParents.php',
+            $this->astLocator,
+        ));
+
+        $class = $reflector->reflectClass($className);
+
+        $this->expectException(CircularReference::class);
+
+        $class->getInterfaces();
+    }
+
     public function testIsInstance(): void
     {
         // note: ClassForHinting is safe to type-check against, as it will actually be loaded at runtime


### PR DESCRIPTION
This was not handled yet in https://github.com/Roave/BetterReflection/pull/1240