### PR TITLE
Interface can have only public properties

### DIFF
--- a/src/Reflection/ReflectionClass.php
+++ b/src/Reflection/ReflectionClass.php
@@ -902,7 +902,7 @@ class ReflectionClass implements Reflection
                     [],
                     $this->getParentClass()?->getProperties(ReflectionPropertyAdapter::IS_PUBLIC | ReflectionPropertyAdapter::IS_PROTECTED) ?? [],
                     ...array_map(
-                        static fn (ReflectionClass $ancestor): array => $ancestor->getProperties(ReflectionPropertyAdapter::IS_PUBLIC | ReflectionPropertyAdapter::IS_PROTECTED),
+                        static fn (ReflectionClass $ancestor): array => $ancestor->getProperties(),
                         array_values($this->getInterfaces()),
                     ),
                     ...array_map(


### PR DESCRIPTION
Interface really should not have any properties but we have `UnitEnum` and `BackedEnum` https://github.com/Roave/BetterReflection/pull/971