### PR TITLE
Optimise interface traversion in `ReflectionClass`

### DIFF
--- a/src/Reflection/ReflectionClass.php
+++ b/src/Reflection/ReflectionClass.php
@@ -396,7 +396,7 @@ class ReflectionClass implements Reflection
             [],
             ...array_map(
                 static fn (ReflectionClass $ancestor): array => $ancestor->getMethods(),
-                array_values($this->getInterfaces()),
+                array_values($this->getCurrentClassImplementedInterfacesIndexedByName()),
             ),
         );
     }
@@ -712,7 +712,7 @@ class ReflectionClass implements Reflection
                 ),
                 ...array_map(
                     static fn (ReflectionClass $interface): array => array_values($interface->getConstants()),
-                    array_values($this->getInterfaces()),
+                    array_values($this->getCurrentClassImplementedInterfacesIndexedByName()),
                 ),
             );
 
@@ -903,7 +903,7 @@ class ReflectionClass implements Reflection
                     $this->getParentClass()?->getProperties(ReflectionPropertyAdapter::IS_PUBLIC | ReflectionPropertyAdapter::IS_PROTECTED) ?? [],
                     ...array_map(
                         static fn (ReflectionClass $ancestor): array => $ancestor->getProperties(),
-                        array_values($this->getInterfaces()),
+                        array_values($this->getCurrentClassImplementedInterfacesIndexedByName()),
                     ),
                     ...array_map(
                         function (ReflectionClass $trait) {


### PR DESCRIPTION
Previously it was using `getInterfaces` which determines the parents and their interfaces too. Now it only uses the currents class interfaces since parent constants or props are already explicitly collected.

This saves merely a couple of unnecessary calls, depending on how heavy inheritance is used. Just noticed it while trying to fully understand how constants, properties and methods are collected.