### PR TITLE
Detection of trait use circular references

### DIFF
--- a/src/Reflection/Exception/NotATraitReflection.php
+++ b/src/Reflection/Exception/NotATraitReflection.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Roave\BetterReflection\Reflection\Exception;
+
+use Roave\BetterReflection\Reflection\ReflectionClass;
+use UnexpectedValueException;
+
+use function sprintf;
+
+class NotATraitReflection extends UnexpectedValueException
+{
+    public static function fromReflectionClass(ReflectionClass $class): self
+    {
+        $type = 'class';
+
+        if ($class->isInterface()) {
+            $type = 'interface';
+        }
+
+        return new self(sprintf('Provided node "%s" is not trait, but "%s"', $class->getName(), $type));
+    }
+}

--- a/test/unit/Fixture/InvalidTraitUses.php
+++ b/test/unit/Fixture/InvalidTraitUses.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Roave\BetterReflectionTest\Fixture\InvalidTraitUses;
+
+trait TraitUsesSelf
+{
+    use TraitUsesSelf;
+}
+
+trait Trait1
+{
+    use Trait2;
+}
+trait Trait2
+{
+    use Trait1;
+}
+trait Trait3
+{
+    use Trait2;
+}
+
+class Class1
+{
+    use TraitUsesSelf;
+}
+
+class Class2
+{
+    use Trait1;
+}

--- a/test/unit/Reflection/Exception/NotATraitReflectionTest.php
+++ b/test/unit/Reflection/Exception/NotATraitReflectionTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Roave\BetterReflectionTest\Reflection\Exception;
+
+use PHPUnit\Framework\TestCase;
+use Roave\BetterReflection\Reflection\Exception\NotATraitReflection;
+use Roave\BetterReflection\Reflector\DefaultReflector;
+use Roave\BetterReflection\SourceLocator\Ast\Locator;
+use Roave\BetterReflection\SourceLocator\Type\SingleFileSourceLocator;
+use Roave\BetterReflectionTest\BetterReflectionSingleton;
+use Roave\BetterReflectionTest\Fixture;
+
+/** @covers \Roave\BetterReflection\Reflection\Exception\NotATraitReflection */
+class NotATraitReflectionTest extends TestCase
+{
+    private Locator $astLocator;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->astLocator = BetterReflectionSingleton::instance()->astLocator();
+    }
+
+    public function testFromClass(): void
+    {
+        $reflector = new DefaultReflector(new SingleFileSourceLocator(__DIR__ . '/../../Fixture/ExampleClass.php', $this->astLocator));
+        $exception = NotATraitReflection::fromReflectionClass($reflector->reflectClass(Fixture\ExampleClass::class));
+
+        self::assertInstanceOf(NotATraitReflection::class, $exception);
+        self::assertSame(
+            'Provided node "' . Fixture\ExampleClass::class . '" is not trait, but "class"',
+            $exception->getMessage(),
+        );
+    }
+
+    public function testFromInterface(): void
+    {
+        $reflector = new DefaultReflector(new SingleFileSourceLocator(__DIR__ . '/../../Fixture/ExampleClass.php', $this->astLocator));
+        $exception = NotATraitReflection::fromReflectionClass($reflector->reflectClass(Fixture\ExampleInterface::class));
+
+        self::assertInstanceOf(NotATraitReflection::class, $exception);
+        self::assertSame(
+            'Provided node "' . Fixture\ExampleInterface::class . '" is not trait, but "interface"',
+            $exception->getMessage(),
+        );
+    }
+}

--- a/test/unit/Reflection/ReflectionClassTest.php
+++ b/test/unit/Reflection/ReflectionClassTest.php
@@ -2663,4 +2663,62 @@ PHP;
         $fooBarDoFooMethod = $fooBar->getMethod('doFoo');
         self::assertTrue($fooBarDoFooMethod->isPublic());
     }
+
+    /** @return list<array{0: string}> */
+    public function traitUseCircularReferencesProvider(): array
+    {
+        return [
+            ['Roave\\BetterReflectionTest\\Fixture\\InvalidTraitUses\\TraitUsesSelf'],
+            ['Roave\\BetterReflectionTest\\Fixture\\InvalidTraitUses\\Trait1'],
+            ['Roave\\BetterReflectionTest\\Fixture\\InvalidTraitUses\\Trait2'],
+            ['Roave\\BetterReflectionTest\\Fixture\\InvalidTraitUses\\Trait3'],
+            ['Roave\\BetterReflectionTest\\Fixture\\InvalidTraitUses\\Class1'],
+            ['Roave\\BetterReflectionTest\\Fixture\\InvalidTraitUses\\Class2'],
+        ];
+    }
+
+    /** @dataProvider traitUseCircularReferencesProvider */
+    public function testGetConstantsFailsWithCircularReference(string $className): void
+    {
+        $reflector = new DefaultReflector(new SingleFileSourceLocator(
+            __DIR__ . '/../Fixture/InvalidTraitUses.php',
+            $this->astLocator,
+        ));
+
+        $class = $reflector->reflectClass($className);
+
+        $this->expectException(CircularReference::class);
+
+        $class->getConstants();
+    }
+
+    /** @dataProvider traitUseCircularReferencesProvider */
+    public function testGetMethodsFailsWithCircularReference(string $className): void
+    {
+        $reflector = new DefaultReflector(new SingleFileSourceLocator(
+            __DIR__ . '/../Fixture/InvalidTraitUses.php',
+            $this->astLocator,
+        ));
+
+        $class = $reflector->reflectClass($className);
+
+        $this->expectException(CircularReference::class);
+
+        $class->getMethods();
+    }
+
+    /** @dataProvider traitUseCircularReferencesProvider */
+    public function testGetPropertiesFailsWithCircularReference(string $className): void
+    {
+        $reflector = new DefaultReflector(new SingleFileSourceLocator(
+            __DIR__ . '/../Fixture/InvalidTraitUses.php',
+            $this->astLocator,
+        ));
+
+        $class = $reflector->reflectClass($className);
+
+        $this->expectException(CircularReference::class);
+
+        $class->getProperties();
+    }
 }


### PR DESCRIPTION
Closes https://github.com/Roave/BetterReflection/issues/1242

The solution is very influenced by (= mostly duplicated :P) the one that is used for interfaces. It is working fine and makes sense to me, but I'm not a 100% sure about the method names and how to make clear what each one does and how it is different to just `getTraits()`.

The new exception class is also influenced by similar older ones. Not sure if the same approach should still be used.