### PR TITLE
Detection of trait use circular references [solution 2]

### DIFF
--- a/test/unit/Fixture/InvalidTraitUses.php
+++ b/test/unit/Fixture/InvalidTraitUses.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Roave\BetterReflectionTest\Fixture\InvalidTraitUses;
+
+trait TraitUsesSelf
+{
+    use TraitUsesSelf;
+}
+
+trait Trait1
+{
+    use Trait2;
+}
+trait Trait2
+{
+    use Trait1;
+}
+trait Trait3
+{
+    use Trait2;
+}
+
+class Class1
+{
+    use TraitUsesSelf;
+}
+
+class Class2
+{
+    use Trait1;
+}

--- a/test/unit/Reflection/ReflectionClassTest.php
+++ b/test/unit/Reflection/ReflectionClassTest.php
@@ -2663,4 +2663,62 @@ PHP;
         $fooBarDoFooMethod = $fooBar->getMethod('doFoo');
         self::assertTrue($fooBarDoFooMethod->isPublic());
     }
+
+    /** @return list<array{0: string}> */
+    public function traitUseCircularReferencesProvider(): array
+    {
+        return [
+            ['Roave\\BetterReflectionTest\\Fixture\\InvalidTraitUses\\TraitUsesSelf'],
+            ['Roave\\BetterReflectionTest\\Fixture\\InvalidTraitUses\\Trait1'],
+            ['Roave\\BetterReflectionTest\\Fixture\\InvalidTraitUses\\Trait2'],
+            ['Roave\\BetterReflectionTest\\Fixture\\InvalidTraitUses\\Trait3'],
+            ['Roave\\BetterReflectionTest\\Fixture\\InvalidTraitUses\\Class1'],
+            ['Roave\\BetterReflectionTest\\Fixture\\InvalidTraitUses\\Class2'],
+        ];
+    }
+
+    /** @dataProvider traitUseCircularReferencesProvider */
+    public function testGetConstantsFailsWithCircularReference(string $className): void
+    {
+        $reflector = new DefaultReflector(new SingleFileSourceLocator(
+            __DIR__ . '/../Fixture/InvalidTraitUses.php',
+            $this->astLocator,
+        ));
+
+        $class = $reflector->reflectClass($className);
+
+        $this->expectException(CircularReference::class);
+
+        $class->getConstants();
+    }
+
+    /** @dataProvider traitUseCircularReferencesProvider */
+    public function testGetMethodsFailsWithCircularReference(string $className): void
+    {
+        $reflector = new DefaultReflector(new SingleFileSourceLocator(
+            __DIR__ . '/../Fixture/InvalidTraitUses.php',
+            $this->astLocator,
+        ));
+
+        $class = $reflector->reflectClass($className);
+
+        $this->expectException(CircularReference::class);
+
+        $class->getMethods();
+    }
+
+    /** @dataProvider traitUseCircularReferencesProvider */
+    public function testGetPropertiesFailsWithCircularReference(string $className): void
+    {
+        $reflector = new DefaultReflector(new SingleFileSourceLocator(
+            __DIR__ . '/../Fixture/InvalidTraitUses.php',
+            $this->astLocator,
+        ));
+
+        $class = $reflector->reflectClass($className);
+
+        $this->expectException(CircularReference::class);
+
+        $class->getProperties();
+    }
 }


### PR DESCRIPTION
Closes https://github.com/Roave/BetterReflection/issues/1242

Simpler alternative to https://github.com/Roave/BetterReflection/pull/1253. This one does more trait recursion checks.

The only alternative, I can think of, that avoids any overhead would be to directly build such checks into `getConstants`, `getMethods` and `getProperties` or respective internal versions of those. I was just worried that it might add too much complexity just for this.. Well, maybe I'll open one more PR tomorrow xD