### PR TITLE
Detection of circular references in constant, method and property getters

### DIFF
--- a/src/Reflection/ClassNameStack.php
+++ b/src/Reflection/ClassNameStack.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Roave\BetterReflection\Reflection;
+
+use Roave\BetterReflection\Reflection\Exception\CircularReference;
+
+use function array_key_exists;
+
+/**
+ * @internal
+ *
+ * @psalm-immutable
+ */
+final class ClassNameStack
+{
+    /** @param array<class-string, null> $classNames */
+    private function __construct(private array $classNames)
+    {
+    }
+
+    public static function createEmpty(): self
+    {
+        return new self([]);
+    }
+
+    /** @param class-string $className */
+    public function push(string $className): self
+    {
+        if (array_key_exists($className, $this->classNames)) {
+            throw CircularReference::fromClassName($className);
+        }
+
+        $classNames             = $this->classNames;
+        $classNames[$className] = null;
+
+        return new self($classNames);
+    }
+}

--- a/src/Reflection/ReflectionClass.php
+++ b/src/Reflection/ReflectionClass.php
@@ -361,7 +361,7 @@ class ReflectionClass implements Reflection
     }
 
     /**
-     * @param list<class-string> $classNameStack
+     * @param array<class-string, null> $classNameStack
      *
      * @return list<ReflectionMethod>
      */
@@ -374,7 +374,7 @@ class ReflectionClass implements Reflection
     }
 
     /**
-     * @param list<class-string> $classNameStack
+     * @param array<class-string, null> $classNameStack
      *
      * @return list<ReflectionMethod>
      */
@@ -398,7 +398,7 @@ class ReflectionClass implements Reflection
     }
 
     /**
-     * @param list<class-string> $classNameStack
+     * @param array<class-string, null> $classNameStack
      *
      * @return list<ReflectionMethod>
      */
@@ -425,7 +425,7 @@ class ReflectionClass implements Reflection
      * Methods are not merged via their name as array index, since internal PHP method
      * sorting does not follow `\array_merge()` semantics.
      *
-     * @param list<class-string> $classNameStack
+     * @param array<class-string, null> $classNameStack
      *
      * @return array<lowercase-string, ReflectionMethod> indexed by method name
      */
@@ -719,7 +719,7 @@ class ReflectionClass implements Reflection
 
     /**
      * @param int-mask-of<ReflectionClassConstantAdapter::IS_*> $filter
-     * @param list<class-string>                                $classNameStack
+     * @param array<class-string, null>                         $classNameStack
      *
      * @return array<non-empty-string, ReflectionClassConstant> indexed by name
      */
@@ -932,7 +932,7 @@ class ReflectionClass implements Reflection
 
     /**
      * @param int-mask-of<ReflectionPropertyAdapter::IS_*> $filter
-     * @param list<class-string>                           $classNameStack
+     * @param array<class-string, null>                    $classNameStack
      *
      * @return array<non-empty-string, ReflectionProperty>
      */
@@ -1630,7 +1630,7 @@ class ReflectionClass implements Reflection
     /**
      * This method allows us to retrieve all interfaces parent of this interface. Do not use on class nodes!
      *
-     * @param list<class-string> $classNameStack
+     * @param array<class-string, null> $classNameStack
      *
      * @return array<class-string, ReflectionClass> parent interfaces of this interface
      *
@@ -1660,18 +1660,18 @@ class ReflectionClass implements Reflection
     }
 
     /**
-     * @param list<class-string> $classNameStack
-     * @param class-string       $className
+     * @param array<class-string, null> $classNameStack
+     * @param class-string              $className
      *
-     * @return list<class-string>
+     * @return array<class-string, null>
      */
     private function pushClassNameStack(array $classNameStack, string $className): array
     {
-        if (in_array($className, $classNameStack, true)) {
+        if (array_key_exists($className, $classNameStack)) {
             throw CircularReference::fromClassName($className);
         }
 
-        $classNameStack[] = $className;
+        $classNameStack[$className] = null;
 
         return $classNameStack;
     }

--- a/src/Reflection/ReflectionClass.php
+++ b/src/Reflection/ReflectionClass.php
@@ -365,7 +365,7 @@ class ReflectionClass implements Reflection
      *
      * @return list<ReflectionMethod>
      */
-    private function getParentMethods(array &$classNameStack = []): array
+    private function getParentMethods(array $classNameStack = []): array
     {
         return array_map(
             fn (ReflectionMethod $method): ReflectionMethod => $method->withCurrentClass($this),
@@ -378,12 +378,12 @@ class ReflectionClass implements Reflection
      *
      * @return list<ReflectionMethod>
      */
-    private function getMethodsFromTraits(array &$classNameStack = []): array
+    private function getMethodsFromTraits(array $classNameStack = []): array
     {
         return array_merge(
             [],
             ...array_map(
-                function (ReflectionClass $trait) use (&$classNameStack): array {
+                function (ReflectionClass $trait) use ($classNameStack): array {
                     return array_merge(
                         [],
                         ...array_map(
@@ -402,7 +402,7 @@ class ReflectionClass implements Reflection
      *
      * @return list<ReflectionMethod>
      */
-    private function getMethodsFromInterfaces(array &$classNameStack = []): array
+    private function getMethodsFromInterfaces(array $classNameStack = []): array
     {
         return array_merge(
             [],

--- a/src/Reflection/Support/AlreadyVisitedClasses.php
+++ b/src/Reflection/Support/AlreadyVisitedClasses.php
@@ -2,18 +2,14 @@
 
 declare(strict_types=1);
 
-namespace Roave\BetterReflection\Reflection;
+namespace Roave\BetterReflection\Reflection\Support;
 
 use Roave\BetterReflection\Reflection\Exception\CircularReference;
 
 use function array_key_exists;
 
-/**
- * @internal
- *
- * @psalm-immutable
- */
-final class ClassNameStack
+/** @internal */
+final class AlreadyVisitedClasses
 {
     /** @param array<class-string, null> $classNames */
     private function __construct(private array $classNames)
@@ -26,15 +22,12 @@ final class ClassNameStack
     }
 
     /** @param class-string $className */
-    public function push(string $className): self
+    public function push(string $className): void
     {
         if (array_key_exists($className, $this->classNames)) {
             throw CircularReference::fromClassName($className);
         }
 
-        $classNames             = $this->classNames;
-        $classNames[$className] = null;
-
-        return new self($classNames);
+        $this->classNames[$className] = null;
     }
 }

--- a/test/unit/Fixture/InvalidTraitUses.php
+++ b/test/unit/Fixture/InvalidTraitUses.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Roave\BetterReflectionTest\Fixture\InvalidTraitUses;
+
+trait TraitUsesSelf
+{
+    use TraitUsesSelf;
+}
+
+trait Trait1
+{
+    use Trait2;
+}
+trait Trait2
+{
+    use Trait1;
+}
+trait Trait3
+{
+    use Trait2;
+}
+
+class Class1
+{
+    use TraitUsesSelf;
+}
+
+class Class2
+{
+    use Trait1;
+}

--- a/test/unit/Reflection/ReflectionClassTest.php
+++ b/test/unit/Reflection/ReflectionClassTest.php
@@ -2661,4 +2661,62 @@ PHP;
         $fooBarDoFooMethod = $fooBar->getMethod('doFoo');
         self::assertTrue($fooBarDoFooMethod->isPublic());
     }
+
+    /** @return list<array{0: string}> */
+    public function traitUseCircularReferencesProvider(): array
+    {
+        return [
+            ['Roave\\BetterReflectionTest\\Fixture\\InvalidTraitUses\\TraitUsesSelf'],
+            ['Roave\\BetterReflectionTest\\Fixture\\InvalidTraitUses\\Trait1'],
+            ['Roave\\BetterReflectionTest\\Fixture\\InvalidTraitUses\\Trait2'],
+            ['Roave\\BetterReflectionTest\\Fixture\\InvalidTraitUses\\Trait3'],
+            ['Roave\\BetterReflectionTest\\Fixture\\InvalidTraitUses\\Class1'],
+            ['Roave\\BetterReflectionTest\\Fixture\\InvalidTraitUses\\Class2'],
+        ];
+    }
+
+    /** @dataProvider traitUseCircularReferencesProvider */
+    public function testGetConstantsFailsWithCircularReference(string $className): void
+    {
+        $reflector = new DefaultReflector(new SingleFileSourceLocator(
+            __DIR__ . '/../Fixture/InvalidTraitUses.php',
+            $this->astLocator,
+        ));
+
+        $class = $reflector->reflectClass($className);
+
+        $this->expectException(CircularReference::class);
+
+        $class->getConstants();
+    }
+
+    /** @dataProvider traitUseCircularReferencesProvider */
+    public function testGetMethodsFailsWithCircularReference(string $className): void
+    {
+        $reflector = new DefaultReflector(new SingleFileSourceLocator(
+            __DIR__ . '/../Fixture/InvalidTraitUses.php',
+            $this->astLocator,
+        ));
+
+        $class = $reflector->reflectClass($className);
+
+        $this->expectException(CircularReference::class);
+
+        $class->getMethods();
+    }
+
+    /** @dataProvider traitUseCircularReferencesProvider */
+    public function testGetPropertiesFailsWithCircularReference(string $className): void
+    {
+        $reflector = new DefaultReflector(new SingleFileSourceLocator(
+            __DIR__ . '/../Fixture/InvalidTraitUses.php',
+            $this->astLocator,
+        ));
+
+        $class = $reflector->reflectClass($className);
+
+        $this->expectException(CircularReference::class);
+
+        $class->getProperties();
+    }
 }

--- a/test/unit/Reflection/ReflectionClassTest.php
+++ b/test/unit/Reflection/ReflectionClassTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Roave\BetterReflectionTest\Reflection;
 
+use ArrayIterator;
 use BackedEnum;
 use Bar;
 use Baz;
@@ -36,6 +37,7 @@ use Roave\BetterReflection\SourceLocator\Ast\Locator;
 use Roave\BetterReflection\SourceLocator\Located\LocatedSource;
 use Roave\BetterReflection\SourceLocator\Type\AggregateSourceLocator;
 use Roave\BetterReflection\SourceLocator\Type\ComposerSourceLocator;
+use Roave\BetterReflection\SourceLocator\Type\FileIteratorSourceLocator;
 use Roave\BetterReflection\SourceLocator\Type\MemoizingSourceLocator;
 use Roave\BetterReflection\SourceLocator\Type\SingleFileSourceLocator;
 use Roave\BetterReflection\SourceLocator\Type\StringSourceLocator;
@@ -79,6 +81,7 @@ use Roave\BetterReflectionTest\Fixture\StaticPropertyGetSet;
 use Roave\BetterReflectionTest\Fixture\StringEnum;
 use Roave\BetterReflectionTest\Fixture\UpperCaseConstructDestruct;
 use Roave\BetterReflectionTest\FixtureOther\AnotherClass;
+use SplFileInfo;
 use stdClass;
 use Stringable;
 use TypeError;
@@ -2675,11 +2678,19 @@ PHP;
         ];
     }
 
-    /** @dataProvider traitUseCircularReferencesProvider */
+    /**
+     * @dataProvider interfaceExtendsCircularReferencesProvider
+     * @dataProvider circularReferencesProvider
+     * @dataProvider traitUseCircularReferencesProvider
+     */
     public function testGetConstantsFailsWithCircularReference(string $className): void
     {
-        $reflector = new DefaultReflector(new SingleFileSourceLocator(
-            __DIR__ . '/../Fixture/InvalidTraitUses.php',
+        $reflector = new DefaultReflector(new FileIteratorSourceLocator(
+            new ArrayIterator([
+                new SplFileInfo(__DIR__ . '/../Fixture/InvalidInterfaceParents.php'),
+                new SplFileInfo(__DIR__ . '/../Fixture/InvalidParents.php'),
+                new SplFileInfo(__DIR__ . '/../Fixture/InvalidTraitUses.php'),
+            ]),
             $this->astLocator,
         ));
 
@@ -2690,11 +2701,19 @@ PHP;
         $class->getConstants();
     }
 
-    /** @dataProvider traitUseCircularReferencesProvider */
+    /**
+     * @dataProvider interfaceExtendsCircularReferencesProvider
+     * @dataProvider circularReferencesProvider
+     * @dataProvider traitUseCircularReferencesProvider
+     */
     public function testGetMethodsFailsWithCircularReference(string $className): void
     {
-        $reflector = new DefaultReflector(new SingleFileSourceLocator(
-            __DIR__ . '/../Fixture/InvalidTraitUses.php',
+        $reflector = new DefaultReflector(new FileIteratorSourceLocator(
+            new ArrayIterator([
+                new SplFileInfo(__DIR__ . '/../Fixture/InvalidInterfaceParents.php'),
+                new SplFileInfo(__DIR__ . '/../Fixture/InvalidParents.php'),
+                new SplFileInfo(__DIR__ . '/../Fixture/InvalidTraitUses.php'),
+            ]),
             $this->astLocator,
         ));
 
@@ -2705,11 +2724,19 @@ PHP;
         $class->getMethods();
     }
 
-    /** @dataProvider traitUseCircularReferencesProvider */
+    /**
+     * @dataProvider interfaceExtendsCircularReferencesProvider
+     * @dataProvider circularReferencesProvider
+     * @dataProvider traitUseCircularReferencesProvider
+     */
     public function testGetPropertiesFailsWithCircularReference(string $className): void
     {
-        $reflector = new DefaultReflector(new SingleFileSourceLocator(
-            __DIR__ . '/../Fixture/InvalidTraitUses.php',
+        $reflector = new DefaultReflector(new FileIteratorSourceLocator(
+            new ArrayIterator([
+                new SplFileInfo(__DIR__ . '/../Fixture/InvalidInterfaceParents.php'),
+                new SplFileInfo(__DIR__ . '/../Fixture/InvalidParents.php'),
+                new SplFileInfo(__DIR__ . '/../Fixture/InvalidTraitUses.php'),
+            ]),
             $this->astLocator,
         ));
 

--- a/test/unit/Reflection/Support/AlreadyVisitedClassesTest.php
+++ b/test/unit/Reflection/Support/AlreadyVisitedClassesTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Roave\BetterReflectionTest\Reflection\Support;
+
+use PHPUnit\Framework\TestCase;
+use Roave\BetterReflection\Reflection\Exception\CircularReference;
+use Roave\BetterReflection\Reflection\Support\AlreadyVisitedClasses;
+
+/** @covers \Roave\BetterReflection\Reflection\Support\AlreadyVisitedClasses */
+class AlreadyVisitedClassesTest extends TestCase
+{
+    public function testPushFailsWithCircularReference(): void
+    {
+        $alreadyVisitedClasses = AlreadyVisitedClasses::createEmpty();
+
+        $alreadyVisitedClasses->push('foo');
+        $alreadyVisitedClasses->push('bar');
+
+        $this->expectException(CircularReference::class);
+        $alreadyVisitedClasses->push('foo');
+    }
+}


### PR DESCRIPTION
Closes https://github.com/Roave/BetterReflection/issues/1242

3 times the charm :)

This one should be better. It should not add performance overhead. But it adds a bit of complexity of course and those private helper methods to "hide" the classNameStack reference from the API.