### PR TITLE
Optimisations of getting methods, properties and constants in `ReflectionClass`

### DIFF
--- a/src/Reflection/ReflectionClass.php
+++ b/src/Reflection/ReflectionClass.php
@@ -1636,7 +1636,8 @@ class ReflectionClass implements Reflection
         /** @var array<class-string, self> $interfaces */
         $interfaces = [$interfaceClassName => $this];
         foreach ($this->getImmediateInterfaces() as $interface) {
-            foreach ($interface->getInterfacesHierarchy(clone $alreadyVisitedClassesCopy) as $extendedInterfaceName => $extendedInterface) {
+            $alreadyVisitedClassesCopyForInterface = clone $alreadyVisitedClassesCopy;
+            foreach ($interface->getInterfacesHierarchy($alreadyVisitedClassesCopyForInterface) as $extendedInterfaceName => $extendedInterface) {
                 $interfaces[$extendedInterfaceName] = $extendedInterface;
             }
         }


### PR DESCRIPTION
`foreach` is not so elegant as `array_map` but it should be less memory and time consuming - probably more in real application.

For example:

```php
class ParentClass
{
    public function method() {}
}

class CurrentClass extends ParentClass
{
    public function method() {}
}
```

**Before**

1. We get methods for `CurrentClass` and for `ParentClass` - we even clone the method in `ParentClass` with `withCurrentClass()`
2. Then we merge methods and throw the parent method clone away.

**After**

1. We get methods for `CurrentClass`
2. We don't get the parent method because we already have method with the same name.