### PR TITLE
Optimisation of getting methods, properties and constants from interfaces

### DIFF
--- a/src/Reflection/ReflectionClass.php
+++ b/src/Reflection/ReflectionClass.php
@@ -396,8 +396,8 @@ class ReflectionClass implements Reflection
         return array_merge(
             [],
             ...array_map(
-                static fn (ReflectionClass $ancestor): array => array_values($ancestor->getMethodsIndexedByLowercasedName($alreadyVisitedClasses)),
-                array_values($this->getCurrentClassImplementedInterfacesIndexedByName()),
+                static fn (ReflectionClass $ancestor): array => array_values($ancestor->getMethodsIndexedByLowercasedName(clone $alreadyVisitedClasses)),
+                array_values($this->getImmediateInterfaces()),
             ),
         );
     }
@@ -428,7 +428,7 @@ class ReflectionClass implements Reflection
         $className        = $this->getName();
         $parentMethods    = $this->getParentMethods(AlreadyVisitedClasses::createEmpty());
         $traitsMethods    = $this->getMethodsFromTraits($alreadyVisitedClasses);
-        $interfaceMethods = $this->getMethodsFromInterfaces(AlreadyVisitedClasses::createEmpty());
+        $interfaceMethods = $this->getMethodsFromInterfaces($alreadyVisitedClasses);
 
         $methods = [];
 
@@ -729,8 +729,8 @@ class ReflectionClass implements Reflection
                     $this->getTraits(),
                 ),
                 ...array_map(
-                    static fn (ReflectionClass $interface): array => array_values($interface->getConstantsConsideringAlreadyVisitedClasses(0, AlreadyVisitedClasses::createEmpty())),
-                    array_values($this->getCurrentClassImplementedInterfacesIndexedByName()),
+                    static fn (ReflectionClass $interface): array => array_values($interface->getConstantsConsideringAlreadyVisitedClasses(0, clone $alreadyVisitedClasses)),
+                    array_values($this->getImmediateInterfaces()),
                 ),
             );
 
@@ -930,10 +930,10 @@ class ReflectionClass implements Reflection
             $this->cachedProperties = array_merge(
                 array_merge(
                     [],
-                    $this->getParentClass()?->getPropertiesConsideringAlreadyVisitedClasses(ReflectionPropertyAdapter::IS_PUBLIC | ReflectionPropertyAdapter::IS_PROTECTED, AlreadyVisitedClasses::createEmpty()) ?? [],
+                    $this->getParentClass()?->getPropertiesConsideringAlreadyVisitedClasses(ReflectionPropertyAdapter::IS_PUBLIC | ReflectionPropertyAdapter::IS_PROTECTED, $alreadyVisitedClasses) ?? [],
                     ...array_map(
-                        static fn (ReflectionClass $ancestor): array => $ancestor->getPropertiesConsideringAlreadyVisitedClasses(ReflectionPropertyAdapter::IS_PUBLIC, AlreadyVisitedClasses::createEmpty()),
-                        array_values($this->getCurrentClassImplementedInterfacesIndexedByName()),
+                        static fn (ReflectionClass $ancestor): array => $ancestor->getPropertiesConsideringAlreadyVisitedClasses(ReflectionPropertyAdapter::IS_PUBLIC, clone $alreadyVisitedClasses),
+                        array_values($this->getImmediateInterfaces()),
                     ),
                     ...array_map(
                         function (ReflectionClass $trait) use ($alreadyVisitedClasses) {

--- a/test/unit/Fixture/InheritedClassConstants.php
+++ b/test/unit/Fixture/InheritedClassConstants.php
@@ -4,11 +4,11 @@ interface Foo {
     const A = 'a';
 }
 
-interface Boo {
+interface Boo extends Foo {
     public const B = 'b';
 }
 
-interface Coo {
+interface Coo extends Foo {
     public const B = 'wrong-b';
 }
 

--- a/test/unit/Fixture/InheritedClassMethods.php
+++ b/test/unit/Fixture/InheritedClassMethods.php
@@ -4,11 +4,14 @@ interface Foo {
     public function a();
 }
 
+interface Boo extends Foo
+{}
+
 trait Bar {
     public function b() {}
 }
 
-class Baz {
+class Baz implements Foo {
     public function c() {}
 
     protected function d() {}
@@ -16,7 +19,7 @@ class Baz {
     private function e() {}
 }
 
-abstract class Qux extends Baz implements Foo {
+abstract class Qux extends Baz implements Foo, Boo {
     use Bar;
     public function f() {}
 }


### PR DESCRIPTION
We can check only immediate interfaces because other interfaces are already processed in parent classes