### PR TITLE
Configure config.platform.php in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -63,6 +63,9 @@
         "allow-plugins": {
             "dealerdirect/phpcodesniffer-composer-installer": true,
             "infection/extension-installer": false
+        },
+        "platform": {
+            "php": "8.0.99"
         }
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "816a0134f5bf3d0ffd70607971662321",
+    "content-hash": "f3243beb23c9b0f80e0c57991a469d9f",
     "packages": [
         {
             "name": "jetbrains/phpstorm-stubs",
@@ -5143,5 +5143,8 @@
         "ext-json": "*"
     },
     "platform-dev": [],
+    "platform-overrides": {
+        "php": "8.0.99"
+    },
     "plugin-api-version": "2.3.0"
 }


### PR DESCRIPTION
should fix Renovate PRs, see https://github.com/Roave/BetterReflection/pull/1305#issuecomment-1301884370

btw., I'm opening this to basically ask (getting more Marco consulting for free hehehe) :D this is normal Composer behaviour, right? I never had to support multiple PHP versions until recently and it surprised me that running `composer update` with e.g. PHP 8.1 creates a lockfile that is not compatible with the virtual `php` dependency in composer.json (like PHP 8 here) :/