### PR TITLE
Fixed adapter `ReflectionMethod::getStartLine()` and `getEndLine()` when code location is missing

### DIFF
--- a/src/Reflection/Adapter/ReflectionMethod.php
+++ b/src/Reflection/Adapter/ReflectionMethod.php
@@ -12,6 +12,7 @@ use ReflectionExtension as CoreReflectionExtension;
 use ReflectionMethod as CoreReflectionMethod;
 use ReflectionType as CoreReflectionType;
 use Roave\BetterReflection\Reflection\Adapter\Exception\NotImplemented;
+use Roave\BetterReflection\Reflection\Exception\CodeLocationMissing;
 use Roave\BetterReflection\Reflection\Exception\MethodPrototypeNotFound;
 use Roave\BetterReflection\Reflection\Exception\NoObjectProvided;
 use Roave\BetterReflection\Reflection\ReflectionAttribute as BetterReflectionAttribute;
@@ -84,12 +85,20 @@ final class ReflectionMethod extends CoreReflectionMethod
 
     public function getStartLine(): int|false
     {
-        return $this->betterReflectionMethod->getStartLine();
+        try {
+            return $this->betterReflectionMethod->getStartLine();
+        } catch (CodeLocationMissing) {
+            return false;
+        }
     }
 
     public function getEndLine(): int|false
     {
-        return $this->betterReflectionMethod->getEndLine();
+        try {
+            return $this->betterReflectionMethod->getEndLine();
+        } catch (CodeLocationMissing) {
+            return false;
+        }
     }
 
     /** @psalm-suppress ImplementedReturnTypeMismatch */

--- a/test/unit/Reflection/Adapter/ReflectionMethodTest.php
+++ b/test/unit/Reflection/Adapter/ReflectionMethodTest.php
@@ -15,6 +15,7 @@ use Roave\BetterReflection\Reflection\Adapter\ReflectionClass as ReflectionClass
 use Roave\BetterReflection\Reflection\Adapter\ReflectionMethod as ReflectionMethodAdapter;
 use Roave\BetterReflection\Reflection\Adapter\ReflectionNamedType as ReflectionNamedTypeAdapter;
 use Roave\BetterReflection\Reflection\Adapter\ReflectionParameter as ReflectionParameterAdapter;
+use Roave\BetterReflection\Reflection\Exception\CodeLocationMissing;
 use Roave\BetterReflection\Reflection\Exception\MethodPrototypeNotFound;
 use Roave\BetterReflection\Reflection\Exception\NoObjectProvided;
 use Roave\BetterReflection\Reflection\Exception\ObjectNotInstanceOfClass;
@@ -585,5 +586,29 @@ class ReflectionMethodTest extends TestCase
         $reflectionMethodAdapter = new ReflectionMethodAdapter($betterReflectionMethod);
 
         self::assertFalse($reflectionMethodAdapter->hasPrototype());
+    }
+
+    public function testGetStartLineReturnsFalseWhenLocationMissing(): void
+    {
+        $betterReflectionMethod = $this->createMock(BetterReflectionMethod::class);
+        $betterReflectionMethod
+            ->method('getStartLine')
+            ->willThrowException(new CodeLocationMissing());
+
+        $reflectionMethodAdapter = new ReflectionMethodAdapter($betterReflectionMethod);
+
+        self::assertFalse($reflectionMethodAdapter->getStartLine());
+    }
+
+    public function testGetEndLineReturnsFalseWhenLocationMissing(): void
+    {
+        $betterReflectionMethod = $this->createMock(BetterReflectionMethod::class);
+        $betterReflectionMethod
+            ->method('getEndLine')
+            ->willThrowException(new CodeLocationMissing());
+
+        $reflectionMethodAdapter = new ReflectionMethodAdapter($betterReflectionMethod);
+
+        self::assertFalse($reflectionMethodAdapter->getEndLine());
     }
 }


### PR DESCRIPTION
Eg. for `Enum::cases()` method.

Fixes https://github.com/Roave/BetterReflection/issues/1309

`ReflectionProperty` or `ReflectionParameter` don't have `getStartLine()` and `getEndLine()` methods.