### PR TITLE
Fix typo in phpdoc of method that should be `@internal`

### DIFF
--- a/src/Reflection/ReflectionAttribute.php
+++ b/src/Reflection/ReflectionAttribute.php
@@ -39,7 +39,7 @@ class ReflectionAttribute
         }
     }
 
-    /** @interal */
+    /** @internal */
     public function withOwner(ReflectionClass|ReflectionMethod|ReflectionFunction|ReflectionClassConstant|ReflectionEnumCase|ReflectionProperty|ReflectionParameter $owner): self
     {
         $clone        = clone $this;


### PR DESCRIPTION
I am annoyed that my phpstorm autocompletes always `@interal` instead of `@internal`