### PR TITLE
Infection: raise timeout for mutants from 10 to 60 seconds

### DIFF
--- a/infection.json.dist
+++ b/infection.json.dist
@@ -4,6 +4,7 @@
             "src"
         ]
     },
+    "timeout": 60,
     "logs": {
         "text": "php:\/\/stderr",
         "stryker": {


### PR DESCRIPTION
The current 10 seconds timeout hides mutants that in reality are escaping if we raise it to just 60 seconds:

```
3676 mutations were generated:
    3607 mutants were killed
       0 mutants were configured to be ignored
       3 mutants were not covered by tests
      38 covered mutants were not detected
      14 errors were encountered
       0 syntax errors were encountered
      14 time outs were encountered
       0 mutants required more time than configured

Metrics:
         Mutation Score Indicator (MSI): 98%
         Mutation Code Coverage: 99%
         Covered Code MSI: 98%
```

/cc @kukulich 