### PR TITLE
`iterable` is really no interface

### DIFF
--- a/src/SourceLocator/SourceStubber/PhpStormStubsSourceStubber.php
+++ b/src/SourceLocator/SourceStubber/PhpStormStubsSourceStubber.php
@@ -206,6 +206,10 @@ final class PhpStormStubsSourceStubber implements SourceStubber
     /** @param class-string|trait-string $className */
     public function generateClassStub(string $className): StubData|null
     {
+        if (strtolower($className) === 'iterable') {
+            return null;
+        }
+
         $classNodeData = $this->getClassNodeData($className);
 
         if ($classNodeData === null) {

--- a/test/unit/SourceLocator/SourceStubber/PhpStormStubsSourceStubberTest.php
+++ b/test/unit/SourceLocator/SourceStubber/PhpStormStubsSourceStubberTest.php
@@ -1217,4 +1217,22 @@ class PhpStormStubsSourceStubberTest extends TestCase
 
         self::assertTrue($class->isSubclassOf($subclassName));
     }
+
+    /** @return list<array{0: class-string}> */
+    public static function dataIterable(): array
+    {
+        return [
+            ['iterable'],
+            ['Iterable'],
+            ['ItErAbLe'],
+        ];
+    }
+
+    #[DataProvider('dataIterable')]
+    public function testIterableInterfaceDoesNotExist(string $className): void
+    {
+        $stub = $this->sourceStubber->generateClassStub($className);
+
+        self::assertNull($stub);
+    }
 }


### PR DESCRIPTION
It's only hack in PhpStorm stubs: https://github.com/JetBrains/phpstorm-stubs/commit/0778a26992c47d7dbee4d0b0bfb7fad4344371b1#diff-575bacb45377d474336c71cbf53c1729

cc @ondrejmirtes 