### PR TITLE
Remove slow `assertReadableFile()` check

### DIFF
--- a/src/SourceLocator/Located/LocatedSource.php
+++ b/src/SourceLocator/Located/LocatedSource.php
@@ -6,7 +6,6 @@ namespace Roave\BetterReflection\SourceLocator\Located;
 
 use InvalidArgumentException;
 use Roave\BetterReflection\SourceLocator\Exception\InvalidFileLocation;
-use Roave\BetterReflection\SourceLocator\FileChecker;
 use Roave\BetterReflection\Util\FileHelper;
 
 use function assert;
@@ -31,8 +30,6 @@ class LocatedSource
     {
         if ($filename !== null) {
             assert($filename !== '');
-
-            FileChecker::assertReadableFile($filename);
 
             $filename = FileHelper::normalizeWindowsPath($filename);
         }

--- a/test/unit/SourceLocator/Located/LocatedSourceTest.php
+++ b/test/unit/SourceLocator/Located/LocatedSourceTest.php
@@ -6,7 +6,6 @@ namespace Roave\BetterReflectionTest\SourceLocator\Located;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
-use Roave\BetterReflection\SourceLocator\Exception\InvalidFileLocation;
 use Roave\BetterReflection\SourceLocator\Located\LocatedSource;
 use Roave\BetterReflection\Util\FileHelper;
 
@@ -49,11 +48,5 @@ class LocatedSourceTest extends TestCase
         $file          = null;
         $locatedSource = new LocatedSource($source, 'name', $file);
         self::assertSame('', $locatedSource->getSource());
-    }
-
-    public function testThrowsExceptionIfFileIsNotReadable(): void
-    {
-        $this->expectException(InvalidFileLocation::class);
-        new LocatedSource('<?php echo "Hello world";', 'name', 'not-readable.php');
     }
 }


### PR DESCRIPTION
this line showed up in my profilling and I realized most call-sites already do file-IO on the given filename before creating a `LocatedSource`, e.g.

- https://github.com/Roave/BetterReflection/blob/6b5cd7f7f68110d08f89644416d4911aff8f1b3e/src/SourceLocator/Type/AnonymousClassObjectSourceLocator.php#L123
- https://github.com/Roave/BetterReflection/blob/6b5cd7f7f68110d08f89644416d4911aff8f1b3e/src/SourceLocator/Type/AutoloadSourceLocator.php#L90-L103
- https://github.com/Roave/BetterReflection/blob/6b5cd7f7f68110d08f89644416d4911aff8f1b3e/src/SourceLocator/Type/SingleFileSourceLocator.php#L46-L50

![grafik](https://github.com/Roave/BetterReflection/assets/120441/950c1591-1c25-45de-8f2f-156dee0e3f1d)
