### PR TITLE
Implement `ReflectionClass->getParentClassName()`

### DIFF
--- a/src/Reflection/Adapter/ReflectionClass.php
+++ b/src/Reflection/Adapter/ReflectionClass.php
@@ -452,6 +452,14 @@ final class ReflectionClass extends CoreReflectionClass
         throw new Exception\NotImplemented('Not implemented');
     }
 
+    /**
+     * @return class-string|null
+     */
+    public function getParentClassName(): ?string
+    {
+        return $this->betterReflectionClass->getParentClassName();
+    }
+
     /** @psalm-mutation-free */
     public function getParentClass(): ReflectionClass|false
     {

--- a/src/Reflection/Adapter/ReflectionClass.php
+++ b/src/Reflection/Adapter/ReflectionClass.php
@@ -452,14 +452,6 @@ final class ReflectionClass extends CoreReflectionClass
         throw new Exception\NotImplemented('Not implemented');
     }
 
-    /**
-     * @return class-string|null
-     */
-    public function getParentClassName(): ?string
-    {
-        return $this->betterReflectionClass->getParentClassName();
-    }
-
     /** @psalm-mutation-free */
     public function getParentClass(): ReflectionClass|false
     {

--- a/src/Reflection/ReflectionClass.php
+++ b/src/Reflection/ReflectionClass.php
@@ -319,13 +319,11 @@ class ReflectionClass implements Reflection
         return $this->name;
     }
 
-	/**
-	 * @return class-string|null
-	 */
-	public function getParentClassName(): ?string
-	{
-		return $this->parentClassName;
-	}
+    /** @return class-string|null */
+    public function getParentClassName(): string|null
+    {
+        return $this->parentClassName;
+    }
 
     /**
      * Get the "namespace" name of the class (e.g. for A\B\Foo, this will

--- a/src/Reflection/ReflectionClass.php
+++ b/src/Reflection/ReflectionClass.php
@@ -101,7 +101,7 @@ class ReflectionClass implements Reflection
     private int $endColumn;
 
     /** @var class-string|null */
-    private string|null $parentClassName;
+    private string|null $parentClassName = null;
 
     /** @var list<class-string> */
     private array $implementsClassNames;
@@ -325,7 +325,7 @@ class ReflectionClass implements Reflection
 	public function getParentClassName(): ?string
 	{
 		return $this->parentClassName;
-	}    
+	}
 
     /**
      * Get the "namespace" name of the class (e.g. for A\B\Foo, this will

--- a/src/Reflection/ReflectionClass.php
+++ b/src/Reflection/ReflectionClass.php
@@ -101,7 +101,7 @@ class ReflectionClass implements Reflection
     private int $endColumn;
 
     /** @var class-string|null */
-    private string|null $parentClassName = null;
+    private string|null $parentClassName;
 
     /** @var list<class-string> */
     private array $implementsClassNames;

--- a/src/Reflection/ReflectionClass.php
+++ b/src/Reflection/ReflectionClass.php
@@ -319,6 +319,14 @@ class ReflectionClass implements Reflection
         return $this->name;
     }
 
+	/**
+	 * @return class-string|null
+	 */
+	public function getParentClassName(): ?string
+	{
+		return $this->parentClassName;
+	}    
+
     /**
      * Get the "namespace" name of the class (e.g. for A\B\Foo, this will
      * return "A\B").

--- a/src/Reflection/ReflectionObject.php
+++ b/src/Reflection/ReflectionObject.php
@@ -294,6 +294,12 @@ class ReflectionObject extends ReflectionClass
         return $this->reflectionClass->getParentClass();
     }
 
+    /** @return class-string|null */
+    public function getParentClassName(): string|null
+    {
+        return $this->reflectionClass->getParentClassName();
+    }
+
     /**
      * {@inheritDoc}
      */

--- a/test/unit/Reflection/ReflectionClassTest.php
+++ b/test/unit/Reflection/ReflectionClassTest.php
@@ -402,6 +402,27 @@ class ReflectionClassTest extends TestCase
         $classInfo->getMethods();
     }
 
+    public function testGetParentClassNameWithMissingParent(): void
+    {
+        $classInfo = (new DefaultReflector(new SingleFileSourceLocator(
+            __DIR__ . '/../Fixture/ClassWithMissingParent.php',
+            $this->astLocator,
+        )))->reflectClass(ClassWithMissingParent::class);
+
+        self::assertSame('Roave\BetterReflectionTest\Fixture\ParentThatDoesNotExist', $classInfo->getParentClassName());
+    }
+
+    public function testGetParentClassWithMissingParent(): void
+    {
+        $classInfo = (new DefaultReflector(new SingleFileSourceLocator(
+            __DIR__ . '/../Fixture/ClassWithMissingParent.php',
+            $this->astLocator,
+        )))->reflectClass(ClassWithMissingParent::class);
+
+        $this->expectException(IdentifierNotFound::class);
+        self::assertNull($classInfo->getParentClass());
+    }
+
     public function testGetMethodsOrder(): void
     {
         $classInfo = (new DefaultReflector(new SingleFileSourceLocator(

--- a/test/unit/Reflection/ReflectionClassTest.php
+++ b/test/unit/Reflection/ReflectionClassTest.php
@@ -409,6 +409,7 @@ class ReflectionClassTest extends TestCase
             $this->astLocator,
         )))->reflectClass(ClassWithMissingParent::class);
 
+        self::assertNotNull($classInfo->getParentClassName());
         self::assertSame('Roave\BetterReflectionTest\Fixture\ParentThatDoesNotExist', $classInfo->getParentClassName());
     }
 
@@ -420,7 +421,8 @@ class ReflectionClassTest extends TestCase
         )))->reflectClass(ClassWithMissingParent::class);
 
         $this->expectException(IdentifierNotFound::class);
-        self::assertNull($classInfo->getParentClass());
+
+        $classInfo->getParentClass();
     }
 
     public function testGetMethodsOrder(): void


### PR DESCRIPTION
A class can declare a parent which we cannot locate via autoloading mechanics.
For some static analysis cases its still useful to know, whether a parent class is defined - even if we can't reflect on it for some reason.

I was not able to find a API which allows me to dermine whether a class has a parent declared but only BetterReflection cannot find its definition from whether there is no parent class declared at all.

Before this PR we had to use reflection hacks to get the private property out of the class, see  https://github.com/rectorphp/rector/issues/8093#issuecomment-1657057947