### PR TITLE
Implement `ReflectionClass#getInterfaceClassNames()`

### DIFF
--- a/src/Reflection/ReflectionClass.php
+++ b/src/Reflection/ReflectionClass.php
@@ -1448,6 +1448,12 @@ class ReflectionClass implements Reflection
         );
     }
 
+    /** @return list<class-string> */
+    public function getInterfaceClassNames(): array
+    {
+        return $this->implementsClassNames;
+    }
+
     /**
      * Gets the interfaces.
      *

--- a/src/Reflection/ReflectionObject.php
+++ b/src/Reflection/ReflectionObject.php
@@ -391,6 +391,14 @@ class ReflectionObject extends ReflectionClass
     /**
      * {@inheritDoc}
      */
+    public function getInterfaceClassNames(): array
+    {
+        return $this->reflectionClass->getInterfaceClassNames();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public function getInterfaces(): array
     {
         return $this->reflectionClass->getInterfaces();

--- a/test/unit/Fixture/ClassWithMissingInterface.php
+++ b/test/unit/Fixture/ClassWithMissingInterface.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Roave\BetterReflectionTest\Fixture;
+
+class ClassWithMissingInterface implements InterfaceThatDoesNotExist
+{
+
+}


### PR DESCRIPTION
same motivation as in https://github.com/Roave/BetterReflection/pull/1359, but this time for interfaces :-)

refs https://github.com/rectorphp/rector/issues/8093#issuecomment-1657057947

---

if we agree on this one, I should do another PR for `traits` as a followup