### PR TITLE
micro-optimization: use `spl_object_id()` instead of `spl_object_hash()`

### DIFF
--- a/src/SourceLocator/Type/MemoizingSourceLocator.php
+++ b/src/SourceLocator/Type/MemoizingSourceLocator.php
@@ -52,7 +52,7 @@ final class MemoizingSourceLocator implements SourceLocator
 
     private function reflectorCacheKey(Reflector $reflector): string
     {
-        return sprintf('type:%s#oid:%s', $reflector::class, spl_object_id($reflector));
+        return sprintf('type:%s#oid:%d', $reflector::class, spl_object_id($reflector));
     }
 
     private function identifierToCacheKey(Identifier $identifier): string

--- a/src/SourceLocator/Type/MemoizingSourceLocator.php
+++ b/src/SourceLocator/Type/MemoizingSourceLocator.php
@@ -10,7 +10,7 @@ use Roave\BetterReflection\Reflection\Reflection;
 use Roave\BetterReflection\Reflector\Reflector;
 
 use function array_key_exists;
-use function spl_object_hash;
+use function spl_object_id;
 use function sprintf;
 
 final class MemoizingSourceLocator implements SourceLocator
@@ -52,7 +52,7 @@ final class MemoizingSourceLocator implements SourceLocator
 
     private function reflectorCacheKey(Reflector $reflector): string
     {
-        return sprintf('type:%s#oid:%s', $reflector::class, spl_object_hash($reflector));
+        return sprintf('type:%s#oid:%s', $reflector::class, spl_object_id($reflector));
     }
 
     private function identifierToCacheKey(Identifier $identifier): string

--- a/test/unit/SourceLocator/Ast/Parser/MemoizingParserTest.php
+++ b/test/unit/SourceLocator/Ast/Parser/MemoizingParserTest.php
@@ -16,7 +16,7 @@ use function array_map;
 use function array_unique;
 use function count;
 use function range;
-use function spl_object_hash;
+use function spl_object_id;
 use function uniqid;
 
 #[CoversClass(MemoizingParser::class)]
@@ -50,7 +50,7 @@ class MemoizingParserTest extends TestCase
         }
 
         $nodeIdentifiers = array_map(
-            static fn (array $nodes): string => spl_object_hash($nodes[0]),
+            static fn (array $nodes): int => spl_object_id($nodes[0]),
             $producedNodes,
         );
 

--- a/test/unit/SourceLocator/Type/MemoizingSourceLocatorTest.php
+++ b/test/unit/SourceLocator/Type/MemoizingSourceLocatorTest.php
@@ -22,7 +22,7 @@ use function count;
 use function in_array;
 use function random_int;
 use function range;
-use function spl_object_hash;
+use function spl_object_id;
 use function uniqid;
 
 #[CoversClass(MemoizingSourceLocator::class)]
@@ -189,8 +189,8 @@ class MemoizingSourceLocatorTest extends TestCase
             ) use (
                 &$fetchedSymbolsCount,
             ): Reflection|null {
-                $identifierId = spl_object_hash($identifier);
-                $reflectorId  = spl_object_hash($reflector);
+                $identifierId = spl_object_id($identifier);
+                $reflectorId  = spl_object_id($reflector);
                 $hash         = $reflectorId . $identifierId;
 
                 $fetchedSymbolsCount[$hash] = ($fetchedSymbolsCount[$hash] ?? 0) + 1;
@@ -212,7 +212,7 @@ class MemoizingSourceLocatorTest extends TestCase
 
         self::assertSame($memoizedSymbols, $cachedSymbols);
 
-        $memoizedSymbolsIds = array_map('spl_object_hash', array_filter($memoizedSymbols));
+        $memoizedSymbolsIds = array_map('spl_object_id', array_filter($memoizedSymbols));
         self::assertCount(count($memoizedSymbolsIds), array_unique($memoizedSymbolsIds), 'No duplicate symbols');
     }
 


### PR DESCRIPTION
`spl_object_id()` exists since php 7.2, I think we can use it over `spl_object_id()`.

rector and wordpress [micro benchmarks suggests](https://github.com/rectorphp/rector-src/pull/4876) its faster