### PR TITLE
Remove @internal from LocatedSource.php

### DIFF
--- a/src/SourceLocator/Located/LocatedSource.php
+++ b/src/SourceLocator/Located/LocatedSource.php
@@ -13,8 +13,6 @@ use function assert;
 /**
  * Value object containing source code that has been located.
  *
- * @internal
- *
  * @psalm-immutable
  */
 class LocatedSource


### PR DESCRIPTION
While `Roave\BetterReflection\SourceLocator\Type\AbstractSourceLocator` is not marked as `@internal`, it expects a child class to implement the `createLocatedSource()` method.

In turn, the `createLocatedSource()` method has a return type of `Roave\BetterReflection\SourceLocator\Located\LocatedSource|null`, and `Roave\BetterReflection\SourceLocator\Located\LocatedSource` which is marked as `@internal`.

This PR

- Removes the `@internal` from `Roave\BetterReflection\SourceLocator\Located\LocatedSource`'s docblock

This is more like an annoyance, when writing custom source locators that extend from `Roave\BetterReflection\SourceLocator\Type\AbstractSourceLocator`, than an issue, as static analysis flags one is using an internal class.

Feel free to reject this PR, or, maybe, mark `Roave\BetterReflection\SourceLocator\Type\AbstractSourceLocator` as `@internal`, in case this change is not desirable.
