### PR TITLE
Fix `ReflectionEnum::newInstance()` return type

### DIFF
--- a/src/Reflection/Adapter/ReflectionEnum.php
+++ b/src/Reflection/Adapter/ReflectionEnum.php
@@ -361,7 +361,7 @@ final class ReflectionEnum extends CoreReflectionEnum
         return $this->betterReflectionEnum->isInstance($object);
     }
 
-    public function newInstance(mixed ...$args): self
+    public function newInstance(mixed ...$args): object
     {
         throw new Exception\NotImplemented('Not implemented');
     }


### PR DESCRIPTION
PHP does not complain about this (because parent has `object` return type) but it's wrong. I found out about it after introducing generics to ReflectionEnum: https://github.com/phpstan/phpstan-src/commit/9ce8faf53c7a78c7887a2c33f9d34944605d6aae

```
 ------ ------------------------------------------------------------------------- 
  Line   src/Reflection/Adapter/ReflectionEnum.php                                
 ------ ------------------------------------------------------------------------- 
  364    Return type                                                              
         (Roave\BetterReflection\Reflection\Adapter\ReflectionEnum) of method     
         Roave\BetterReflection\Reflection\Adapter\ReflectionEnum::newInstance()  
         should be compatible with return type (UnitEnum) of method               
         ReflectionClass<UnitEnum>::newInstance()                                 
 ------ ------------------------------------------------------------------------- 
```