### PR TITLE
`CompileNodeToValue` allow getting `enum` constant value

### DIFF
--- a/src/NodeCompiler/CompileNodeToValue.php
+++ b/src/NodeCompiler/CompileNodeToValue.php
@@ -245,7 +245,9 @@ class CompileNodeToValue
         $classReflection = $classContext !== null && $classContext->getName() === $className ? $classContext : $context->getReflector()->reflectClass($className);
 
         if ($classReflection instanceof ReflectionEnum) {
-            throw Exception\UnableToCompileNode::becauseOfValueIsEnum($context, $classReflection, $node);
+            if ($classReflection->hasCase($constantName)) {
+                throw Exception\UnableToCompileNode::becauseOfValueIsEnum($context, $classReflection, $node);
+            }
         }
 
         $reflectionConstant = $classReflection->getConstant($constantName);

--- a/test/unit/NodeCompiler/CompileNodeToValueTest.php
+++ b/test/unit/NodeCompiler/CompileNodeToValueTest.php
@@ -764,6 +764,28 @@ PHP;
         $classInfo->getConstant('ONE_VALUE')->getValue();
     }
 
+    public function testEnumConstantValueDoesNotThrowException(): void
+    {
+        $phpCode = <<<'PHP'
+        <?php
+
+        enum Foo: int {
+            const ONE = 1;
+        }
+        class Bat {
+            const ONE_VALUE = Foo::ONE;
+        }
+        PHP;
+
+        $reflector = new DefaultReflector(new AggregateSourceLocator([
+            new StringSourceLocator($phpCode, $this->astLocator),
+            new PhpInternalSourceLocator($this->astLocator, $this->sourceStubber),
+        ]));
+        $classInfo = $reflector->reflectClass('Bat');
+
+        self::assertSame(1, $classInfo->getConstant('ONE_VALUE')->getValue());
+    }
+
     /** @return list<array{0: string, 1: mixed}> */
     public static function magicConstantsWithoutNamespaceProvider(): array
     {


### PR DESCRIPTION
This is a fix for a regression from https://github.com/Roave/BetterReflection/pull/1380.