### PR TITLE
Prevent creation of ReflectionMethod objects

### DIFF
--- a/src/Reflection/ReflectionClass.php
+++ b/src/Reflection/ReflectionClass.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Roave\BetterReflection\Reflection;
 
 use BackedEnum;
+use LogicException;
 use PhpParser\Node;
 use PhpParser\Node\Stmt\Class_ as ClassNode;
 use PhpParser\Node\Stmt\ClassMethod;
@@ -540,12 +541,17 @@ class ReflectionClass implements Reflection
         $methods = [];
 
         foreach ($node->getMethods() as $methodNode) {
-            if (array_key_exists($methodNode->name->toString(), $methods)) {
+            $methodName = $methodNode->name->toString();
+            if ($methodName === '') {
+                throw new LogicException('Method name cannot be empty');
+            }
+
+            if (array_key_exists($methodName, $methods)) {
                 continue;
             }
 
-            $method                                 = ReflectionMethod::createFromNode($reflector, $methodNode, $this->locatedSource, $this->getNamespaceName(), $this, $this, $this);
-            $methods[$methodNode->name->toString()] = $method;
+            $method               = ReflectionMethod::createFromNode($reflector, $methodNode, $this->locatedSource, $this->getNamespaceName(), $this, $this, $this);
+            $methods[$methodName] = $method;
         }
 
         if ($node instanceof EnumNode) {

--- a/src/Reflection/ReflectionClass.php
+++ b/src/Reflection/ReflectionClass.php
@@ -540,17 +540,12 @@ class ReflectionClass implements Reflection
         $methods = [];
 
         foreach ($node->getMethods() as $methodNode) {
-            $method = ReflectionMethod::createFromNode(
-                $reflector,
-                $methodNode,
-                $this->locatedSource,
-                $this->getNamespaceName(),
-                $this,
-                $this,
-                $this,
-            );
+            if (array_key_exists($methodNode->name->toString(), $methods)) {
+                continue;
+            }
 
-            $methods[$method->getName()] = $method;
+			$method = ReflectionMethod::createFromNode($reflector, $methodNode, $this->locatedSource, $this->getNamespaceName(), $this, $this, $this);
+            $methods[$methodNode->name->toString()] = $method;
         }
 
         if ($node instanceof EnumNode) {

--- a/src/Reflection/ReflectionClass.php
+++ b/src/Reflection/ReflectionClass.php
@@ -544,7 +544,7 @@ class ReflectionClass implements Reflection
                 continue;
             }
 
-			$method = ReflectionMethod::createFromNode($reflector, $methodNode, $this->locatedSource, $this->getNamespaceName(), $this, $this, $this);
+            $method                                 = ReflectionMethod::createFromNode($reflector, $methodNode, $this->locatedSource, $this->getNamespaceName(), $this, $this, $this);
             $methods[$methodNode->name->toString()] = $method;
         }
 


### PR DESCRIPTION
while profilling a PHPStan `createImmediateMethods` was showing up.

lets make it more lazy and don't create unnecessary objects

![grafik](https://github.com/Roave/BetterReflection/assets/120441/b1acf339-e3f1-4669-bd7e-83000a9d5ee1)
