### PR TITLE
Implement PHP Version dependent deprecations for constants

### DIFF
--- a/src/SourceLocator/SourceStubber/PhpStormStubsSourceStubber.php
+++ b/src/SourceLocator/SourceStubber/PhpStormStubsSourceStubber.php
@@ -673,7 +673,7 @@ final class PhpStormStubsSourceStubber implements SourceStubber
             return false;
         }
 
-        if (preg_match('#@deprecated (\d+)\.(\d+)(?:\.(\d+)?)$#m', $docComment->getText(), $matches) === 1) {
+        if (preg_match('#@deprecated\s+(\d+)\.(\d+)(?:\.(\d+)?)$#m', $docComment->getText(), $matches) === 1) {
             $major     = $matches[1];
             $minor     = $matches[2];
             $patch     = $matches[3] ?? 0;

--- a/test/unit/SourceLocator/SourceStubber/PhpStormStubsSourceStubberTest.php
+++ b/test/unit/SourceLocator/SourceStubber/PhpStormStubsSourceStubberTest.php
@@ -467,16 +467,24 @@ class PhpStormStubsSourceStubberTest extends TestCase
 
     public function testStubForConstantThatIsDeprecated(): void
     {
-        $stubData = $this->sourceStubber->generateConstantStub('FILTER_SANITIZE_STRING');
+        // use a faked stub to make this test independent of the actual PHP version
+        $exampleStub = <<<'EOT'
+<?php
 
-        self::assertInstanceOf(StubData::class, $stubData);
+/**
+ * ID of "string" filter.
+ * @link https://php.net/manual/en/filter.constants.php
+ * @deprecated 8.1
+ */
+\define('FILTER_SANITIZE_STRING', 513);
+EOT;
+        $stubData    = new StubData($exampleStub, 'filter');
 
         self::assertStringMatchesFormat(
             "%Adefine('FILTER_SANITIZE_STRING',%w%d);",
             $stubData->getStub(),
         );
 
-        // the constant is deprecated as of PHP 8.1
         if (PHP_VERSION_ID >= 80100) {
             self::assertStringContainsString(
                 '@deprecated 8.1',

--- a/test/unit/SourceLocator/SourceStubber/PhpStormStubsSourceStubberTest.php
+++ b/test/unit/SourceLocator/SourceStubber/PhpStormStubsSourceStubberTest.php
@@ -465,6 +465,33 @@ class PhpStormStubsSourceStubberTest extends TestCase
         self::assertSame('Core', $stubData->getExtensionName());
     }
 
+    public function testStubForConstantThatIsDeprecated(): void
+    {
+        $stubData = $this->sourceStubber->generateConstantStub('FILTER_SANITIZE_STRING');
+
+        self::assertInstanceOf(StubData::class, $stubData);
+
+        self::assertStringMatchesFormat(
+            "%Adefine('FILTER_SANITIZE_STRING',%w%d);",
+            $stubData->getStub(),
+        );
+
+        // the constant is deprecated as of PHP 8.1
+        if (PHP_VERSION_ID >= 80100) {
+            self::assertStringContainsString(
+                '@deprecated 8.1',
+                $stubData->getStub(),
+            );
+        } else {
+            self::assertStringNotContainsString(
+                '@deprecated 8.1',
+                $stubData->getStub(),
+            );
+        }
+
+        self::assertSame('filter', $stubData->getExtensionName());
+    }
+
     public function testNoStubForConstantThatDoesNotExist(): void
     {
         self::assertNull($this->sourceStubber->generateConstantStub('SOME_CONSTANT'));


### PR DESCRIPTION
with this PR we strip the `@deprecated` phpdoc tag on constant definitions, in case the current php version does not match the declared min version.

motivation: report deprecation errors for constants only when the phpversion matches the `@deprecated $version`  we find in the jetbrains/phpstorm-stubs in PHPStan

example: https://github.com/JetBrains/phpstorm-stubs/blob/9608c953230b08f07b703ecfe459cc58d5421437/filter/filter.php#L478