### PR TITLE
Added test-case for deprecated phpstorm stub with patch-version

### DIFF
--- a/test/unit/SourceLocator/SourceStubber/PhpStormStubsSourceStubberTest.php
+++ b/test/unit/SourceLocator/SourceStubber/PhpStormStubsSourceStubberTest.php
@@ -501,6 +501,39 @@ EOT;
         self::assertSame('filter', $stubData->getExtensionName());
     }
 
+    public function testStubForConstantThatIsDeprecatedInPatchRelease(): void
+    {
+        // use a faked stub to make this test independent of the actual PHP version
+        $exampleStub = <<<'EOT'
+<?php
+
+/**
+ * @deprecated 8.1.2
+ */
+\define('A_CUSTOM_CONSTANT', 513);
+EOT;
+        $stubData    = new StubData($exampleStub, null);
+
+        self::assertStringMatchesFormat(
+            "%Adefine('A_CUSTOM_CONSTANT',%w%d);",
+            $stubData->getStub(),
+        );
+
+        if (PHP_VERSION_ID >= 80100) {
+            self::assertStringContainsString(
+                '@deprecated 8.1.2',
+                $stubData->getStub(),
+            );
+        } else {
+            self::assertStringNotContainsString(
+                '@deprecated 8.1.2',
+                $stubData->getStub(),
+            );
+        }
+
+        self::assertNull($stubData->getExtensionName());
+    }
+
     public function testNoStubForConstantThatDoesNotExist(): void
     {
         self::assertNull($this->sourceStubber->generateConstantStub('SOME_CONSTANT'));

--- a/test/unit/SourceLocator/SourceStubber/PhpStormStubsSourceStubberTest.php
+++ b/test/unit/SourceLocator/SourceStubber/PhpStormStubsSourceStubberTest.php
@@ -534,6 +534,32 @@ EOT;
         self::assertNull($stubData->getExtensionName());
     }
 
+    public function testStubForConstantThatIsDeprecatedWithUserMessage(): void
+    {
+        // use a faked stub to make this test independent of the actual PHP version
+        $exampleStub = <<<'EOT'
+<?php
+
+/**
+ * @deprecated you should not use it.
+ */
+\define('A_CUSTOM_CONSTANT', 513);
+EOT;
+        $stubData    = new StubData($exampleStub, null);
+
+        self::assertStringMatchesFormat(
+            "%Adefine('A_CUSTOM_CONSTANT',%w%d);",
+            $stubData->getStub(),
+        );
+
+        self::assertStringContainsString(
+            '@deprecated you should not use it.',
+            $stubData->getStub(),
+        );
+
+        self::assertNull($stubData->getExtensionName());
+    }
+
     public function testNoStubForConstantThatDoesNotExist(): void
     {
         self::assertNull($this->sourceStubber->generateConstantStub('SOME_CONSTANT'));

--- a/test/unit/SourceLocator/SourceStubber/PhpStormStubsSourceStubberTest.php
+++ b/test/unit/SourceLocator/SourceStubber/PhpStormStubsSourceStubberTest.php
@@ -560,6 +560,24 @@ EOT;
         self::assertNull($stubData->getExtensionName());
     }
 
+    public function testStubForConstantWithoutPhpdoc(): void
+    {
+        // use a faked stub to make this test independent of the actual PHP version
+        $exampleStub = <<<'EOT'
+<?php
+
+\define('A_CUSTOM_CONSTANT', 513);
+EOT;
+        $stubData    = new StubData($exampleStub, null);
+
+        self::assertStringMatchesFormat(
+            "%Adefine('A_CUSTOM_CONSTANT',%w%d);",
+            $stubData->getStub(),
+        );
+
+        self::assertNull($stubData->getExtensionName());
+    }
+
     public function testNoStubForConstantThatDoesNotExist(): void
     {
         self::assertNull($this->sourceStubber->generateConstantStub('SOME_CONSTANT'));


### PR DESCRIPTION
tests the ternary in https://github.com/Roave/BetterReflection/blob/ab47d0b335a33ac211d5ad8758a48ed6be8622ca/src/SourceLocator/SourceStubber/PhpStormStubsSourceStubber.php#L677 which wasn't covered before