### PR TITLE
Fix php version dependent constant deprecation

### DIFF
--- a/src/SourceLocator/SourceStubber/PhpStormStubsSourceStubber.php
+++ b/src/SourceLocator/SourceStubber/PhpStormStubsSourceStubber.php
@@ -686,7 +686,7 @@ final class PhpStormStubsSourceStubber implements SourceStubber
             return false;
         }
 
-        if (preg_match('#@deprecated\s+(\d+)\.(\d+)(?:\.(\d+)?)$#m', $docComment->getText(), $matches) === 1) {
+        if (preg_match('#@deprecated\s+(\d+)\.(\d+)(?:\.(\d+))?$#m', $docComment->getText(), $matches) === 1) {
             $major     = $matches[1];
             $minor     = $matches[2];
             $patch     = $matches[3] ?? 0;

--- a/test/unit/SourceLocator/SourceStubber/PhpStormStubsSourceStubberTest.php
+++ b/test/unit/SourceLocator/SourceStubber/PhpStormStubsSourceStubberTest.php
@@ -468,37 +468,26 @@ class PhpStormStubsSourceStubberTest extends TestCase
 
     public function testStubForConstantThatIsDeprecated(): void
     {
-        // use a faked stub to make this test independent of the actual PHP version
-        $exampleStub = <<<'EOT'
-<?php
+        $stubData = $this->sourceStubber->generateConstantStub('MT_RAND_PHP');
 
-/**
- * ID of "string" filter.
- * @link https://php.net/manual/en/filter.constants.php
- * @deprecated 8.1
- */
-\define('FILTER_SANITIZE_STRING', 513);
-EOT;
-        $stubData    = new StubData($exampleStub, 'filter');
-
-        self::assertStringMatchesFormat(
-            "%Adefine('FILTER_SANITIZE_STRING',%w%d);",
+        self::assertStringContainsString(
+            'define("MT_RAND_PHP", 1);',
             $stubData->getStub(),
         );
 
-        if (PHP_VERSION_ID >= 80100) {
+        if (PHP_VERSION_ID >= 80300) {
             self::assertStringContainsString(
-                '@deprecated 8.1',
+                '@deprecated 8.3',
                 $stubData->getStub(),
             );
         } else {
             self::assertStringNotContainsString(
-                '@deprecated 8.1',
+                '@deprecated 8.3',
                 $stubData->getStub(),
             );
         }
 
-        self::assertSame('filter', $stubData->getExtensionName());
+        self::assertSame('standard', $stubData->getExtensionName());
     }
 
     public function testNoStubForConstantThatDoesNotExist(): void


### PR DESCRIPTION
the previous test was running against PHP 8.1, which we don't run in CI.
thats the reason why it [did not catch the implementation bug](https://github.com/Roave/BetterReflection/pull/1406#discussion_r1523065225)