### PR TITLE
Improve `ReflectionEnum->getCases()` performance

### DIFF
--- a/src/Reflection/Adapter/ReflectionEnum.php
+++ b/src/Reflection/Adapter/ReflectionEnum.php
@@ -530,14 +530,18 @@ final class ReflectionEnum extends CoreReflectionEnum
     /** @return list<ReflectionEnumUnitCase|ReflectionEnumBackedCase> */
     public function getCases(): array
     {
-        /** @psalm-suppress ImpureFunctionCall */
-        return array_map(function (BetterReflectionEnumCase $case): ReflectionEnumUnitCase|ReflectionEnumBackedCase {
-            if ($this->betterReflectionEnum->isBacked()) {
-                return new ReflectionEnumBackedCase($case);
-            }
+        $cases = array_values($this->betterReflectionEnum->getCases());
 
-            return new ReflectionEnumUnitCase($case);
-        }, array_values($this->betterReflectionEnum->getCases()));
+        $mappedCases = [];
+        foreach ($cases as $case) {
+            if ($this->betterReflectionEnum->isBacked()) {
+                $mappedCases[] = new ReflectionEnumBackedCase($case);
+            } else {
+                $mappedCases[] = new ReflectionEnumUnitCase($case);
+            }
+        }
+
+        return $mappedCases;
     }
 
     public function isBacked(): bool

--- a/src/Reflection/Adapter/ReflectionEnum.php
+++ b/src/Reflection/Adapter/ReflectionEnum.php
@@ -530,7 +530,7 @@ final class ReflectionEnum extends CoreReflectionEnum
     /** @return list<ReflectionEnumUnitCase|ReflectionEnumBackedCase> */
     public function getCases(): array
     {
-        $cases = array_values($this->betterReflectionEnum->getCases());
+        $cases = $this->betterReflectionEnum->getCases();
 
         $mappedCases = [];
         foreach ($cases as $case) {

--- a/src/Reflection/Adapter/ReflectionEnum.php
+++ b/src/Reflection/Adapter/ReflectionEnum.php
@@ -537,11 +537,12 @@ final class ReflectionEnum extends CoreReflectionEnum
             return $this->cases;
         }
 
-        $cases = $this->betterReflectionEnum->getCases();
+        $isBacked = $this->betterReflectionEnum->isBacked();
+        $cases    = $this->betterReflectionEnum->getCases();
 
         $mappedCases = [];
         foreach ($cases as $case) {
-            if ($this->betterReflectionEnum->isBacked()) {
+            if ($isBacked) {
                 $mappedCases[] = new ReflectionEnumBackedCase($case);
             } else {
                 $mappedCases[] = new ReflectionEnumUnitCase($case);

--- a/src/Reflection/Adapter/ReflectionEnum.php
+++ b/src/Reflection/Adapter/ReflectionEnum.php
@@ -33,6 +33,9 @@ use function strtolower;
  */
 final class ReflectionEnum extends CoreReflectionEnum
 {
+    /** @var list<ReflectionEnumUnitCase>|list<ReflectionEnumBackedCase>|null */
+    private array|null $cases = null;
+
     public function __construct(private BetterReflectionEnum $betterReflectionEnum)
     {
         unset($this->name);
@@ -527,9 +530,13 @@ final class ReflectionEnum extends CoreReflectionEnum
         return new ReflectionEnumUnitCase($case);
     }
 
-    /** @return list<ReflectionEnumUnitCase|ReflectionEnumBackedCase> */
+    /** @return list<ReflectionEnumUnitCase>|list<ReflectionEnumBackedCase> */
     public function getCases(): array
     {
+        if ($this->cases !== null) {
+            return $this->cases;
+        }
+
         $cases = $this->betterReflectionEnum->getCases();
 
         $mappedCases = [];
@@ -541,7 +548,7 @@ final class ReflectionEnum extends CoreReflectionEnum
             }
         }
 
-        return $mappedCases;
+        return $this->cases = $mappedCases;
     }
 
     public function isBacked(): bool

--- a/src/Reflection/Adapter/ReflectionEnum.php
+++ b/src/Reflection/Adapter/ReflectionEnum.php
@@ -41,7 +41,7 @@ final class ReflectionEnum extends CoreReflectionEnum
     {
         unset($this->name);
 
-        $this->cases = new Memoize(function() {
+        $this->cases = new Memoize(function () {
             $isBacked = $this->betterReflectionEnum->isBacked();
             $cases    = $this->betterReflectionEnum->getCases();
 
@@ -53,6 +53,7 @@ final class ReflectionEnum extends CoreReflectionEnum
                     $mappedCases[] = new ReflectionEnumUnitCase($case);
                 }
             }
+
             return $mappedCases;
         });
     }
@@ -549,7 +550,7 @@ final class ReflectionEnum extends CoreReflectionEnum
     /** @return list<ReflectionEnumUnitCase>|list<ReflectionEnumBackedCase> */
     public function getCases(): array
     {
-        return $this->cases->memoize();
+        return $this->cases->get();
     }
 
     public function isBacked(): bool

--- a/src/Util/Memoize.php
+++ b/src/Util/Memoize.php
@@ -4,33 +4,25 @@ declare(strict_types=1);
 
 namespace Roave\BetterReflection\Util;
 
-/** @template T */
-final class Memoize {
-    /**
-     * @var T
-     * @psalm-suppress PossiblyNullPropertyAssignmentValue
-     */
-    private mixed $cached = null;
+use Closure;
 
-    /**
-     * @var (callable(): T)|null
-     */
-    private $fn;
+/** * @template T * @internal do not touch: you have been warned. */
+final class Memoize
+{
+    private readonly mixed $cached;
 
-    /** @param callable(): T $fn */
-    public function __construct(callable $fn)
+    /** @param pure-Closure(): T $cb */
+    public function __construct(private Closure|null $cb)
     {
-        $this->fn = $fn;
     }
 
-    /**
-     * @return T
-     */
-    public function memoize(): mixed {
-        if ($this->cached === null && $this->fn !== null) {
-            $this->cached = ($this->fn)();
-            $this->fn = null;
+    public function get(): mixed
+    {
+        if ($this->cb) {
+            $this->cached = ($this->cb)();
+            $this->cb     = null;
         }
+
         return $this->cached;
     }
 }

--- a/src/Util/Memoize.php
+++ b/src/Util/Memoize.php
@@ -16,6 +16,7 @@ final class Memoize
     {
     }
 
+    /** @return T */
     public function get(): mixed
     {
         if ($this->cb) {

--- a/src/Util/Memoize.php
+++ b/src/Util/Memoize.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Roave\BetterReflection\Util;
+
+/** @template T */
+final class Memoize {
+    /**
+     * @var T
+     * @psalm-suppress PossiblyNullPropertyAssignmentValue
+     */
+    private mixed $cached = null;
+
+    /**
+     * @var callable(): T
+     */
+    private  $fn;
+
+    /** @param callable(): T $fn */
+    public function __construct(callable $fn)
+    {
+        $this->fn = $fn;
+    }
+
+    /**
+     * @return T
+     */
+    public function memoize(): mixed {
+        if ($this->cached === null) {
+            $this->cached = ($this->fn)();
+        }
+        return $this->cached;
+    }
+}

--- a/src/Util/Memoize.php
+++ b/src/Util/Memoize.php
@@ -13,9 +13,9 @@ final class Memoize {
     private mixed $cached = null;
 
     /**
-     * @var callable(): T
+     * @var (callable(): T)|null
      */
-    private  $fn;
+    private $fn;
 
     /** @param callable(): T $fn */
     public function __construct(callable $fn)
@@ -27,8 +27,9 @@ final class Memoize {
      * @return T
      */
     public function memoize(): mixed {
-        if ($this->cached === null) {
+        if ($this->cached === null && $this->fn !== null) {
             $this->cached = ($this->fn)();
+            $this->fn = null;
         }
         return $this->cached;
     }


### PR DESCRIPTION
the method is showing up in profiles of https://github.com/phpstan/phpstan/issues/10772
I am aware that this PR will not fix the root cause of the perf problem, but its a low hanging fruit on my way :)

![grafik](https://github.com/Roave/BetterReflection/assets/120441/673d279c-2a7a-4aa1-a759-8bd7e8455501)


lets remove the `array_map` magic and the unnecessary closure invocation
