### PR TITLE
Use static closures where possible

### DIFF
--- a/src/Reflection/ReflectionMethod.php
+++ b/src/Reflection/ReflectionMethod.php
@@ -427,7 +427,7 @@ class ReflectionMethod
         $implementingClassName = $this->getImplementingClass()->getName();
 
         /** @psalm-suppress InvalidStringClass */
-        $closure = Closure::bind(fn (string $implementingClassName, string $_methodName, array $methodArgs): mixed => $implementingClassName::{$_methodName}(...$methodArgs), null, $implementingClassName);
+        $closure = Closure::bind(static fn (string $implementingClassName, string $_methodName, array $methodArgs): mixed => $implementingClassName::{$_methodName}(...$methodArgs), null, $implementingClassName);
 
         assert($closure instanceof Closure);
 
@@ -438,7 +438,7 @@ class ReflectionMethod
     private function callObjectMethod(object $object, array $args): mixed
     {
         /** @psalm-suppress MixedMethodCall */
-        $closure = Closure::bind(fn (object $object, string $methodName, array $methodArgs): mixed => $object->{$methodName}(...$methodArgs), $object, $this->getImplementingClass()->getName());
+        $closure = Closure::bind(static fn (object $object, string $methodName, array $methodArgs): mixed => $object->{$methodName}(...$methodArgs), $object, $this->getImplementingClass()->getName());
 
         assert($closure instanceof Closure);
 

--- a/src/Reflection/ReflectionProperty.php
+++ b/src/Reflection/ReflectionProperty.php
@@ -460,7 +460,7 @@ class ReflectionProperty
 
         $instance = $this->assertObject($object);
 
-        $closure = Closure::bind(fn (object $instance, string $propertyName): mixed => $instance->{$propertyName}, $instance, $implementingClassName);
+        $closure = Closure::bind(static fn (object $instance, string $propertyName): mixed => $instance->{$propertyName}, $instance, $implementingClassName);
 
         assert($closure instanceof Closure);
 
@@ -494,7 +494,7 @@ class ReflectionProperty
 
         $instance = $this->assertObject($object);
 
-        $closure = Closure::bind(function (object $instance, string $propertyName, mixed $value): void {
+        $closure = Closure::bind(static function (object $instance, string $propertyName, mixed $value): void {
             $instance->{$propertyName} = $value;
         }, $instance, $implementingClassName);
 


### PR DESCRIPTION
Reduce unnecessary `$this` bind; noticed while working on https://github.com/Roave/BetterReflection/pull/1410