### PR TITLE
Failing test - CURLOPT_FTP_SSL being deprecated is false

### DIFF
--- a/test/unit/Reflection/ReflectionConstantTest.php
+++ b/test/unit/Reflection/ReflectionConstantTest.php
@@ -338,4 +338,13 @@ class ReflectionConstantTest extends TestCase
 
         self::assertSame($isDeprecated, $constantReflection->isDeprecated());
     }
+
+    public function testIsCurloptFtpSslConstantDeprecated(): void
+    {
+        $betterReflection   = BetterReflectionSingleton::instance();
+        $reflector          = new DefaultReflector($betterReflection->sourceLocator());
+        $constantReflection = $reflector->reflectConstant('CURLOPT_FTP_SSL');
+
+        self::assertTrue($constantReflection->isDeprecated());
+    }
 }


### PR DESCRIPTION
The test passes if I revert https://github.com/Roave/BetterReflection/commit/145cdb2d78b7340d061a47114880dbed0a7f5367 from https://github.com/Roave/BetterReflection/pull/1408.

/cc @staabm 

This is how the constant looks like in phpstorm-stubs:

```php
/**
 * @link https://php.net/manual/en/curl.constants.php
 * @deprecated use <b>CURLOPT_USE_SSL</b> instead.
 */
define('CURLOPT_FTP_SSL', 119);
```