### PR TITLE
More efficient `ReflectionClass#getParentClass()` - prevent loading all parent classes upfront

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -100,6 +100,7 @@
       <code><![CDATA[reflectClass]]></code>
       <code><![CDATA[reflectClass]]></code>
       <code><![CDATA[reflectClass]]></code>
+      <code><![CDATA[reflectClass]]></code>
       <code><![CDATA[toLowerString]]></code>
     </ImpureMethodCall>
   </file>

--- a/src/Reflection/ReflectionClass.php
+++ b/src/Reflection/ReflectionClass.php
@@ -1086,12 +1086,16 @@ class ReflectionClass implements Reflection
      */
     public function getParentClass(): ReflectionClass|null
     {
-        $parentClass = $this->getParentClasses()[0] ?? null;
-
-        if ($parentClass === null) {
+        $parentClassName = $this->getParentClassName();
+        if ($parentClassName === null) {
             return null;
         }
 
+        if ($this->name === $parentClassName) {
+            throw CircularReference::fromClassName($parentClassName);
+        }
+
+        $parentClass = $this->reflector->reflectClass($parentClassName);
         if ($parentClass->isInterface() || $parentClass->isTrait()) {
             throw NotAClassReflection::fromReflectionClass($parentClass);
         }


### PR DESCRIPTION
Before this PR `getParentClass` was unnecessary greedy resolving the whole parent hierarchy even though only a single level would be sufficient

the method stood out on a recent blackfire profile. notice the "explosion" of calls from ~1.500 to ~67.400 in

![grafik](https://github.com/Roave/BetterReflection/assets/120441/76a14598-bf59-4e3a-90f6-7fec1a2b6444)
