### PR TITLE
Assert parsing PHPStorm stubs will never trigger autoload

### DIFF
--- a/test/unit/SourceLocator/SourceStubber/PhpStormStubsSourceStubberTest.php
+++ b/test/unit/SourceLocator/SourceStubber/PhpStormStubsSourceStubberTest.php
@@ -63,6 +63,7 @@ use function get_defined_functions;
 use function in_array;
 use function sort;
 use function spl_autoload_register;
+use function spl_autoload_unregister;
 use function sprintf;
 
 use const PHP_VERSION_ID;
@@ -87,6 +88,8 @@ class PhpStormStubsSourceStubberTest extends TestCase
     {
         parent::setUp();
 
+        spl_autoload_register([$this, 'failAutoload']);
+
         $betterReflection = BetterReflectionSingleton::instance();
 
         $this->phpParser                = $betterReflection->phpParser();
@@ -94,6 +97,18 @@ class PhpStormStubsSourceStubberTest extends TestCase
         $this->sourceStubber            = new PhpStormStubsSourceStubber($this->phpParser, PHP_VERSION_ID);
         $this->phpInternalSourceLocator = new PhpInternalSourceLocator($this->astLocator, $this->sourceStubber);
         $this->reflector                = new DefaultReflector($this->phpInternalSourceLocator);
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        spl_autoload_unregister([$this, 'failAutoload']);
+    }
+
+    public function failAutoload(string $className): void
+    {
+        self::fail('Parsing PHPStorm stubs should never trigger autoloading - tried loading ' . $className);
     }
 
     /** @return list<array{0: string}> */


### PR DESCRIPTION
looking again at my patch in https://github.com/Roave/BetterReflection/commit/b9e11a2f6c51c54a7396d86a1f39beb88e2ecd7a#diff-41fe06041ece0f581f2a6b1bb811daf7e9d02d18efd83a1ca636caf6ea7e2330R206 I wondered whether we should also use `interface_exists()` and or `trait_exists()` to prevent other cases of autoading.

I couldn't reproduce a case with phpstorm stubs though, which would trigger autoloading for a interface or trait-constant.
therefore I figured we should just add a security measure, to make sure non of the tests in `PhpStormStubsSourceStubberTest` will unnoticed trigger autoloading.