### PR TITLE
Update CI jobs to PHP 8.3

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -192,7 +192,7 @@ jobs:
         dependencies:
           - "locked"
         php-version:
-          - "8.2"
+          - "8.3"
         operating-system:
           - "ubuntu-latest"
           - "windows-latest"
@@ -234,7 +234,7 @@ jobs:
         dependencies:
           - "locked"
         php-version:
-          - "8.2"
+          - "8.3"
         operating-system:
           - "ubuntu-latest"
 
@@ -268,7 +268,7 @@ jobs:
         dependencies:
           - "locked"
         php-version:
-          - "8.2"
+          - "8.3"
         operating-system:
           - "ubuntu-latest"
           - "windows-latest"
@@ -347,7 +347,7 @@ jobs:
         dependencies:
           - "locked"
         php-version:
-          - "8.2"
+          - "8.3"
         operating-system:
           - "ubuntu-latest"
 


### PR DESCRIPTION
I left the coding standard job on 8.2 since this is the lowest supported version and we should make sure cs-fixing does not introduce features which are not compatible with the lowest supported one