### PR TITLE
Add support for CodeLocationMissing to give a hint what code is missing

### DIFF
--- a/src/Reflection/Exception/CodeLocationMissing.php
+++ b/src/Reflection/Exception/CodeLocationMissing.php
@@ -8,11 +8,11 @@ use RuntimeException;
 
 class CodeLocationMissing extends RuntimeException
 {
-    public static function create(string $hint = null): self
+    public static function create(string|null $hint = null): self
     {
         $message = 'Code location is missing';
         if ($hint !== null) {
-            $message .= '. '.$hint;
+            $message .= '. ' . $hint;
         }
 
         return new self($message);

--- a/src/Reflection/Exception/CodeLocationMissing.php
+++ b/src/Reflection/Exception/CodeLocationMissing.php
@@ -8,8 +8,13 @@ use RuntimeException;
 
 class CodeLocationMissing extends RuntimeException
 {
-    public static function create(): self
+    public static function create(string $hint = null): self
     {
-        return new self('Code location is missing');
+        $message = 'Code location is missing';
+        if ($hint !== null) {
+            $message .= '. '.$hint;
+        }
+
+        return new self($message);
     }
 }

--- a/src/Reflection/ReflectionParameter.php
+++ b/src/Reflection/ReflectionParameter.php
@@ -487,7 +487,7 @@ class ReflectionParameter
     public function getStartLine(): int
     {
         if ($this->startLine === null) {
-            throw CodeLocationMissing::create();
+            throw CodeLocationMissing::create(sprintf('Was looking for parameter "$%s".', $this->name));
         }
 
         return $this->startLine;
@@ -501,7 +501,7 @@ class ReflectionParameter
     public function getEndLine(): int
     {
         if ($this->endLine === null) {
-            throw CodeLocationMissing::create();
+            throw CodeLocationMissing::create(sprintf('Was looking for parameter "$%s".', $this->name));
         }
 
         return $this->endLine;
@@ -515,7 +515,7 @@ class ReflectionParameter
     public function getStartColumn(): int
     {
         if ($this->startColumn === null) {
-            throw CodeLocationMissing::create();
+            throw CodeLocationMissing::create(sprintf('Was looking for parameter "$%s".', $this->name));
         }
 
         return $this->startColumn;
@@ -529,7 +529,7 @@ class ReflectionParameter
     public function getEndColumn(): int
     {
         if ($this->endColumn === null) {
-            throw CodeLocationMissing::create();
+            throw CodeLocationMissing::create(sprintf('Was looking for parameter "$%s".', $this->name));
         }
 
         return $this->endColumn;

--- a/src/Reflection/ReflectionProperty.php
+++ b/src/Reflection/ReflectionProperty.php
@@ -367,7 +367,7 @@ class ReflectionProperty
     public function getStartLine(): int
     {
         if ($this->startLine === null) {
-            throw CodeLocationMissing::create();
+            throw CodeLocationMissing::create(sprintf('Was looking for property "$%s" in "%s".', $this->name, $this->implementingClass->getName()));
         }
 
         return $this->startLine;
@@ -383,7 +383,7 @@ class ReflectionProperty
     public function getEndLine(): int
     {
         if ($this->endLine === null) {
-            throw CodeLocationMissing::create();
+            throw CodeLocationMissing::create(sprintf('Was looking for property "$%s" in "%s".', $this->name, $this->implementingClass->getName()));
         }
 
         return $this->endLine;
@@ -397,7 +397,7 @@ class ReflectionProperty
     public function getStartColumn(): int
     {
         if ($this->startColumn === null) {
-            throw CodeLocationMissing::create();
+            throw CodeLocationMissing::create(sprintf('Was looking for property "$%s" in "%s".', $this->name, $this->implementingClass->getName()));
         }
 
         return $this->startColumn;
@@ -411,7 +411,7 @@ class ReflectionProperty
     public function getEndColumn(): int
     {
         if ($this->endColumn === null) {
-            throw CodeLocationMissing::create();
+            throw CodeLocationMissing::create(sprintf('Was looking for property "$%s" in "%s".', $this->name, $this->implementingClass->getName()));
         }
 
         return $this->endColumn;

--- a/test/unit/Reflection/Exception/CodeLocationMissingTest.php
+++ b/test/unit/Reflection/Exception/CodeLocationMissingTest.php
@@ -18,4 +18,12 @@ class CodeLocationMissingTest extends TestCase
         self::assertInstanceOf(CodeLocationMissing::class, $exception);
         self::assertSame('Code location is missing', $exception->getMessage());
     }
+
+    public function testCreateWithHint(): void
+    {
+        $exception = CodeLocationMissing::create('Foobar');
+
+        self::assertInstanceOf(CodeLocationMissing::class, $exception);
+        self::assertSame('Code location is missing. Foobar', $exception->getMessage());
+    }
 }


### PR DESCRIPTION
This is a small quality of life improvement. It will add a better exception message when `CodeLocationMissing` is thrown. It will help debugging to add a little more context. 