### PR TITLE
Removed need for manually checking for parsing errors on `composer.(json|lock)` and `installed.json`

### DIFF
--- a/src/Reflection/StringCast/ReflectionAttributeStringCast.php
+++ b/src/Reflection/StringCast/ReflectionAttributeStringCast.php
@@ -43,10 +43,6 @@ final class ReflectionAttributeStringCast
      */
     private static function argumentsToString(array $arguments): string
     {
-        if ($arguments === []) {
-            return '';
-        }
-
         $string = '';
 
         $argumentNo = 0;

--- a/src/SourceLocator/Type/Composer/Factory/MakeLocatorForComposerJson.php
+++ b/src/SourceLocator/Type/Composer/Factory/MakeLocatorForComposerJson.php
@@ -21,12 +21,13 @@ use function array_merge;
 use function array_values;
 use function assert;
 use function file_get_contents;
-use function is_array;
 use function is_dir;
 use function is_file;
 use function is_string;
 use function json_decode;
 use function realpath;
+
+use const JSON_THROW_ON_ERROR;
 
 /**
  * @psalm-type ComposerAutoload array{

--- a/src/SourceLocator/Type/Composer/Factory/MakeLocatorForComposerJson.php
+++ b/src/SourceLocator/Type/Composer/Factory/MakeLocatorForComposerJson.php
@@ -6,7 +6,6 @@ namespace Roave\BetterReflection\SourceLocator\Type\Composer\Factory;
 
 use Roave\BetterReflection\SourceLocator\Ast\Locator;
 use Roave\BetterReflection\SourceLocator\Type\AggregateSourceLocator;
-use Roave\BetterReflection\SourceLocator\Type\Composer\Factory\Exception\FailedToParseJson;
 use Roave\BetterReflection\SourceLocator\Type\Composer\Factory\Exception\InvalidProjectDirectory;
 use Roave\BetterReflection\SourceLocator\Type\Composer\Factory\Exception\MissingComposerJson;
 use Roave\BetterReflection\SourceLocator\Type\Composer\Psr\Psr0Mapping;
@@ -65,12 +64,8 @@ final class MakeLocatorForComposerJson
         $composerJsonContent = file_get_contents($composerJsonPath);
         assert(is_string($composerJsonContent));
 
-        /** @psalm-var array{autoload: ComposerAutoload}|null $composer */
-        $composer = json_decode($composerJsonContent, true);
-
-        if (! is_array($composer)) {
-            throw FailedToParseJson::inFile($composerJsonPath);
-        }
+        /** @psalm-var array{autoload: ComposerAutoload} $composer */
+        $composer = json_decode($composerJsonContent, true, flags: JSON_THROW_ON_ERROR);
 
         $pathPrefix          = $realInstallationPath . '/';
         $classMapPaths       = $this->prefixPaths($this->packageToClassMapPaths($composer), $pathPrefix);

--- a/src/SourceLocator/Type/Composer/Factory/MakeLocatorForComposerJsonAndInstalledJson.php
+++ b/src/SourceLocator/Type/Composer/Factory/MakeLocatorForComposerJsonAndInstalledJson.php
@@ -23,13 +23,14 @@ use function array_merge_recursive;
 use function array_values;
 use function assert;
 use function file_get_contents;
-use function is_array;
 use function is_dir;
 use function is_file;
 use function is_string;
 use function json_decode;
 use function realpath;
 use function rtrim;
+
+use const JSON_THROW_ON_ERROR;
 
 /**
  * @psalm-import-type ComposerAutoload from MakeLocatorForComposerJson

--- a/src/SourceLocator/Type/Composer/Factory/MakeLocatorForComposerJsonAndInstalledJson.php
+++ b/src/SourceLocator/Type/Composer/Factory/MakeLocatorForComposerJsonAndInstalledJson.php
@@ -6,7 +6,6 @@ namespace Roave\BetterReflection\SourceLocator\Type\Composer\Factory;
 
 use Roave\BetterReflection\SourceLocator\Ast\Locator;
 use Roave\BetterReflection\SourceLocator\Type\AggregateSourceLocator;
-use Roave\BetterReflection\SourceLocator\Type\Composer\Factory\Exception\FailedToParseJson;
 use Roave\BetterReflection\SourceLocator\Type\Composer\Factory\Exception\InvalidProjectDirectory;
 use Roave\BetterReflection\SourceLocator\Type\Composer\Factory\Exception\MissingComposerJson;
 use Roave\BetterReflection\SourceLocator\Type\Composer\Factory\Exception\MissingInstalledJson;
@@ -56,10 +55,9 @@ final class MakeLocatorForComposerJsonAndInstalledJson
         $composerJsonContent = file_get_contents($composerJsonPath);
         assert(is_string($composerJsonContent));
 
-        /** @psalm-var Composer|null $composer */
-        $composer  = json_decode($composerJsonContent, true);
-        $vendorDir = $composer['config']['vendor-dir'] ?? 'vendor';
-        $vendorDir = rtrim($vendorDir, '/');
+        /** @psalm-var Composer $composer */
+        $composer  = json_decode($composerJsonContent, true, flags: JSON_THROW_ON_ERROR);
+        $vendorDir = rtrim($composer['config']['vendor-dir'] ?? 'vendor', '/');
 
         $installedJsonPath = $realInstallationPath . '/' . $vendorDir . '/composer/installed.json';
 
@@ -70,16 +68,8 @@ final class MakeLocatorForComposerJsonAndInstalledJson
         $jsonContent = file_get_contents($installedJsonPath);
         assert(is_string($jsonContent));
 
-        /** @psalm-var array{packages: list<mixed[]>}|list<mixed[]>|null $installedJson */
-        $installedJson = json_decode($jsonContent, true);
-
-        if (! is_array($composer)) {
-            throw FailedToParseJson::inFile($composerJsonPath);
-        }
-
-        if (! is_array($installedJson)) {
-            throw FailedToParseJson::inFile($installedJsonPath);
-        }
+        /** @psalm-var array{packages?: list<ComposerPackage>}|list<ComposerPackage> $installedJson */
+        $installedJson = json_decode($jsonContent, true, flags: JSON_THROW_ON_ERROR);
 
         /** @psalm-var list<ComposerPackage> $installed */
         $installed = $installedJson['packages'] ?? $installedJson;
@@ -188,7 +178,7 @@ final class MakeLocatorForComposerJsonAndInstalledJson
 
     /**
      * @param array<string, list<string>> $paths
-     * @param ComposerPackage             $package $package
+     * @param ComposerPackage             $package
      *
      * @return array<string, list<string>>
      */

--- a/src/SourceLocator/Type/Composer/Factory/MakeLocatorForInstalledJson.php
+++ b/src/SourceLocator/Type/Composer/Factory/MakeLocatorForInstalledJson.php
@@ -23,13 +23,14 @@ use function array_merge_recursive;
 use function array_values;
 use function assert;
 use function file_get_contents;
-use function is_array;
 use function is_dir;
 use function is_file;
 use function is_string;
 use function json_decode;
 use function realpath;
 use function rtrim;
+
+use const JSON_THROW_ON_ERROR;
 
 /**
  * @psalm-import-type ComposerAutoload from MakeLocatorForComposerJson

--- a/test/unit/SourceLocator/Type/Composer/Factory/MakeLocatorForComposerInstalledJsonTest.php
+++ b/test/unit/SourceLocator/Type/Composer/Factory/MakeLocatorForComposerInstalledJsonTest.php
@@ -9,7 +9,6 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Roave\BetterReflection\SourceLocator\Type\AggregateSourceLocator;
-use Roave\BetterReflection\SourceLocator\Type\Composer\Factory\Exception\FailedToParseJson;
 use Roave\BetterReflection\SourceLocator\Type\Composer\Factory\Exception\InvalidProjectDirectory;
 use Roave\BetterReflection\SourceLocator\Type\Composer\Factory\Exception\MissingComposerJson;
 use Roave\BetterReflection\SourceLocator\Type\Composer\Factory\Exception\MissingInstalledJson;

--- a/test/unit/SourceLocator/Type/Composer/Factory/MakeLocatorForComposerInstalledJsonTest.php
+++ b/test/unit/SourceLocator/Type/Composer/Factory/MakeLocatorForComposerInstalledJsonTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Roave\BetterReflectionTest\SourceLocator\Type\Composer\Factory;
 
+use JsonException;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
@@ -281,7 +282,7 @@ class MakeLocatorForComposerInstalledJsonTest extends TestCase
 
     public function testWillFailToProduceLocatorForProjectWithInvalidInstalledJson(): void
     {
-        $this->expectException(FailedToParseJson::class);
+        $this->expectException(JsonException::class);
 
         (new MakeLocatorForInstalledJson())
             ->__invoke(

--- a/test/unit/SourceLocator/Type/Composer/Factory/MakeLocatorForComposerJsonAndInstalledJsonTest.php
+++ b/test/unit/SourceLocator/Type/Composer/Factory/MakeLocatorForComposerJsonAndInstalledJsonTest.php
@@ -9,7 +9,6 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Roave\BetterReflection\SourceLocator\Type\AggregateSourceLocator;
-use Roave\BetterReflection\SourceLocator\Type\Composer\Factory\Exception\FailedToParseJson;
 use Roave\BetterReflection\SourceLocator\Type\Composer\Factory\Exception\InvalidProjectDirectory;
 use Roave\BetterReflection\SourceLocator\Type\Composer\Factory\Exception\MissingComposerJson;
 use Roave\BetterReflection\SourceLocator\Type\Composer\Factory\Exception\MissingInstalledJson;

--- a/test/unit/SourceLocator/Type/Composer/Factory/MakeLocatorForComposerJsonAndInstalledJsonTest.php
+++ b/test/unit/SourceLocator/Type/Composer/Factory/MakeLocatorForComposerJsonAndInstalledJsonTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Roave\BetterReflectionTest\SourceLocator\Type\Composer\Factory;
 
+use JsonException;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
@@ -333,7 +334,7 @@ class MakeLocatorForComposerJsonAndInstalledJsonTest extends TestCase
 
     public function testWillFailToProduceLocatorForProjectWithInvalidComposerJson(): void
     {
-        $this->expectException(FailedToParseJson::class);
+        $this->expectException(JsonException::class);
 
         (new MakeLocatorForComposerJsonAndInstalledJson())
             ->__invoke(
@@ -344,7 +345,7 @@ class MakeLocatorForComposerJsonAndInstalledJsonTest extends TestCase
 
     public function testWillFailToProduceLocatorForProjectWithInvalidInstalledJson(): void
     {
-        $this->expectException(FailedToParseJson::class);
+        $this->expectException(JsonException::class);
 
         (new MakeLocatorForComposerJsonAndInstalledJson())
             ->__invoke(

--- a/test/unit/SourceLocator/Type/Composer/Factory/MakeLocatorForComposerJsonTest.php
+++ b/test/unit/SourceLocator/Type/Composer/Factory/MakeLocatorForComposerJsonTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Roave\BetterReflectionTest\SourceLocator\Type\Composer\Factory;
 
+use JsonException;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
@@ -137,7 +138,7 @@ class MakeLocatorForComposerJsonTest extends TestCase
 
     public function testWillFailToProduceLocatorForProjectWithInvalidComposerJson(): void
     {
-        $this->expectException(FailedToParseJson::class);
+        $this->expectException(JsonException::class);
 
         (new MakeLocatorForComposerJson())
             ->__invoke(

--- a/test/unit/SourceLocator/Type/Composer/Factory/MakeLocatorForComposerJsonTest.php
+++ b/test/unit/SourceLocator/Type/Composer/Factory/MakeLocatorForComposerJsonTest.php
@@ -9,7 +9,6 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Roave\BetterReflection\SourceLocator\Type\AggregateSourceLocator;
-use Roave\BetterReflection\SourceLocator\Type\Composer\Factory\Exception\FailedToParseJson;
 use Roave\BetterReflection\SourceLocator\Type\Composer\Factory\Exception\InvalidProjectDirectory;
 use Roave\BetterReflection\SourceLocator\Type\Composer\Factory\Exception\MissingComposerJson;
 use Roave\BetterReflection\SourceLocator\Type\Composer\Factory\MakeLocatorForComposerJson;


### PR DESCRIPTION
This marginally reduces code size, and reduces `mixed` types a bit, but would benefit
tons from removing direct usage of `json_decode()`, which is an unsafe construct, when
the results of its calls go un-checked.

Ideally, we'd use `azjezz/psl`, but that library comes with added dependencies that we can't afford
here, for now.