### PR TITLE
Remove unnecessary constants

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -3,8 +3,6 @@ includes:
     - tools/vendor/phpstan/phpstan-phpunit/rules.neon
 
 parameters:
-    phpVersion: 80100
-
     level: 6
 
     paths:

--- a/src/Reflection/Adapter/ReflectionClass.php
+++ b/src/Reflection/Adapter/ReflectionClass.php
@@ -33,9 +33,6 @@ use function strtolower;
  */
 final class ReflectionClass extends CoreReflectionClass
 {
-    /** @internal */
-    public const IS_READONLY_COMPATIBILITY = 65536;
-
     public function __construct(private BetterReflectionClass|BetterReflectionEnum $betterReflectionClass)
     {
         unset($this->name);

--- a/src/Reflection/Adapter/ReflectionClassConstant.php
+++ b/src/Reflection/Adapter/ReflectionClassConstant.php
@@ -21,9 +21,6 @@ use function sprintf;
  */
 final class ReflectionClassConstant extends CoreReflectionClassConstant
 {
-    /** @internal */
-    public const IS_FINAL_COMPATIBILITY = 32;
-
     public function __construct(private BetterReflectionClassConstant|BetterReflectionEnumCase $betterClassConstantOrEnumCase)
     {
         unset($this->name);

--- a/src/Reflection/Adapter/ReflectionProperty.php
+++ b/src/Reflection/Adapter/ReflectionProperty.php
@@ -23,9 +23,6 @@ use function sprintf;
 /** @psalm-suppress PropertyNotSetInConstructor */
 final class ReflectionProperty extends CoreReflectionProperty
 {
-    /** @internal */
-    public const IS_READONLY_COMPATIBILITY = 128;
-
     public function __construct(private BetterReflectionProperty $betterReflectionProperty)
     {
         unset($this->name);

--- a/src/Reflection/ReflectionClass.php
+++ b/src/Reflection/ReflectionClass.php
@@ -1201,7 +1201,7 @@ class ReflectionClass implements Reflection
 
     public function isReadOnly(): bool
     {
-        return ($this->modifiers & ReflectionClassAdapter::IS_READONLY_COMPATIBILITY) === ReflectionClassAdapter::IS_READONLY_COMPATIBILITY;
+        return ($this->modifiers & CoreReflectionClass::IS_READONLY) === CoreReflectionClass::IS_READONLY;
     }
 
     /**
@@ -1223,7 +1223,7 @@ class ReflectionClass implements Reflection
 
         $modifiers  = $node->isAbstract() ? CoreReflectionClass::IS_EXPLICIT_ABSTRACT : 0;
         $modifiers += $node->isFinal() ? CoreReflectionClass::IS_FINAL : 0;
-        $modifiers += $node->isReadonly() ? ReflectionClassAdapter::IS_READONLY_COMPATIBILITY : 0;
+        $modifiers += $node->isReadonly() ? CoreReflectionClass::IS_READONLY : 0;
 
         return $modifiers;
     }

--- a/test/unit/Reflection/ReflectionClassTest.php
+++ b/test/unit/Reflection/ReflectionClassTest.php
@@ -23,7 +23,6 @@ use ReflectionClass as CoreReflectionClass;
 use ReflectionClassConstant as CoreReflectionClassConstant;
 use ReflectionMethod as CoreReflectionMethod;
 use ReflectionProperty as CoreReflectionProperty;
-use Roave\BetterReflection\Reflection\Adapter\ReflectionClass as ReflectionClassAdapter;
 use Roave\BetterReflection\Reflection\Adapter\ReflectionClassConstant as ReflectionClassConstantAdapter;
 use Roave\BetterReflection\Reflection\Exception\CircularReference;
 use Roave\BetterReflection\Reflection\Exception\NotAClassReflection;
@@ -1308,7 +1307,7 @@ PHP;
             ['ExampleClass', 0],
             ['AbstractClass', CoreReflectionClass::IS_EXPLICIT_ABSTRACT],
             ['FinalClass', CoreReflectionClass::IS_FINAL],
-            ['ReadOnlyClass', ReflectionClassAdapter::IS_READONLY_COMPATIBILITY],
+            ['ReadOnlyClass', CoreReflectionClass::IS_READONLY],
             ['ExampleTrait', 0],
         ];
     }


### PR DESCRIPTION
Fix of https://github.com/Roave/BetterReflection/pull/1442

Yes, @akmandev was right!

The broken build in https://github.com/Roave/BetterReflection/pull/1441 has confused me... 😞  The constants really already exist in 8.2 and we can safely remove them.

The really problem was broken PHPStan configuration. Thanks to @ondrejmirtes to figured out.