### PR TITLE
Failing test: `ReflectionClass::getTraitAliases` does not maintain case

### DIFF
--- a/test/unit/Fixture/TraitFixture.php
+++ b/test/unit/Fixture/TraitFixture.php
@@ -30,6 +30,7 @@ trait TraitFixtureTraitC
     public function a() {}
     public function b() {}
     public function c() {}
+    public function camelCase() {}
 }
 trait TraitFixtureTraitC2
 {
@@ -45,6 +46,7 @@ class TraitFixtureC
         a as protected a_protected;
         b as b_renamed;
         c as private;
+        camelCase as differentCamelCase;
     }
     use TraitFixtureTraitC3 {
         d as d_renamed;

--- a/test/unit/Reflection/ReflectionClassTest.php
+++ b/test/unit/Reflection/ReflectionClassTest.php
@@ -1500,6 +1500,7 @@ PHP;
         self::assertSame([
             'a_protected' => 'TraitFixtureTraitC::a',
             'b_renamed' => 'TraitFixtureTraitC::b',
+            'differentCamelCase' => 'TraitFixtureTraitC::camelCase',
             'd_renamed' => 'TraitFixtureTraitC3::d',
         ], $classInfo->getTraitAliases());
     }


### PR DESCRIPTION
I'm not sure if this is intentional, but it is harder to work with and does [not comply with the phpdoc of the `getTraitAliases` method](https://github.com/Roave/BetterReflection/blob/5ea77d6/src/Reflection/ReflectionClass.php#L1359).