### PR TITLE
Fix support of Enum stubs from PHPStorm

### DIFF
--- a/src/SourceLocator/SourceStubber/PhpStormStubsSourceStubber.php
+++ b/src/SourceLocator/SourceStubber/PhpStormStubsSourceStubber.php
@@ -514,7 +514,7 @@ final class PhpStormStubsSourceStubber implements SourceStubber
     {
         $newStmts = [];
         foreach ($stmts as $stmt) {
-            assert($stmt instanceof Node\Stmt\ClassConst || $stmt instanceof Node\Stmt\Property || $stmt instanceof Node\Stmt\ClassMethod);
+            assert($stmt instanceof Node\Stmt\ClassConst || $stmt instanceof Node\Stmt\Property || $stmt instanceof Node\Stmt\ClassMethod || $stmt instanceof Node\Stmt\EnumCase);
 
             if (! $this->isSupportedInPhpVersion($stmt)) {
                 continue;
@@ -624,7 +624,7 @@ final class PhpStormStubsSourceStubber implements SourceStubber
             : null;
     }
 
-    private function addDeprecatedDocComment(Node\Stmt\ClassLike|Node\Stmt\ClassConst|Node\Stmt\Property|Node\Stmt\ClassMethod|Node\Stmt\Function_|Node\Expr\FuncCall|Node\Stmt\Const_ $node): void
+    private function addDeprecatedDocComment(Node\Stmt\ClassLike|Node\Stmt\ClassConst|Node\Stmt\Property|Node\Stmt\ClassMethod|Node\Stmt\Function_|Node\Expr\FuncCall|Node\Stmt\Const_|Node\Stmt\EnumCase $node): void
     {
         if ($node instanceof Node\Expr\FuncCall) {
             if (! $this->isDeprecatedByPhpDocInPhpVersion($node)) {
@@ -648,7 +648,7 @@ final class PhpStormStubsSourceStubber implements SourceStubber
     }
 
     private function addAnnotationToDocComment(
-        Node\Stmt\ClassLike|Node\Stmt\ClassConst|Node\Stmt\Property|Node\Stmt\ClassMethod|Node\Stmt\Function_|Node\Stmt\Const_ $node,
+        Node\Stmt\ClassLike|Node\Stmt\ClassConst|Node\Stmt\Property|Node\Stmt\ClassMethod|Node\Stmt\Function_|Node\Stmt\Const_|Node\Stmt\EnumCase $node,
         string $annotationName,
     ): void {
         $docComment = $node->getDocComment();
@@ -663,7 +663,7 @@ final class PhpStormStubsSourceStubber implements SourceStubber
     }
 
     private function removeAnnotationFromDocComment(
-        Node\Stmt\ClassLike|Node\Stmt\ClassConst|Node\Stmt\Property|Node\Stmt\ClassMethod|Node\Stmt\Function_|Node\Expr\FuncCall|Node\Stmt\Const_ $node,
+        Node\Stmt\ClassLike|Node\Stmt\ClassConst|Node\Stmt\Property|Node\Stmt\ClassMethod|Node\Stmt\Function_|Node\Expr\FuncCall|Node\Stmt\Const_|Node\Stmt\EnumCase $node,
         string $annotationName,
     ): void {
         $docComment = $node->getDocComment();
@@ -699,7 +699,7 @@ final class PhpStormStubsSourceStubber implements SourceStubber
         return true;
     }
 
-    private function isDeprecatedInPhpVersion(Node\Stmt\ClassLike|Node\Stmt\ClassConst|Node\Stmt\Property|Node\Stmt\ClassMethod|Node\Stmt\Function_ $node): bool
+    private function isDeprecatedInPhpVersion(Node\Stmt\ClassLike|Node\Stmt\ClassConst|Node\Stmt\Property|Node\Stmt\ClassMethod|Node\Stmt\Function_|Node\Stmt\EnumCase $node): bool
     {
         $deprecatedAttribute = $this->getNodeAttribute($node, 'JetBrains\PhpStorm\Deprecated');
         if ($deprecatedAttribute === null) {
@@ -718,7 +718,7 @@ final class PhpStormStubsSourceStubber implements SourceStubber
     }
 
     private function isSupportedInPhpVersion(
-        Node\Stmt\ClassLike|Node\Stmt\Function_|Node\Stmt\Const_|Node\Expr\FuncCall|Node\Stmt\ClassConst|Node\Stmt\Property|Node\Stmt\ClassMethod|Node\Param $node,
+        Node\Stmt\ClassLike|Node\Stmt\Function_|Node\Stmt\Const_|Node\Expr\FuncCall|Node\Stmt\ClassConst|Node\Stmt\Property|Node\Stmt\ClassMethod|Node\Param|Node\Stmt\EnumCase $node,
     ): bool {
         [$fromVersion, $toVersion] = $this->getSupportedPhpVersions($node);
 
@@ -731,7 +731,7 @@ final class PhpStormStubsSourceStubber implements SourceStubber
 
     /** @return array{0: int|null, 1: int|null} */
     private function getSupportedPhpVersions(
-        Node\Stmt\ClassLike|Node\Stmt\Function_|Node\Stmt\Const_|Node\Expr\FuncCall|Node\Stmt\ClassConst|Node\Stmt\Property|Node\Stmt\ClassMethod|Node\Param $node,
+        Node\Stmt\ClassLike|Node\Stmt\Function_|Node\Stmt\Const_|Node\Expr\FuncCall|Node\Stmt\ClassConst|Node\Stmt\Property|Node\Stmt\ClassMethod|Node\Param|Node\Stmt\EnumCase $node,
     ): array {
         $fromVersion = null;
         $toVersion   = null;
@@ -770,7 +770,7 @@ final class PhpStormStubsSourceStubber implements SourceStubber
     }
 
     private function getNodeAttribute(
-        Node\Stmt\ClassLike|Node\Stmt\Function_|Node\Stmt\Const_|Node\Expr\FuncCall|Node\Stmt\ClassConst|Node\Stmt\Property|Node\Stmt\ClassMethod|Node\Param $node,
+        Node\Stmt\ClassLike|Node\Stmt\Function_|Node\Stmt\Const_|Node\Expr\FuncCall|Node\Stmt\ClassConst|Node\Stmt\Property|Node\Stmt\ClassMethod|Node\Param|Node\Stmt\EnumCase $node,
         string $attributeName,
     ): Node\Attribute|null {
         if ($node instanceof Node\Expr\FuncCall || $node instanceof Node\Stmt\Const_) {

--- a/src/SourceLocator/SourceStubber/PhpStormStubsSourceStubber.php
+++ b/src/SourceLocator/SourceStubber/PhpStormStubsSourceStubber.php
@@ -107,6 +107,7 @@ final class PhpStormStubsSourceStubber implements SourceStubber
         'Phar',
         'posix',
         'pspell',
+        'random',
         'readline',
         'recode',
         'Reflection',

--- a/test/unit/SourceLocator/SourceStubber/PhpStormStubsSourceStubberTest.php
+++ b/test/unit/SourceLocator/SourceStubber/PhpStormStubsSourceStubberTest.php
@@ -460,6 +460,17 @@ class PhpStormStubsSourceStubberTest extends TestCase
         self::assertNull($this->sourceStubber->generateClassStub($someClassName));
     }
 
+    public function testStubForEnum(): void
+    {
+        $stub = $this->sourceStubber->generateClassStub('Random\IntervalBoundary');
+
+        if (PHP_VERSION_ID >= 80300) {
+            self::assertInstanceOf(StubData::class, $stub);
+        } else {
+            self::assertNull($stub);
+        }
+    }
+
     public function testStubForFunctionThatExists(): void
     {
         self::assertInstanceOf(StubData::class, $this->sourceStubber->generateFunctionStub('phpversion'));


### PR DESCRIPTION
Hi @Ocramius,

An (old) assert was added by @kukulich in https://github.com/Roave/BetterReflection/commit/933dcb9c61745c29702199f0a1260d36c083cda0

This one is not true anymore, cause PHPStorm stubs use `@since` on Enum like
https://github.com/JetBrains/phpstorm-stubs/commit/2630c4604859a43fe761108360f4b4352056aa74#diff-11cfa64a565c311363b652c7494df2be636c9934afac14510bdd70e50d7044ceR6

Such error was discovered by the PHPStan CI which run on PHP 8.4 https://github.com/phpstan/phpstan-src/actions/runs/10680283358/job/29601421334?pr=3393 ; but I'm unsure how much work it would require so far to have a full Ci running on PHP 8.4. I can try in another PR if you want to.