### PR TITLE
Add missing entries to gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,11 +7,13 @@
 /composer.lock export-ignore
 /demo/ export-ignore
 /docs/ export-ignore
+/infection.json.dist export-ignore
 /phpbench.json export-ignore
 /phpcs.xml.dist export-ignore
 /phpstan.neon export-ignore
 /phpunit.xml.dist export-ignore
 /psalm.xml export-ignore
 /psalm-baseline.xml export-ignore
+/renovate.json export-ignore
 /tools/ export-ignore
 /test/ export-ignore


### PR DESCRIPTION
Not sure if it's done on purpose or just an oversight.