### PR TITLE
Add fix for SplObjectStorage with next PHPStorm stubs

### DIFF
--- a/src/SourceLocator/SourceStubber/PhpStormStubsSourceStubber.php
+++ b/src/SourceLocator/SourceStubber/PhpStormStubsSourceStubber.php
@@ -29,8 +29,10 @@ use Roave\BetterReflection\SourceLocator\FileChecker;
 use Roave\BetterReflection\SourceLocator\SourceStubber\Exception\CouldNotFindPhpStormStubs;
 use Roave\BetterReflection\SourceLocator\SourceStubber\PhpStormStubs\CachingVisitor;
 use Roave\BetterReflection\Util\ConstantNodeChecker;
+use SeekableIterator;
 use SimpleXMLElement;
 use SplFixedArray;
+use SplObjectStorage;
 use Traversable;
 
 use function array_change_key_case;
@@ -490,6 +492,11 @@ final class PhpStormStubsSourceStubber implements SourceStubber
             } elseif ($className === DatePeriod::class || $className === PDOStatement::class) {
                 if ($name === IteratorAggregate::class && $this->phpVersion < 80000) {
                     $modifiedNames[] = new Node\Name\FullyQualified(Traversable::class);
+                    continue;
+                }
+            } elseif ($className === SplObjectStorage::class) {
+                if ($name === SeekableIterator::class && $this->phpVersion < 80400) {
+                    $modifiedNames[] = new Node\Name\FullyQualified(Iterator::class);
                     continue;
                 }
             }


### PR DESCRIPTION
While working on https://github.com/Roave/BetterReflection/pull/1445

I discovered that in the next PHPStorm/stub tag you'll get an issue with SplObjectStorage because `Iterator` is changed to `SeekableIterator` for PHP >= 8.4.
https://github.com/JetBrains/phpstorm-stubs/blob/56f6b9e55f5885e651553843a1aaf9ec9c586c04/SPL/SPL_c1.php#L2061

So I extracted the fix in a separate PR.