### PR TITLE
Adding methods for sequential processing and filtering of class reflections

### DIFF
--- a/demo/parsing-whole-directory/example3.php
+++ b/demo/parsing-whole-directory/example3.php
@@ -1,6 +1,6 @@
 <?php
 
-# parse all classes in a directory that use some dependencies from /vendor
+# example of class iterator operation
 
 require_once __DIR__ . '/../../vendor/autoload.php';
 

--- a/demo/parsing-whole-directory/example3.php
+++ b/demo/parsing-whole-directory/example3.php
@@ -1,0 +1,37 @@
+<?php
+
+# parse all classes in a directory that use some dependencies from /vendor
+
+require_once __DIR__ . '/../../vendor/autoload.php';
+
+use Roave\BetterReflection\BetterReflection;
+use Roave\BetterReflection\Reflector\DefaultReflector;
+use Roave\BetterReflection\SourceLocator\Type\AggregateSourceLocator;
+use Roave\BetterReflection\SourceLocator\Type\DirectoriesSourceLocator;
+use Roave\BetterReflection\SourceLocator\Type\SourceFilter\FileSizeFilter;
+use Roave\BetterReflection\SourceLocator\Type\SourceFilter\AggregateFilter;
+use Roave\BetterReflection\SourceLocator\Type\SourceFilter\SourceContainsFilter;
+
+$directories = [__DIR__ . '/../../src', __DIR__ . '/../../demo'];
+
+$sourceLocator = new AggregateSourceLocator([
+    new DirectoriesSourceLocator(
+        $directories,
+        (new BetterReflection())->astLocator()
+    ),
+]);
+
+$reflector = new DefaultReflector($sourceLocator);
+
+$classReflections = $reflector->iterateClasses(
+    new AggregateFilter(
+        new FileSizeFilter(10000),
+        new SourceContainsFilter(['class ReflectionMethod', 'class ReflectionClass'])
+    ),
+);
+
+print iterator_count($classReflections);
+
+$classReflections = $reflector->iterateClasses(new SourceContainsFilter(['class MyClass']));
+
+print iterator_count($classReflections);

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,16 +1,16 @@
 # Basic Usage
 
-The starting point for creating a reflection class does not match the typical core reflection API. Instead of 
-instantiating a `new \ReflectionClass`, you must use the appropriate `\Roave\BetterReflection\Reflector\Reflector` 
+The starting point for creating a reflection class does not match the typical core reflection API. Instead of
+instantiating a `new \ReflectionClass`, you must use the appropriate `\Roave\BetterReflection\Reflector\Reflector`
 helper.
 
 All `*Reflector` classes require a class that implements the `SourceLocator` interface as a dependency.
 
 ## Basic Reflection
 
-Better Reflection is, in most cases, able to automatically reflect on classes by using a similar creation technique to 
+Better Reflection is, in most cases, able to automatically reflect on classes by using a similar creation technique to
 PHP's internal reflection. However, this works on the basic assumption that whichever autoloader you are using will
-attempt to load a file, and only one file, which should contain the class you are trying to reflect. For example, the 
+attempt to load a file, and only one file, which should contain the class you are trying to reflect. For example, the
 autoloader that Composer provides will work with this technique.
 
 ```php
@@ -23,10 +23,10 @@ $classInfo = (new BetterReflection)
     ->reflectClass(\Foo\Bar\MyClass::class);
 ```
 
-If this instantiation technique is not possible - for example, your autoloader does not load classes from file, then 
+If this instantiation technique is not possible - for example, your autoloader does not load classes from file, then
 you *must* use `SourceLocator` creation.
 
-> Fun fact... using the method described above actually uses a SourceLocator under the hood - it uses the 
+> Fun fact... using the method described above actually uses a SourceLocator under the hood - it uses the
   `AutoloadSourceLocator`.
 
 ### Initialisers
@@ -60,20 +60,20 @@ ReflectionProperty::createFromInstance(new \ReflectionClass(\stdClass::class), '
 
 ## SourceLocators
 
-Source locators are helpers that identify how to load code that can be used within the `Reflector`s. The library comes 
+Source locators are helpers that identify how to load code that can be used within the `Reflector`s. The library comes
 bundled with the following `SourceLocator` classes:
 
- * `ComposerSourceLocator` - you'll probably use this most of the time. This uses Composer's built-in autoloader to 
+ * `ComposerSourceLocator` - you'll probably use this most of the time. This uses Composer's built-in autoloader to
    locate a class and return the source.
-    
+
  * `SingleFileSourceLocator` - this locator loads the filename specified in the constructor.
-    
- * `StringSourceLocator` - pass a string as a constructor argument which will be used directly. Note that any 
+
+ * `StringSourceLocator` - pass a string as a constructor argument which will be used directly. Note that any
    references to filenames when using this locator will be `null` because no files are loaded.
 
- * `AutoloadSourceLocator` - this is a little hacky, but works on the assumption that when a registered autoloader 
+ * `AutoloadSourceLocator` - this is a little hacky, but works on the assumption that when a registered autoloader
   identifies a file and attempts to open it, then that file will contain the class. Internally, it works by overriding
-  the `file://` protocol stream wrapper to grab the path of the file the autoloader is trying to locate. This source 
+  the `file://` protocol stream wrapper to grab the path of the file the autoloader is trying to locate. This source
   locator is used internally by the `ReflectionClass::createFromName` static constructor.
 
  * `EvaledCodeSourceLocator` - used to perform reflection on code that is already loaded into memory using `eval()`
@@ -84,7 +84,7 @@ bundled with the following `SourceLocator` classes:
 
  * `ClosureSourceLocator` - used to perform reflection on a closure.
 
- * `AggregateSourceLocator` - a combination of multiple `SourceLocator`s which are hunted through in the given order to 
+ * `AggregateSourceLocator` - a combination of multiple `SourceLocator`s which are hunted through in the given order to
    locate the source.
 
  * `FileIteratorSourceLocator` - iterates all files in a given iterator containing `SplFileInfo` instances.
@@ -94,7 +94,7 @@ bundled with the following `SourceLocator` classes:
 A `SourceLocator` is a callable, which when invoked must be given an `Identifier` (which describes a class/function/etc)
 . The `SourceLocator` should be written so that it returns a `Reflection` object directly.
 
-> Note that using `EvaledCodeSourceLocator` and `PhpInternalSourceLocator` will result in specific types of 
+> Note that using `EvaledCodeSourceLocator` and `PhpInternalSourceLocator` will result in specific types of
   `LocatedSource` within the reflection - namely `EvaledLocatedSource` and `InternalLocatedSource` respectively.
 
 > Note that if you use a locator other than the default and the class you want to reflect extends a built-in PHP class (e.g. `\Exception`)
@@ -103,12 +103,12 @@ A `SourceLocator` is a callable, which when invoked must be given an `Identifier
 
 ## Reflecting Classes
 
-The `Reflector` is used to create Better Reflection `ReflectionClass` instances. You may pass it any 
+The `Reflector` is used to create Better Reflection `ReflectionClass` instances. You may pass it any
 `SourceLocator` to reflect on any class that can be located using the given that `SourceLocator`.
 
 ### Using the AutoloadSourceLocator
 
-There is no need to use the `AutoloadSourceLocator` directly. Use the static constructors for `ReflectionClass` 
+There is no need to use the `AutoloadSourceLocator` directly. Use the static constructors for `ReflectionClass`
 and `ReflectionFunction`:
 
 ```php
@@ -237,10 +237,31 @@ $reflector = new DefaultReflector($directoriesSourceLocator);
 $classes = $reflector->reflectAllClasses();
 ```
 
+### Iterate filtered reflections in a directory
+
+```php
+<?php
+
+use Roave\BetterReflection\BetterReflection;
+use Roave\BetterReflection\Reflector\DefaultReflector;
+use Roave\BetterReflection\SourceLocator\Type\DirectoriesSourceLocator;
+
+$astLocator = (new BetterReflection())->astLocator();
+
+$directoriesSourceLocator = new DirectoriesSourceLocator(['path/to/directory1'], $astLocator);
+
+$reflector = new DefaultReflector($directoriesSourceLocator);
+
+$generator = $reflector->iterateClasses(new SourceContainsFilter(['some substring']));
+
+foreach ($generator as $reflection) {
+    $reflection->getName();
+}
+```
 
 ## Reflecting Functions
 
-The `Reflector` is used to create Better Reflection `ReflectionFunction` instances. You may pass it any 
+The `Reflector` is used to create Better Reflection `ReflectionFunction` instances. You may pass it any
 `SourceLocator` to reflect on any class that can be located using the given `SourceLocator`.
 
 ### Using the AutoloadSourceLocator
@@ -277,5 +298,5 @@ $myClosure = function () {
 $functionInfo = ReflectionFunction::createFromClosure($myClosure);
 ```
 
-> Note that when you reflect on a closure, in order to match the core reflection API, the function "short" name will be 
+> Note that when you reflect on a closure, in order to match the core reflection API, the function "short" name will be
   just `{closure}`.

--- a/src/Reflector/DefaultReflector.php
+++ b/src/Reflector/DefaultReflector.php
@@ -4,14 +4,15 @@ declare(strict_types=1);
 
 namespace Roave\BetterReflection\Reflector;
 
+use Iterator;
 use Roave\BetterReflection\Identifier\Identifier;
 use Roave\BetterReflection\Identifier\IdentifierType;
 use Roave\BetterReflection\Reflection\ReflectionClass;
 use Roave\BetterReflection\Reflection\ReflectionConstant;
 use Roave\BetterReflection\Reflection\ReflectionFunction;
 use Roave\BetterReflection\Reflector\Exception\IdentifierNotFound;
+use Roave\BetterReflection\SourceLocator\Type\SourceFilter\SourceFilter;
 use Roave\BetterReflection\SourceLocator\Type\SourceLocator;
-
 use function assert;
 
 final class DefaultReflector implements Reflector
@@ -54,6 +55,23 @@ final class DefaultReflector implements Reflector
         );
 
         return $allClasses;
+    }
+
+    /**
+     * Iterate classes available in the scope specified by the SourceLocator.
+     *
+     * @return Iterator<ReflectionClass>
+     */
+    public function iterateClasses(?SourceFilter $filter = null): Iterator
+    {
+        /** @var Iterator<ReflectionClass> $allClasses */
+        $allClasses = $this->sourceLocator->iterateIdentifiersByType(
+            $this,
+            new IdentifierType(IdentifierType::IDENTIFIER_CLASS),
+            $filter,
+        );
+
+        yield from $allClasses;
     }
 
     /**

--- a/src/Reflector/DefaultReflector.php
+++ b/src/Reflector/DefaultReflector.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Roave\BetterReflection\Reflector;
 
-use Iterator;
+use Generator;
 use Roave\BetterReflection\Identifier\Identifier;
 use Roave\BetterReflection\Identifier\IdentifierType;
 use Roave\BetterReflection\Reflection\ReflectionClass;
@@ -60,11 +60,11 @@ final class DefaultReflector implements Reflector
     /**
      * Iterate classes available in the scope specified by the SourceLocator.
      *
-     * @return Iterator<ReflectionClass>
+     * @return Generator<ReflectionClass>
      */
-    public function iterateClasses(?SourceFilter $filter = null): Iterator
+    public function iterateClasses(?SourceFilter $filter = null): Generator
     {
-        /** @var Iterator<ReflectionClass> $allClasses */
+        /** @var Generator<ReflectionClass> $allClasses */
         $allClasses = $this->sourceLocator->iterateIdentifiersByType(
             $this,
             new IdentifierType(IdentifierType::IDENTIFIER_CLASS),

--- a/src/SourceLocator/Type/AbstractSourceLocator.php
+++ b/src/SourceLocator/Type/AbstractSourceLocator.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Roave\BetterReflection\SourceLocator\Type;
 
+use Generator;
 use Roave\BetterReflection\Identifier\Identifier;
 use Roave\BetterReflection\Identifier\IdentifierType;
 use Roave\BetterReflection\Reflection\Reflection;
@@ -12,6 +13,7 @@ use Roave\BetterReflection\Reflector\Reflector;
 use Roave\BetterReflection\SourceLocator\Ast\Exception\ParseToAstFailure;
 use Roave\BetterReflection\SourceLocator\Ast\Locator as AstLocator;
 use Roave\BetterReflection\SourceLocator\Located\LocatedSource;
+use Roave\BetterReflection\SourceLocator\Type\SourceFilter\SourceFilter;
 
 abstract class AbstractSourceLocator implements SourceLocator
 {
@@ -63,6 +65,33 @@ abstract class AbstractSourceLocator implements SourceLocator
         }
 
         return $this->astLocator->findReflectionsOfType(
+            $reflector,
+            $locatedSource,
+            $identifierType,
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @throws ParseToAstFailure
+     */
+    public function iterateIdentifiersByType(
+        Reflector $reflector,
+        IdentifierType $identifierType,
+        ?SourceFilter $sourceFilter,
+    ): Generator {
+        $locatedSource = $this->createLocatedSource(new Identifier(Identifier::WILDCARD, $identifierType));
+
+        if (!$locatedSource || $sourceFilter?->isAllowed(
+                $locatedSource->getSource(),
+                $locatedSource->getName(),
+                $locatedSource->getFileName(),
+            ) === false) {
+            return;
+        }
+
+        yield from $this->astLocator->findReflectionsOfType(
             $reflector,
             $locatedSource,
             $identifierType,

--- a/src/SourceLocator/Type/AggregateSourceLocator.php
+++ b/src/SourceLocator/Type/AggregateSourceLocator.php
@@ -4,10 +4,12 @@ declare(strict_types=1);
 
 namespace Roave\BetterReflection\SourceLocator\Type;
 
+use Generator;
 use Roave\BetterReflection\Identifier\Identifier;
 use Roave\BetterReflection\Identifier\IdentifierType;
 use Roave\BetterReflection\Reflection\Reflection;
 use Roave\BetterReflection\Reflector\Reflector;
+use Roave\BetterReflection\SourceLocator\Type\SourceFilter\SourceFilter;
 
 use function array_map;
 use function array_merge;
@@ -41,5 +43,19 @@ class AggregateSourceLocator implements SourceLocator
             [],
             ...array_map(static fn (SourceLocator $sourceLocator): array => $sourceLocator->locateIdentifiersByType($reflector, $identifierType), $this->sourceLocators),
         );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function iterateIdentifiersByType(
+        Reflector $reflector,
+        IdentifierType $identifierType,
+        ?SourceFilter $sourceFilter,
+    ): Generator
+    {
+        foreach ($this->sourceLocators as $sourceLocator) {
+            yield from $sourceLocator->iterateIdentifiersByType($reflector, $identifierType, $sourceFilter);
+        }
     }
 }

--- a/src/SourceLocator/Type/Composer/PsrAutoloaderLocator.php
+++ b/src/SourceLocator/Type/Composer/PsrAutoloaderLocator.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Roave\BetterReflection\SourceLocator\Type\Composer;
 
+use Generator;
 use Roave\BetterReflection\Identifier\Identifier;
 use Roave\BetterReflection\Identifier\IdentifierType;
 use Roave\BetterReflection\Reflection\Reflection;
@@ -15,8 +16,8 @@ use Roave\BetterReflection\SourceLocator\FileChecker;
 use Roave\BetterReflection\SourceLocator\Located\LocatedSource;
 use Roave\BetterReflection\SourceLocator\Type\Composer\Psr\PsrAutoloaderMapping;
 use Roave\BetterReflection\SourceLocator\Type\DirectoriesSourceLocator;
+use Roave\BetterReflection\SourceLocator\Type\SourceFilter\SourceFilter;
 use Roave\BetterReflection\SourceLocator\Type\SourceLocator;
-
 use function file_get_contents;
 
 final class PsrAutoloaderLocator implements SourceLocator
@@ -62,5 +63,22 @@ final class PsrAutoloaderLocator implements SourceLocator
             $this->mapping->directories(),
             $this->astLocator,
         ))->locateIdentifiersByType($reflector, $identifierType);
+    }
+
+    /**
+     * Iterate filtered identifiers of a type
+     *
+     * @return Generator<Reflection>
+     */
+    public function iterateIdentifiersByType(
+        Reflector $reflector,
+        IdentifierType $identifierType,
+        ?SourceFilter $sourceFilter,
+    ): Generator
+    {
+        return (new DirectoriesSourceLocator(
+            $this->mapping->directories(),
+            $this->astLocator,
+        ))->iterateIdentifiersByType($reflector, $identifierType, $sourceFilter);
     }
 }

--- a/src/SourceLocator/Type/DirectoriesSourceLocator.php
+++ b/src/SourceLocator/Type/DirectoriesSourceLocator.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Roave\BetterReflection\SourceLocator\Type;
 
+use FilesystemIterator;
+use Generator;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 use Roave\BetterReflection\Identifier\Identifier;
@@ -13,6 +15,7 @@ use Roave\BetterReflection\Reflector\Reflector;
 use Roave\BetterReflection\SourceLocator\Ast\Locator;
 use Roave\BetterReflection\SourceLocator\Exception\InvalidDirectory;
 use Roave\BetterReflection\SourceLocator\Exception\InvalidFileInfo;
+use Roave\BetterReflection\SourceLocator\Type\SourceFilter\SourceFilter;
 
 use function array_map;
 use function is_dir;
@@ -41,7 +44,7 @@ class DirectoriesSourceLocator implements SourceLocator
                 return new FileIteratorSourceLocator(
                     new RecursiveIteratorIterator(new RecursiveDirectoryIterator(
                         $directory,
-                        RecursiveDirectoryIterator::SKIP_DOTS,
+                        FilesystemIterator::SKIP_DOTS,
                     )),
                     $astLocator,
                 );
@@ -61,5 +64,17 @@ class DirectoriesSourceLocator implements SourceLocator
     public function locateIdentifiersByType(Reflector $reflector, IdentifierType $identifierType): array
     {
         return $this->aggregateSourceLocator->locateIdentifiersByType($reflector, $identifierType);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function iterateIdentifiersByType(
+        Reflector $reflector,
+        IdentifierType $identifierType,
+        ?SourceFilter $sourceFilter,
+    ): Generator
+    {
+        return $this->aggregateSourceLocator->iterateIdentifiersByType($reflector, $identifierType, $sourceFilter);
     }
 }

--- a/src/SourceLocator/Type/MemoizingSourceLocator.php
+++ b/src/SourceLocator/Type/MemoizingSourceLocator.php
@@ -24,7 +24,7 @@ final class MemoizingSourceLocator implements SourceLocator
     /** @var array<string, list<Reflection>> indexed by reflector key and identifier type cache key */
     private array $cacheByIdentifierTypeKeyAndOid = [];
 
-    /** @var array<string, Iterator<Reflection>> indexed by reflector key and identifier type cache key */
+    /** @var array<string, list<Reflection>> indexed by reflector key, filter key and identifier type cache key */
     private array $cacheIteratorByIdentifierTypeKeyAndOid = [];
 
     public function __construct(private SourceLocator $wrappedSourceLocator)

--- a/src/SourceLocator/Type/SingleFileSourceLocator.php
+++ b/src/SourceLocator/Type/SingleFileSourceLocator.php
@@ -6,6 +6,7 @@ namespace Roave\BetterReflection\SourceLocator\Type;
 
 use InvalidArgumentException;
 use Roave\BetterReflection\Identifier\Identifier;
+use Roave\BetterReflection\Reflection\ReflectionClass;
 use Roave\BetterReflection\SourceLocator\Ast\Locator;
 use Roave\BetterReflection\SourceLocator\Exception\InvalidFileLocation;
 use Roave\BetterReflection\SourceLocator\FileChecker;
@@ -43,9 +44,28 @@ class SingleFileSourceLocator extends AbstractSourceLocator
      */
     protected function createLocatedSource(Identifier $identifier): LocatedSource|null
     {
+        $content = file_get_contents($this->fileName);
+        if (! $content) {
+            return null;
+        }
+
+        $name = $identifier->getName();
+
+        if (
+            $name !== Identifier::WILDCARD &&
+            ! str_starts_with($name, ReflectionClass::ANONYMOUS_CLASS_NAME_PREFIX)
+        ) {
+
+            $shortName = array_reverse(explode('\\', $identifier->getName()))[0];
+
+            if (! str_contains($content, $shortName)) {
+                return null;
+            }
+        }
+
         return new LocatedSource(
-            file_get_contents($this->fileName),
-            $identifier->getName(),
+            $content,
+            $name,
             $this->fileName,
         );
     }

--- a/src/SourceLocator/Type/SourceFilter/AggregateFilter.php
+++ b/src/SourceLocator/Type/SourceFilter/AggregateFilter.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Roave\BetterReflection\SourceLocator\Type\SourceFilter;
+
+class AggregateFilter implements SourceFilter
+{
+    private array $filters;
+
+    public function __construct(SourceFilter ...$filters)
+    {
+        $this->filters = $filters;
+    }
+
+    public function getKey(): string
+    {
+        $keys = array_map(static fn(SourceFilter $filter) => $filter->getKey(), $this->filters);
+
+        return 'group_' . md5(serialize($keys));
+    }
+
+    public function isAllowed(string $source, ?string $name, ?string $filename = null): bool
+    {
+        foreach ($this->filters as $filter) {
+            if (!$filter->isAllowed($source, $name, $filename)) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/src/SourceLocator/Type/SourceFilter/FileNameContainsFilter.php
+++ b/src/SourceLocator/Type/SourceFilter/FileNameContainsFilter.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Roave\BetterReflection\SourceLocator\Type\SourceFilter;
+
+class FileNameContainsFilter implements SourceFilter
+{
+    public function __construct(private readonly array $substrings)
+    {
+    }
+
+    public function getKey(): string
+    {
+
+        return 'fileNameContains_' . md5(serialize($this->substrings));
+    }
+
+    public function isAllowed(string $source, ?string $name, ?string $filename = null): bool
+    {
+        foreach ($this->substrings as $substring) {
+
+            if (is_null($filename) && is_null($substring)) {
+                return true;
+            }
+
+            if (is_null($filename) || is_null($substring)) {
+                return false;
+            }
+
+            if (str_contains($filename, $substring)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/src/SourceLocator/Type/SourceFilter/FileSizeFilter.php
+++ b/src/SourceLocator/Type/SourceFilter/FileSizeFilter.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Roave\BetterReflection\SourceLocator\Type\SourceFilter;
+
+class FileSizeFilter implements SourceFilter
+{
+    public function __construct(private readonly int $maxFileSize)
+    {
+    }
+
+    public function getKey(): string
+    {
+        return "fileSize_{$this->maxFileSize}";
+    }
+
+    public function isAllowed(string $source, ?string $name, ?string $filename = null): bool
+    {
+        return mb_strlen($source) <= $this->maxFileSize;
+    }
+}

--- a/src/SourceLocator/Type/SourceFilter/SourceContainsFilter.php
+++ b/src/SourceLocator/Type/SourceFilter/SourceContainsFilter.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Roave\BetterReflection\SourceLocator\Type\SourceFilter;
+
+class SourceContainsFilter implements SourceFilter
+{
+    public function __construct(private readonly array $substrings)
+    {
+    }
+
+    public function getKey(): string
+    {
+
+        return 'sourceContains_' . md5(serialize($this->substrings));
+    }
+
+    public function isAllowed(string $source, ?string $name, ?string $filename = null): bool
+    {
+        foreach ($this->substrings as $substring) {
+            if (str_contains($source, $substring)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/src/SourceLocator/Type/SourceFilter/SourceFilter.php
+++ b/src/SourceLocator/Type/SourceFilter/SourceFilter.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Roave\BetterReflection\SourceLocator\Type\SourceFilter;
+
+interface SourceFilter
+{
+    public function getKey(): string;
+
+    public function isAllowed(string $source, ?string $name, ?string $filename = null): bool;
+}

--- a/src/SourceLocator/Type/SourceLocator.php
+++ b/src/SourceLocator/Type/SourceLocator.php
@@ -4,10 +4,12 @@ declare(strict_types=1);
 
 namespace Roave\BetterReflection\SourceLocator\Type;
 
+use Generator;
 use Roave\BetterReflection\Identifier\Identifier;
 use Roave\BetterReflection\Identifier\IdentifierType;
 use Roave\BetterReflection\Reflection\Reflection;
 use Roave\BetterReflection\Reflector\Reflector;
+use Roave\BetterReflection\SourceLocator\Type\SourceFilter\SourceFilter;
 
 interface SourceLocator
 {
@@ -29,4 +31,15 @@ interface SourceLocator
      * @return list<Reflection>
      */
     public function locateIdentifiersByType(Reflector $reflector, IdentifierType $identifierType): array;
+
+    /**
+     * Iterate filtered identifiers of a type
+     *
+     * @return Generator<Reflection>
+     */
+    public function iterateIdentifiersByType(
+        Reflector $reflector,
+        IdentifierType $identifierType,
+        ?SourceFilter $sourceFilter,
+    ): Generator;
 }

--- a/test/demo/check-demo.sh
+++ b/test/demo/check-demo.sh
@@ -20,3 +20,4 @@ check demo/basic-reflection/example2.php $'Roave\BetterReflection\Reflection\Ref
 check demo/basic-reflection/example3.php $'MyClass\nprivate'
 check demo/parsing-whole-directory/example1.php $'success'
 check demo/parsing-whole-directory/example2.php $'success'
+check demo/parsing-whole-directory/example3.php $'51'

--- a/test/unit/SourceLocator/Type/AggregateSourceLocatorTest.php
+++ b/test/unit/SourceLocator/Type/AggregateSourceLocatorTest.php
@@ -125,4 +125,42 @@ class AggregateSourceLocatorTest extends TestCase
             ]))->locateIdentifiersByType($this->getMockReflector(), $identifierType),
         );
     }
+
+    public function testIterateIdentifiersByTypeAggregatesSource(): void
+    {
+        $identifierType = new IdentifierType();
+
+        $locator1 = $this->createMock(SourceLocator::class);
+        $locator2 = $this->createMock(SourceLocator::class);
+        $locator3 = $this->createMock(SourceLocator::class);
+        $locator4 = $this->createMock(SourceLocator::class);
+
+        $source2 = $this->createMock(ReflectionClass::class);
+
+        $source3 = $this->createMock(ReflectionClass::class);
+
+        $locator1->expects($this->once())->method('iterateIdentifiersByType')->willReturnCallback(fn() => yield from []);
+        $locator2->expects($this->once())->method('iterateIdentifiersByType')->willReturnCallback(fn() => yield $source2);
+        $locator3->expects($this->once())->method('iterateIdentifiersByType')->willReturnCallback(fn() => yield $source3);
+        $locator4->expects($this->once())->method('iterateIdentifiersByType')->willReturnCallback(fn() => yield from []);
+
+        $locator = (new AggregateSourceLocator([
+            $locator1,
+            $locator2,
+            $locator3,
+            $locator4,
+        ]));
+
+        $generator = $locator->iterateIdentifiersByType($this->getMockReflector(), $identifierType, null);
+
+        $result = [];
+        foreach ($generator as $identifier) {
+            $result[] = $identifier;
+        }
+
+        self::assertSame(
+            [$source2, $source3],
+            $result,
+        );
+    }
 }

--- a/test/unit/SourceLocator/Type/AnonymousClassObjectSourceLocatorTest.php
+++ b/test/unit/SourceLocator/Type/AnonymousClassObjectSourceLocatorTest.php
@@ -144,6 +144,21 @@ class AnonymousClassObjectSourceLocatorTest extends TestCase
         self::assertCount(0, $reflections);
     }
 
+    public function testIterateIdentifiersByTypeWithFunctionIdentifier(): void
+    {
+        $anonymousClass = new class {
+        };
+
+        /** @var list<ReflectionClass> $reflections */
+        $reflections = (new AnonymousClassObjectSourceLocator($anonymousClass, $this->parser))->iterateIdentifiersByType(
+            $this->reflector,
+            new IdentifierType(IdentifierType::IDENTIFIER_FUNCTION),
+            null,
+        );
+
+        self::assertSame(0, iterator_count($reflections));
+    }
+
     public function testExceptionIfAnonymousClassNotFoundOnExpectedLine(): void
     {
         $anonymousClass = new class {

--- a/test/unit/SourceLocator/Type/DirectoriesSourceLocatorTest.php
+++ b/test/unit/SourceLocator/Type/DirectoriesSourceLocatorTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Roave\BetterReflectionTest\SourceLocator\Type;
 
+use Generator;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
@@ -13,6 +14,7 @@ use Roave\BetterReflection\Reflection\ReflectionClass;
 use Roave\BetterReflection\Reflector\DefaultReflector;
 use Roave\BetterReflection\SourceLocator\Exception\InvalidDirectory;
 use Roave\BetterReflection\SourceLocator\Type\DirectoriesSourceLocator;
+use Roave\BetterReflection\SourceLocator\Type\SourceFilter\SourceContainsFilter;
 use Roave\BetterReflectionTest\Assets\DirectoryScannerAssets;
 use Roave\BetterReflectionTest\Assets\DirectoryScannerAssetsFoo;
 use Roave\BetterReflectionTest\BetterReflectionSingleton;
@@ -60,6 +62,49 @@ class DirectoriesSourceLocatorTest extends TestCase
         self::assertEquals(DirectoryScannerAssetsFoo\Foo::class, $classNames[1]);
         self::assertEquals(DirectoryScannerAssets\Bar\FooBar::class, $classNames[2]);
         self::assertEquals(DirectoryScannerAssets\Foo::class, $classNames[3]);
+    }
+
+    #[DataProvider('iterateClassesProvider')]
+    public function testIterateClasses(
+        array $filter,
+        array $expected,
+    ): void
+    {
+        /** @var Generator<ReflectionClass> $generator */
+        $generator = $this->sourceLocator->iterateIdentifiersByType(
+            new DefaultReflector($this->sourceLocator),
+            new IdentifierType(IdentifierType::IDENTIFIER_CLASS),
+            $filter ? new SourceContainsFilter($filter) : null,
+        );
+
+        $classes = [];
+        foreach ($generator as $class) {
+            $classes[] = $class->getName();
+        }
+
+        $this->assertSame($expected, $classes);
+    }
+
+    public static function iterateClassesProvider(): array
+    {
+        return [
+            'Without filter' => [
+                'filter' => [],
+                'expected' => [
+                    DirectoryScannerAssets\Bar\FooBar::class,
+                    DirectoryScannerAssets\Foo::class,
+                    DirectoryScannerAssetsFoo\Bar\FooBar::class,
+                    DirectoryScannerAssetsFoo\Foo::class
+                ],
+            ],
+            'With filter' => [
+                'filter' => ['FooBar'],
+                'expected' => [
+                    DirectoryScannerAssets\Bar\FooBar::class,
+                    DirectoryScannerAssetsFoo\Bar\FooBar::class,
+                ],
+            ]
+        ];
     }
 
     public function testLocateIdentifier(): void

--- a/test/unit/SourceLocator/Type/SourceFilter/AggregateFilterTest.php
+++ b/test/unit/SourceLocator/Type/SourceFilter/AggregateFilterTest.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Roave\BetterReflectionTest\SourceLocator\Type\SourceFilter;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Roave\BetterReflection\SourceLocator\Type\SourceFilter\AggregateFilter;
+use Roave\BetterReflection\SourceLocator\Type\SourceFilter\SourceFilter;
+
+#[CoversClass(AggregateFilter::class)]
+class AggregateFilterTest extends TestCase
+{
+    #[DataProvider('getKeyProvider')]
+    public function testGetKey(
+        array $subFiltersKeys,
+        string $expected,
+    ): void {
+
+        $subFilters = [];
+
+        foreach ($subFiltersKeys as $subFilterKey) {
+            $subFilters[] = new class($subFilterKey) implements SourceFilter {
+
+                public function __construct(
+                    private readonly string $subFilterKey,
+                ) {
+                }
+
+                public function getKey(): string
+                {
+                    return $this->subFilterKey;
+                }
+
+                public function isAllowed(string $source, ?string $name, ?string $filename = null): bool
+                {
+                    return true;
+                }
+            };
+        }
+
+        $filter = new AggregateFilter(...$subFilters);
+
+        $this->assertSame($expected, $filter->getKey());
+    }
+
+    public static function getKeyProvider(): array
+    {
+        return [
+            'Without sub filters' => [
+                'subFiltersKeys' => [],
+                'expected' => 'group_40cd750bba9870f18aada2478b24840a',
+            ],
+            'With sub filters case 1' => [
+                'subFiltersKeys' => [
+                    '111',
+                ],
+                'expected' => 'group_a4628f8734c9d9f1c0af618f5f2e9109',
+            ],
+            'With sub filters case 2' => [
+                'subFiltersKeys' => [
+                    '111',
+                    '333',
+                    'def11',
+                ],
+                'expected' => 'group_93519df5c4a8d75f8fc858f126563cb7',
+            ],
+        ];
+    }
+
+    #[DataProvider('isAllowedProvider')]
+    public function testIsAllowed(
+        array $results,
+        bool $expected,
+    ): void {
+
+        $source = 'testSource';
+        $name = 'testName';
+        $fileName = 'testFileName';
+
+        $subFilters = [];
+        foreach ($results as $result) {
+
+            $sourceFilter = $this->createMock(SourceFilter::class);
+            $sourceFilter
+                ->method('isAllowed')
+                ->with($source, $name, $fileName)
+                ->willReturn($result);
+
+            $subFilters[] = $sourceFilter;
+        }
+
+        $filter = new AggregateFilter(...$subFilters);
+
+        $this->assertSame($expected, $filter->isAllowed($source, $name, $fileName));
+    }
+
+    public static function isAllowedProvider(): array
+    {
+        return [
+            'Without sub filters' => [
+                'results' => [],
+                'expected' => true,
+            ],
+            'With one false sub filter' => [
+                'results' => [false],
+                'expected' => false,
+            ],
+            'With different filters case 1' => [
+                'results' => [true, false],
+                'expected' => false,
+            ],
+            'With different filters case 2' => [
+                'results' => [true, false, false],
+                'expected' => false,
+            ],
+            'With true filter' => [
+                'results' => [true],
+                'expected' => true,
+            ],
+            'With same filters case 1' => [
+                'results' => [true, true],
+                'expected' => true,
+            ],
+            'With same filters case 2' => [
+                'results' => [false, false],
+                'expected' => false,
+            ],
+        ];
+    }
+}

--- a/test/unit/SourceLocator/Type/SourceFilter/FileNameContainsFilterTest.php
+++ b/test/unit/SourceLocator/Type/SourceFilter/FileNameContainsFilterTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Roave\BetterReflectionTest\SourceLocator\Type\SourceFilter;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Roave\BetterReflection\SourceLocator\Type\SourceFilter\FileNameContainsFilter;
+
+#[CoversClass(FileNameContainsFilter::class)]
+class FileNameContainsFilterTest extends TestCase
+{
+    #[DataProvider('getKeyProvider')]
+    public function testGetKey(
+        array $substrings,
+        string $expected,
+    ): void {
+
+        $filter = new FileNameContainsFilter($substrings);
+
+        $this->assertSame($expected, $filter->getKey());
+    }
+
+    public static function getKeyProvider(): array
+    {
+        return [
+            'Without substrings' => [
+                'substrings' => [],
+                'expected' => 'fileNameContains_40cd750bba9870f18aada2478b24840a',
+            ],
+            'With one substring' => [
+                'substrings' => ['2d4f4'],
+                'expected' => 'fileNameContains_c1b5c5d2b3c7d6af36c3a6469ec32678',
+            ],
+            'With null substring' => [
+                'substrings' => [null],
+                'expected' => 'fileNameContains_38017a839aaeb8ff1a658fce9af6edd3',
+            ],
+            'With several substring' => [
+                'substrings' => ['vvvx', '64g22', 'gwqw', '0000', null],
+                'expected' => 'fileNameContains_62ed0da44ff7d9fe6312fd10dfa3a4fc',
+            ],
+        ];
+    }
+
+    #[DataProvider('isAllowedProvider')]
+    public function testIsAllowed(
+        array $substrings,
+        ?string $fileName,
+        bool $expected,
+    ): void {
+
+        $filter = new FileNameContainsFilter($substrings);
+
+        $this->assertSame($expected, $filter->isAllowed('', null, $fileName));
+    }
+
+    public static function isAllowedProvider(): array
+    {
+        return [
+            'Without substrings' => [
+                'substrings' => [],
+                'fileName' => 'sqfw',
+                'expected' => false,
+            ],
+            'Without substrings and null fileName' => [
+                'substrings' => [],
+                'fileName' => null,
+                'expected' => false,
+            ],
+            'With null substring' => [
+                'substrings' => [null],
+                'fileName' => 'sqfw',
+                'expected' => false,
+            ],
+            'With null substring and null fileName' => [
+                'substrings' => [null],
+                'fileName' => null,
+                'expected' => true,
+            ],
+            'With substring' => [
+                'substrings' => ['qq'],
+                'fileName' => 'qqq',
+                'expected' => true,
+            ],
+            'With several substring. The fileName contains one of them' => [
+                'substrings' => ['cc', 'aaa', 'bb'],
+                'fileName' => 'qqq bb cc',
+                'expected' => true,
+            ],
+            'With several substring. The fileName does not contain them' => [
+                'substrings' => ['11', 'aaa', '22'],
+                'fileName' => 'qqq bb cc',
+                'expected' => false,
+            ],
+        ];
+    }
+}

--- a/test/unit/SourceLocator/Type/SourceFilter/FileSizeFilterTest.php
+++ b/test/unit/SourceLocator/Type/SourceFilter/FileSizeFilterTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Roave\BetterReflectionTest\SourceLocator\Type\SourceFilter;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Roave\BetterReflection\SourceLocator\Type\SourceFilter\FileSizeFilter;
+
+#[CoversClass(FileSizeFilter::class)]
+class FileSizeFilterTest extends TestCase
+{
+    #[DataProvider('getKeyProvider')]
+    public function testGetKey(
+        int $fileSize,
+        string $expected,
+    ): void {
+
+        $filter = new FileSizeFilter($fileSize);
+
+        $this->assertSame($expected, $filter->getKey());
+    }
+
+    public static function getKeyProvider(): array
+    {
+        return [
+            'Key 1' => [
+                'fileSize' => 0,
+                'expected' => 'fileSize_0',
+            ],
+            'Key 2' => [
+                'fileSize' => 19324,
+                'expected' => 'fileSize_19324',
+            ],
+        ];
+    }
+
+    #[DataProvider('isAllowedProvider')]
+    public function testIsAllowed(
+        int $maxFileSize,
+        string $source,
+        bool $expected,
+    ): void {
+
+        $filter = new FileSizeFilter($maxFileSize);
+
+        $this->assertSame($expected, $filter->isAllowed($source, null));
+    }
+
+    public static function isAllowedProvider(): array
+    {
+        return [
+            'Allowed size' => [
+                'maxFileSize' => 10,
+                'source' => 'qqq',
+                'expected' => true,
+            ],
+            'Allowed size (max size)' => [
+                'maxFileSize' => 4,
+                'source' => 'qqqq',
+                'expected' => true,
+            ],
+            'Not allowed size' => [
+                'maxFileSize' => 4,
+                'source' => 'qqqqq',
+                'expected' => false,
+            ],
+        ];
+    }
+}

--- a/test/unit/SourceLocator/Type/SourceFilter/SourceContainsFilterTest.php
+++ b/test/unit/SourceLocator/Type/SourceFilter/SourceContainsFilterTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Roave\BetterReflectionTest\SourceLocator\Type\SourceFilter;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Roave\BetterReflection\SourceLocator\Type\SourceFilter\SourceContainsFilter;
+
+#[CoversClass(SourceContainsFilter::class)]
+class SourceContainsFilterTest extends TestCase
+{
+    #[DataProvider('getKeyProvider')]
+    public function testGetKey(
+        array $substrings,
+        string $expected,
+    ): void {
+
+        $filter = new SourceContainsFilter($substrings);
+
+        $this->assertSame($expected, $filter->getKey());
+    }
+
+    public static function getKeyProvider(): array
+    {
+        return [
+            'Without substrings' => [
+                'substrings' => [],
+                'expected' => 'sourceContains_40cd750bba9870f18aada2478b24840a',
+            ],
+            'With one substring' => [
+                'substrings' => ['eff'],
+                'expected' => 'sourceContains_188297be5710cb65088c823bb6909954',
+            ],
+            'With several substring' => [
+                'substrings' => ['eff', '333', 'gtre'],
+                'expected' => 'sourceContains_c4f41f83316c44c3b24385808eadc245',
+            ],
+        ];
+    }
+
+    #[DataProvider('isAllowedProvider')]
+    public function testIsAllowed(
+        array $substrings,
+        string $source,
+        bool $expected,
+    ): void {
+
+        $filter = new SourceContainsFilter($substrings);
+
+        $this->assertSame($expected, $filter->isAllowed($source, null));
+    }
+
+    public static function isAllowedProvider(): array
+    {
+        return [
+            'Without substrings' => [
+                'substrings' => [],
+                'source' => 'qqq',
+                'expected' => false,
+            ],
+            'With substring' => [
+                'substrings' => ['qq'],
+                'source' => 'qqq',
+                'expected' => true,
+            ],
+            'With several substring. The source contains one of them' => [
+                'substrings' => ['cc', 'aaa', 'bb'],
+                'source' => 'qqq bb cc',
+                'expected' => true,
+            ],
+            'With several substring. The source does not contain them' => [
+                'substrings' => ['11', 'aaa', '22'],
+                'source' => 'qqq bb cc',
+                'expected' => false,
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
I made a small optimization of the `FileIteratorSourceLocator` so that all files are not loaded into the array before filtering, but only after it, and also added new functionality for sequential work with files and the ability to filter them.

**Motivation**

When working with really big projects, performance issues often arise. They can be solved with some techniques, such as sequential file processing. This was my main motivation for this work.

**What has been done?**

1) New methods for sequentially obtaining `*Reflection` have been added to `SourceLocators`;
2) A wrapper method has been added to `DefaultReflector` for sequentially obtaining reflect classes;
3) A filtering system has been implemented for obtained `*Reflection`. In most cases, filters are triggered before all complex operations with AST, so filtering in this way is a much more productive method than obtaining individual classes using `reflectClass`;
4) The method for processing files in `FileIteratorSourceLocator` has been changed. Now they are processed sequentially, and not immediately loaded into an array. This reduces resource consumption and speeds up the work of this locator.