### PR TITLE
Using generators to get a list of reflections

### DIFF
--- a/demo/parsing-whole-directory/example1.php
+++ b/demo/parsing-whole-directory/example1.php
@@ -17,6 +17,11 @@ $sourceLocator = new DirectoriesSourceLocator(
 
 $reflector = new DefaultReflector($sourceLocator);
 
-$classReflections = $reflector->reflectAllClasses();
+$generator = $reflector->reflectAllClasses();
+
+$classReflections = [];
+foreach ($generator as $classReflection) {
+    $classReflections[] = $classReflection;
+}
 
 !empty($classReflections) && print 'success';

--- a/demo/parsing-whole-directory/example2.php
+++ b/demo/parsing-whole-directory/example2.php
@@ -23,6 +23,11 @@ $sourceLocator = new AggregateSourceLocator([
 
 $reflector = new DefaultReflector($sourceLocator);
 
-$classReflections = $reflector->reflectAllClasses();
+$generator = $reflector->reflectAllClasses();
+
+$classReflections = [];
+foreach ($generator as $classReflection) {
+    $classReflections[] = $classReflection;
+}
 
 !empty($classReflections) && print 'success';

--- a/src/Reflector/DefaultReflector.php
+++ b/src/Reflector/DefaultReflector.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Roave\BetterReflection\Reflector;
 
+use Generator;
 use Roave\BetterReflection\Identifier\Identifier;
 use Roave\BetterReflection\Identifier\IdentifierType;
 use Roave\BetterReflection\Reflection\ReflectionClass;
@@ -43,11 +44,11 @@ final class DefaultReflector implements Reflector
     /**
      * Get all the classes available in the scope specified by the SourceLocator.
      *
-     * @return list<ReflectionClass>
+     * @return Generator<ReflectionClass>
      */
-    public function reflectAllClasses(): iterable
+    public function reflectAllClasses(): Generator
     {
-        /** @var list<ReflectionClass> $allClasses */
+        /** @var Generator<ReflectionClass> $allClasses */
         $allClasses = $this->sourceLocator->locateIdentifiersByType(
             $this,
             new IdentifierType(IdentifierType::IDENTIFIER_CLASS),
@@ -79,11 +80,11 @@ final class DefaultReflector implements Reflector
     /**
      * Get all the functions available in the scope specified by the SourceLocator.
      *
-     * @return list<ReflectionFunction>
+     * @return Generator<ReflectionFunction>
      */
-    public function reflectAllFunctions(): iterable
+    public function reflectAllFunctions(): Generator
     {
-        /** @var list<ReflectionFunction> $allFunctions */
+        /** @var Generator<ReflectionFunction> $allFunctions */
         $allFunctions = $this->sourceLocator->locateIdentifiersByType(
             $this,
             new IdentifierType(IdentifierType::IDENTIFIER_FUNCTION),
@@ -115,11 +116,11 @@ final class DefaultReflector implements Reflector
     /**
      * Get all the constants available in the scope specified by the SourceLocator.
      *
-     * @return list<ReflectionConstant>
+     * @return Generator<ReflectionConstant>
      */
-    public function reflectAllConstants(): iterable
+    public function reflectAllConstants(): Generator
     {
-        /** @var list<ReflectionConstant> $allConstants */
+        /** @var Generator<ReflectionConstant> $allConstants */
         $allConstants = $this->sourceLocator->locateIdentifiersByType(
             $this,
             new IdentifierType(IdentifierType::IDENTIFIER_CONSTANT),

--- a/src/Reflector/Reflector.php
+++ b/src/Reflector/Reflector.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Roave\BetterReflection\Reflector;
 
+use Generator;
 use Roave\BetterReflection\Reflection\ReflectionClass;
 use Roave\BetterReflection\Reflection\ReflectionConstant;
 use Roave\BetterReflection\Reflection\ReflectionFunction;
@@ -21,9 +22,9 @@ interface Reflector
     /**
      * Get all the classes available in the scope specified by the SourceLocator.
      *
-     * @return list<ReflectionClass>
+     * @return Generator<ReflectionClass>
      */
-    public function reflectAllClasses(): iterable;
+    public function reflectAllClasses(): Generator;
 
     /**
      * Create a ReflectionFunction for the specified $functionName.
@@ -35,9 +36,9 @@ interface Reflector
     /**
      * Get all the functions available in the scope specified by the SourceLocator.
      *
-     * @return list<ReflectionFunction>
+     * @return Generator<ReflectionFunction>
      */
-    public function reflectAllFunctions(): iterable;
+    public function reflectAllFunctions(): Generator;
 
     /**
      * Create a ReflectionConstant for the specified $constantName.
@@ -49,7 +50,7 @@ interface Reflector
     /**
      * Get all the constants available in the scope specified by the SourceLocator.
      *
-     * @return list<ReflectionConstant>
+     * @return Generator<ReflectionConstant>
      */
-    public function reflectAllConstants(): iterable;
+    public function reflectAllConstants(): Generator;
 }

--- a/src/SourceLocator/Type/AbstractSourceLocator.php
+++ b/src/SourceLocator/Type/AbstractSourceLocator.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Roave\BetterReflection\SourceLocator\Type;
 
+use Generator;
 use Roave\BetterReflection\Identifier\Identifier;
 use Roave\BetterReflection\Identifier\IdentifierType;
 use Roave\BetterReflection\Reflection\Reflection;
@@ -54,15 +55,15 @@ abstract class AbstractSourceLocator implements SourceLocator
      *
      * @throws ParseToAstFailure
      */
-    final public function locateIdentifiersByType(Reflector $reflector, IdentifierType $identifierType): array
+    final public function locateIdentifiersByType(Reflector $reflector, IdentifierType $identifierType): Generator
     {
         $locatedSource = $this->createLocatedSource(new Identifier(Identifier::WILDCARD, $identifierType));
 
         if (! $locatedSource) {
-            return [];
+            return;
         }
 
-        return $this->astLocator->findReflectionsOfType(
+        yield from $this->astLocator->findReflectionsOfType(
             $reflector,
             $locatedSource,
             $identifierType,

--- a/src/SourceLocator/Type/AggregateSourceLocator.php
+++ b/src/SourceLocator/Type/AggregateSourceLocator.php
@@ -4,13 +4,11 @@ declare(strict_types=1);
 
 namespace Roave\BetterReflection\SourceLocator\Type;
 
+use Generator;
 use Roave\BetterReflection\Identifier\Identifier;
 use Roave\BetterReflection\Identifier\IdentifierType;
 use Roave\BetterReflection\Reflection\Reflection;
 use Roave\BetterReflection\Reflector\Reflector;
-
-use function array_map;
-use function array_merge;
 
 class AggregateSourceLocator implements SourceLocator
 {
@@ -32,14 +30,10 @@ class AggregateSourceLocator implements SourceLocator
         return null;
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    public function locateIdentifiersByType(Reflector $reflector, IdentifierType $identifierType): array
+    public function locateIdentifiersByType(Reflector $reflector, IdentifierType $identifierType): Generator
     {
-        return array_merge(
-            [],
-            ...array_map(static fn (SourceLocator $sourceLocator): array => $sourceLocator->locateIdentifiersByType($reflector, $identifierType), $this->sourceLocators),
-        );
+        foreach ($this->sourceLocators as $sourceLocator) {
+            yield from $sourceLocator->locateIdentifiersByType($reflector, $identifierType);
+        }
     }
 }

--- a/src/SourceLocator/Type/AnonymousClassObjectSourceLocator.php
+++ b/src/SourceLocator/Type/AnonymousClassObjectSourceLocator.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Roave\BetterReflection\SourceLocator\Type;
 
+use Generator;
 use PhpParser\Node;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\NodeTraverser;
@@ -25,7 +26,6 @@ use Roave\BetterReflection\SourceLocator\FileChecker;
 use Roave\BetterReflection\SourceLocator\Located\AnonymousLocatedSource;
 use Roave\BetterReflection\Util\FileHelper;
 
-use function array_filter;
 use function assert;
 use function file_get_contents;
 use function str_contains;
@@ -55,9 +55,14 @@ final class AnonymousClassObjectSourceLocator implements SourceLocator
      *
      * @throws ParseToAstFailure
      */
-    public function locateIdentifiersByType(Reflector $reflector, IdentifierType $identifierType): array
+    public function locateIdentifiersByType(Reflector $reflector, IdentifierType $identifierType): Generator
     {
-        return array_filter([$this->getReflectionClass($reflector, $identifierType)]);
+        $reflection = $this->getReflectionClass($reflector, $identifierType);
+        if (! $reflection) {
+            return;
+        }
+
+        yield $reflection;
     }
 
     private function getReflectionClass(Reflector $reflector, IdentifierType $identifierType): ReflectionClass|null

--- a/src/SourceLocator/Type/ClosureSourceLocator.php
+++ b/src/SourceLocator/Type/ClosureSourceLocator.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Roave\BetterReflection\SourceLocator\Type;
 
 use Closure;
+use Generator;
 use PhpParser\Node;
 use PhpParser\Node\Stmt\Namespace_;
 use PhpParser\NodeTraverser;
@@ -26,7 +27,6 @@ use Roave\BetterReflection\SourceLocator\FileChecker;
 use Roave\BetterReflection\SourceLocator\Located\AnonymousLocatedSource;
 use Roave\BetterReflection\Util\FileHelper;
 
-use function array_filter;
 use function assert;
 use function file_get_contents;
 use function str_contains;
@@ -56,9 +56,14 @@ final class ClosureSourceLocator implements SourceLocator
      *
      * @throws ParseToAstFailure
      */
-    public function locateIdentifiersByType(Reflector $reflector, IdentifierType $identifierType): array
+    public function locateIdentifiersByType(Reflector $reflector, IdentifierType $identifierType): Generator
     {
-        return array_filter([$this->getReflectionFunction($reflector, $identifierType)]);
+        $reflection = $this->getReflectionFunction($reflector, $identifierType);
+        if (! $reflection) {
+            return;
+        }
+
+        yield $reflection;
     }
 
     private function getReflectionFunction(Reflector $reflector, IdentifierType $identifierType): ReflectionFunction|null

--- a/src/SourceLocator/Type/Composer/PsrAutoloaderLocator.php
+++ b/src/SourceLocator/Type/Composer/PsrAutoloaderLocator.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Roave\BetterReflection\SourceLocator\Type\Composer;
 
+use Generator;
 use Roave\BetterReflection\Identifier\Identifier;
 use Roave\BetterReflection\Identifier\IdentifierType;
 use Roave\BetterReflection\Reflection\Reflection;
@@ -54,11 +55,11 @@ final class PsrAutoloaderLocator implements SourceLocator
     /**
      * Find all identifiers of a type
      *
-     * @return list<Reflection>
+     * @return Generator<Reflection>
      */
-    public function locateIdentifiersByType(Reflector $reflector, IdentifierType $identifierType): array
+    public function locateIdentifiersByType(Reflector $reflector, IdentifierType $identifierType): Generator
     {
-        return (new DirectoriesSourceLocator(
+        yield from (new DirectoriesSourceLocator(
             $this->mapping->directories(),
             $this->astLocator,
         ))->locateIdentifiersByType($reflector, $identifierType);

--- a/src/SourceLocator/Type/DirectoriesSourceLocator.php
+++ b/src/SourceLocator/Type/DirectoriesSourceLocator.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Roave\BetterReflection\SourceLocator\Type;
 
+use Generator;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 use Roave\BetterReflection\Identifier\Identifier;
@@ -55,11 +56,8 @@ class DirectoriesSourceLocator implements SourceLocator
         return $this->aggregateSourceLocator->locateIdentifier($reflector, $identifier);
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    public function locateIdentifiersByType(Reflector $reflector, IdentifierType $identifierType): array
+    public function locateIdentifiersByType(Reflector $reflector, IdentifierType $identifierType): Generator
     {
-        return $this->aggregateSourceLocator->locateIdentifiersByType($reflector, $identifierType);
+        yield from $this->aggregateSourceLocator->locateIdentifiersByType($reflector, $identifierType);
     }
 }

--- a/src/SourceLocator/Type/FileIteratorSourceLocator.php
+++ b/src/SourceLocator/Type/FileIteratorSourceLocator.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Roave\BetterReflection\SourceLocator\Type;
 
+use Generator;
 use Iterator;
 use Roave\BetterReflection\Identifier\Identifier;
 use Roave\BetterReflection\Identifier\IdentifierType;
@@ -83,8 +84,8 @@ class FileIteratorSourceLocator implements SourceLocator
      *
      * @throws InvalidFileLocation
      */
-    public function locateIdentifiersByType(Reflector $reflector, IdentifierType $identifierType): array
+    public function locateIdentifiersByType(Reflector $reflector, IdentifierType $identifierType): Generator
     {
-        return $this->getAggregatedSourceLocator()->locateIdentifiersByType($reflector, $identifierType);
+        yield from $this->getAggregatedSourceLocator()->locateIdentifiersByType($reflector, $identifierType);
     }
 }

--- a/src/SourceLocator/Type/MemoizingSourceLocator.php
+++ b/src/SourceLocator/Type/MemoizingSourceLocator.php
@@ -49,10 +49,12 @@ final class MemoizingSourceLocator implements SourceLocator
             return;
         }
 
+        $items = [];
         foreach ($this->wrappedSourceLocator->locateIdentifiersByType($reflector, $identifierType) as $item) {
-            yield $this->cacheByIdentifierTypeKeyAndOid[$cacheKey][] = $item;
+            yield $items[] = $item;
         }
-        //todo
+
+        $this->cacheByIdentifierTypeKeyAndOid[$cacheKey] = $items;
     }
 
     private function reflectorCacheKey(Reflector $reflector): string

--- a/src/SourceLocator/Type/MemoizingSourceLocator.php
+++ b/src/SourceLocator/Type/MemoizingSourceLocator.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Roave\BetterReflection\SourceLocator\Type;
 
+use Generator;
 use Roave\BetterReflection\Identifier\Identifier;
 use Roave\BetterReflection\Identifier\IdentifierType;
 use Roave\BetterReflection\Reflection\Reflection;
@@ -37,17 +38,21 @@ final class MemoizingSourceLocator implements SourceLocator
             = $this->wrappedSourceLocator->locateIdentifier($reflector, $identifier);
     }
 
-    /** @return list<Reflection> */
-    public function locateIdentifiersByType(Reflector $reflector, IdentifierType $identifierType): array
+    /** @return Generator<Reflection> */
+    public function locateIdentifiersByType(Reflector $reflector, IdentifierType $identifierType): Generator
     {
         $cacheKey = sprintf('%s_%s', $this->reflectorCacheKey($reflector), $this->identifierTypeToCacheKey($identifierType));
 
         if (array_key_exists($cacheKey, $this->cacheByIdentifierTypeKeyAndOid)) {
-            return $this->cacheByIdentifierTypeKeyAndOid[$cacheKey];
+            yield from $this->cacheByIdentifierTypeKeyAndOid[$cacheKey];
+
+            return;
         }
 
-        return $this->cacheByIdentifierTypeKeyAndOid[$cacheKey]
-            = $this->wrappedSourceLocator->locateIdentifiersByType($reflector, $identifierType);
+        foreach ($this->wrappedSourceLocator->locateIdentifiersByType($reflector, $identifierType) as $item) {
+            yield $this->cacheByIdentifierTypeKeyAndOid[$cacheKey][] = $item;
+        }
+        //todo
     }
 
     private function reflectorCacheKey(Reflector $reflector): string

--- a/src/SourceLocator/Type/SourceLocator.php
+++ b/src/SourceLocator/Type/SourceLocator.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Roave\BetterReflection\SourceLocator\Type;
 
+use Generator;
 use Roave\BetterReflection\Identifier\Identifier;
 use Roave\BetterReflection\Identifier\IdentifierType;
 use Roave\BetterReflection\Reflection\Reflection;
@@ -26,7 +27,7 @@ interface SourceLocator
     /**
      * Find all identifiers of a type
      *
-     * @return list<Reflection>
+     * @return Generator<Reflection>
      */
-    public function locateIdentifiersByType(Reflector $reflector, IdentifierType $identifierType): array;
+    public function locateIdentifiersByType(Reflector $reflector, IdentifierType $identifierType): Generator;
 }

--- a/test/unit/Reflection/ReflectionClassTest.php
+++ b/test/unit/Reflection/ReflectionClassTest.php
@@ -1153,7 +1153,13 @@ PHP;
             $this->astLocator,
         ));
 
-        $allClassesInfo = $reflector->reflectAllClasses();
+        $generator = $reflector->reflectAllClasses();
+
+        $allClassesInfo = [];
+        foreach ($generator as $reflectionClass) {
+            $allClassesInfo[] = $reflectionClass;
+        }
+
         self::assertCount(1, $allClassesInfo);
 
         $classInfo = $allClassesInfo[0];
@@ -1171,14 +1177,17 @@ PHP;
         ));
 
         $allClassesInfo = $reflector->reflectAllClasses();
-        self::assertCount(2, $allClassesInfo);
 
+        $count = 0;
         foreach ($allClassesInfo as $classInfo) {
             self::assertTrue($classInfo->isAnonymous());
             self::assertFalse($classInfo->inNamespace());
             self::assertStringStartsWith(ReflectionClass::ANONYMOUS_CLASS_NAME_PREFIX, $classInfo->getName());
             self::assertStringMatchesFormat('%sFixture/AnonymousClassInNamespace.php(%d)', $classInfo->getName());
+            ++$count;
         }
+
+        self::assertSame(2, $count);
     }
 
     public function testIsAnonymousWithNestedAnonymousClasses(): void
@@ -1189,14 +1198,17 @@ PHP;
         ));
 
         $allClassesInfo = $reflector->reflectAllClasses();
-        self::assertCount(3, $allClassesInfo);
 
+        $count = 0;
         foreach ($allClassesInfo as $classInfo) {
             self::assertTrue($classInfo->isAnonymous());
             self::assertFalse($classInfo->inNamespace());
             self::assertStringStartsWith(ReflectionClass::ANONYMOUS_CLASS_NAME_PREFIX, $classInfo->getName());
             self::assertStringMatchesFormat('%sFixture/NestedAnonymousClassInstances.php(%d)', $classInfo->getName());
+            ++$count;
         }
+
+        self::assertSame(3, $count);
     }
 
     public function testAnonymousClassWithParent(): void
@@ -1206,7 +1218,11 @@ PHP;
             $this->astLocator,
         ));
 
-        $allClassesInfo = $reflector->reflectAllClasses();
+        $allClassesInfo = [];
+        foreach ($reflector->reflectAllClasses() as $classInfo) {
+            $allClassesInfo[] = $classInfo;
+        }
+
         self::assertCount(3, $allClassesInfo);
 
         $classInfo = $allClassesInfo[2];
@@ -1227,7 +1243,13 @@ PHP;
             $this->astLocator,
         ));
 
-        $allClassesInfo = $reflector->reflectAllClasses();
+        $generator = $reflector->reflectAllClasses();
+
+        $allClassesInfo = [];
+        foreach ($generator as $reflectionClass) {
+            $allClassesInfo[] = $reflectionClass;
+        }
+
         self::assertCount(2, $allClassesInfo);
 
         $classInfo = $allClassesInfo[0];
@@ -1244,7 +1266,13 @@ PHP;
             $this->astLocator,
         ));
 
-        $allClassesInfo = $reflector->reflectAllClasses();
+        $generator = $reflector->reflectAllClasses();
+
+        $allClassesInfo = [];
+        foreach ($generator as $reflectionClass) {
+            $allClassesInfo[] = $reflectionClass;
+        }
+
         self::assertCount(3, $allClassesInfo);
 
         $classInfo = $allClassesInfo[2];
@@ -1266,7 +1294,13 @@ PHP;
 
         $reflector = new DefaultReflector(new StringSourceLocator($php, $this->astLocator));
 
-        $allClassesInfo = $reflector->reflectAllClasses();
+        $generator = $reflector->reflectAllClasses();
+
+        $allClassesInfo = [];
+        foreach ($generator as $reflectionClass) {
+            $allClassesInfo[] = $reflectionClass;
+        }
+
         self::assertCount(1, $allClassesInfo);
 
         $classInfo = $allClassesInfo[0];

--- a/test/unit/Reflector/DefaultReflectorTest.php
+++ b/test/unit/Reflector/DefaultReflectorTest.php
@@ -56,9 +56,14 @@ class DefaultReflectorTest extends TestCase
 
     public function testReflectAllClasses(): void
     {
-        $classes = (new DefaultReflector(
+        $generator = (new DefaultReflector(
             new SingleFileSourceLocator(__DIR__ . '/../Fixture/ExampleClass.php', $this->astLocator),
         ))->reflectAllClasses();
+
+        $classes = [];
+        foreach ($generator as $class) {
+            $classes[] = $class;
+        }
 
         self::assertContainsOnlyInstancesOf(ReflectionClass::class, $classes);
         self::assertCount(11, $classes);
@@ -88,9 +93,14 @@ class DefaultReflectorTest extends TestCase
 
     public function testReflectAllFunction(): void
     {
-        $functions = (new DefaultReflector(
+        $generator = (new DefaultReflector(
             new SingleFileSourceLocator(__DIR__ . '/../Fixture/Functions.php', $this->astLocator),
         ))->reflectAllFunctions();
+
+        $functions = [];
+        foreach ($generator as $reflection) {
+            $functions[] = $reflection;
+        }
 
         self::assertContainsOnlyInstancesOf(ReflectionFunction::class, $functions);
         self::assertCount(2, $functions);
@@ -120,9 +130,14 @@ class DefaultReflectorTest extends TestCase
 
     public function testReflectAllConstants(): void
     {
-        $constants = (new DefaultReflector(
+        $generator = (new DefaultReflector(
             new SingleFileSourceLocator(__DIR__ . '/../Fixture/Constants.php', $this->astLocator),
         ))->reflectAllConstants();
+
+        $constants = [];
+        foreach ($generator as $reflection) {
+            $constants[] = $reflection;
+        }
 
         self::assertContainsOnlyInstancesOf(ReflectionConstant::class, $constants);
         self::assertCount(5, $constants);

--- a/test/unit/SourceLocator/Type/AbstractSourceLocatorTest.php
+++ b/test/unit/SourceLocator/Type/AbstractSourceLocatorTest.php
@@ -15,6 +15,9 @@ use Roave\BetterReflection\SourceLocator\Ast\Locator as AstLocator;
 use Roave\BetterReflection\SourceLocator\Located\LocatedSource;
 use Roave\BetterReflection\SourceLocator\Type\AbstractSourceLocator;
 
+use function iterator_count;
+use function iterator_to_array;
+
 #[CoversClass(AbstractSourceLocator::class)]
 class AbstractSourceLocatorTest extends TestCase
 {
@@ -126,7 +129,9 @@ class AbstractSourceLocatorTest extends TestCase
             ->method('createLocatedSource')
             ->willReturn($locatedSource);
 
-        self::assertSame([$mockReflection], $sourceLocator->locateIdentifiersByType($mockReflector, $identifierType));
+        $generator = $sourceLocator->locateIdentifiersByType($mockReflector, $identifierType);
+
+        self::assertSame([$mockReflection], iterator_to_array($generator));
     }
 
     public function testLocateIdentifiersByTypeReturnsEmptyArrayWithoutTryingToFindReflectionsWhenUnableToLocateSource(): void
@@ -149,6 +154,8 @@ class AbstractSourceLocatorTest extends TestCase
             ->method('createLocatedSource')
             ->willReturn(null);
 
-        self::assertSame([], $sourceLocator->locateIdentifiersByType($mockReflector, $identifierType));
+        $generator = $sourceLocator->locateIdentifiersByType($mockReflector, $identifierType);
+
+        self::assertSame(0, iterator_count($generator));
     }
 }

--- a/test/unit/SourceLocator/Type/Composer/PsrAutoloaderLocatorTest.php
+++ b/test/unit/SourceLocator/Type/Composer/PsrAutoloaderLocatorTest.php
@@ -9,7 +9,6 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Roave\BetterReflection\Identifier\Identifier;
 use Roave\BetterReflection\Identifier\IdentifierType;
-use Roave\BetterReflection\Reflection\Reflection;
 use Roave\BetterReflection\Reflector\DefaultReflector;
 use Roave\BetterReflection\Reflector\Reflector;
 use Roave\BetterReflection\SourceLocator\Type\Composer\Psr\Psr4Mapping;
@@ -21,7 +20,6 @@ use Roave\BetterReflectionTest\Assets\DirectoryScannerAssetsFoo\Bar\FooBar as Fo
 use Roave\BetterReflectionTest\Assets\DirectoryScannerAssetsFoo\Foo as Foo1;
 use Roave\BetterReflectionTest\BetterReflectionSingleton;
 
-use function array_map;
 use function sort;
 
 #[CoversClass(PsrAutoloaderLocator::class)]
@@ -166,13 +164,15 @@ class PsrAutoloaderLocatorTest extends TestCase
             Foo1::class,
         ];
 
-        $actual = array_map(
-            static fn (Reflection $reflection): string => $reflection->getName(),
-            $locator->locateIdentifiersByType(
-                new DefaultReflector($locator),
-                new IdentifierType(IdentifierType::IDENTIFIER_CLASS),
-            ),
+        $generator = $locator->locateIdentifiersByType(
+            new DefaultReflector($locator),
+            new IdentifierType(IdentifierType::IDENTIFIER_CLASS),
         );
+
+        $actual = [];
+        foreach ($generator as $reflection) {
+            $actual[] = $reflection->getName();
+        }
 
         // Sorting may depend on filesystem here
         sort($expected);

--- a/test/unit/SourceLocator/Type/DirectoriesSourceLocatorTest.php
+++ b/test/unit/SourceLocator/Type/DirectoriesSourceLocatorTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Roave\BetterReflectionTest\SourceLocator\Type;
 
+use Generator;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
@@ -17,7 +18,6 @@ use Roave\BetterReflectionTest\Assets\DirectoryScannerAssets;
 use Roave\BetterReflectionTest\Assets\DirectoryScannerAssetsFoo;
 use Roave\BetterReflectionTest\BetterReflectionSingleton;
 
-use function array_map;
 use function sort;
 use function uniqid;
 
@@ -41,18 +41,18 @@ class DirectoriesSourceLocatorTest extends TestCase
 
     public function testScanDirectoryClasses(): void
     {
-        /** @var list<ReflectionClass> $classes */
-        $classes = $this->sourceLocator->locateIdentifiersByType(
+        /** @var Generator<ReflectionClass> $generator */
+        $generator = $this->sourceLocator->locateIdentifiersByType(
             new DefaultReflector($this->sourceLocator),
             new IdentifierType(IdentifierType::IDENTIFIER_CLASS),
         );
 
-        self::assertCount(4, $classes);
+        $classNames = [];
+        foreach ($generator as $reflectionClass) {
+            $classNames[] = $reflectionClass->getName();
+        }
 
-        $classNames = array_map(
-            static fn (ReflectionClass $reflectionClass): string => $reflectionClass->getName(),
-            $classes,
-        );
+        self::assertCount(4, $classNames);
 
         sort($classNames);
 

--- a/test/unit/SourceLocator/Type/FileIteratorSourceLocatorTest.php
+++ b/test/unit/SourceLocator/Type/FileIteratorSourceLocatorTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Roave\BetterReflectionTest\SourceLocator\Type;
 
 use ArrayIterator;
+use FilesystemIterator;
+use Generator;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use RecursiveDirectoryIterator;
@@ -19,7 +21,6 @@ use Roave\BetterReflectionTest\Assets\DirectoryScannerAssets;
 use Roave\BetterReflectionTest\BetterReflectionSingleton;
 use stdClass;
 
-use function array_map;
 use function sort;
 
 #[CoversClass(FileIteratorSourceLocator::class)]
@@ -34,7 +35,7 @@ class FileIteratorSourceLocatorTest extends TestCase
         $this->sourceLocator = new FileIteratorSourceLocator(
             new RecursiveIteratorIterator(new RecursiveDirectoryIterator(
                 __DIR__ . '/../../Assets/DirectoryScannerAssets',
-                RecursiveDirectoryIterator::SKIP_DOTS,
+                FilesystemIterator::SKIP_DOTS,
             ), RecursiveIteratorIterator::SELF_FIRST),
             BetterReflectionSingleton::instance()->astLocator(),
         );
@@ -42,18 +43,18 @@ class FileIteratorSourceLocatorTest extends TestCase
 
     public function testScanDirectoryClasses(): void
     {
-        /** @var list<ReflectionClass> $classes */
+        /** @var Generator<ReflectionClass> $classes */
         $classes = $this->sourceLocator->locateIdentifiersByType(
             new DefaultReflector($this->sourceLocator),
             new IdentifierType(IdentifierType::IDENTIFIER_CLASS),
         );
 
-        self::assertCount(2, $classes);
+        $classNames = [];
+        foreach ($classes as $reflectionClass) {
+            $classNames[] = $reflectionClass->getName();
+        }
 
-        $classNames = array_map(
-            static fn (ReflectionClass $reflectionClass): string => $reflectionClass->getName(),
-            $classes,
-        );
+        self::assertCount(2, $classNames);
 
         sort($classNames);
 


### PR DESCRIPTION
Part of PR https://github.com/Roave/BetterReflection/pull/1475 related to using generators instead of arrays to get a list of reflections

**What has been done?**

1) `locateIdentifiersByType` now returns a generator to process each individual class sequentially

2) `reflectAllClasses` / `reflectAllFunctions` / `reflectAllConstants` methods of `DefaultReflector` class now return generators instead of arrays

3) `FindReflectionOnLine` now takes reflections one by one using generators