### PR TITLE
Simplify `FileIteratorSourceLocator`, prevent stat calls on paths that aren't PHP files

### DIFF
--- a/src/SourceLocator/Type/FileIteratorSourceLocator.php
+++ b/src/SourceLocator/Type/FileIteratorSourceLocator.php
@@ -18,9 +18,6 @@ use function array_filter;
 use function array_map;
 use function array_values;
 use function iterator_to_array;
-use function pathinfo;
-
-use const PATHINFO_EXTENSION;
 
 /**
  * This source locator loads all php files from \FileSystemIterator
@@ -56,13 +53,11 @@ class FileIteratorSourceLocator implements SourceLocator
         return $this->aggregateSourceLocator
             ?? $this->aggregateSourceLocator = new AggregateSourceLocator(array_values(array_filter(array_map(
                 function (SplFileInfo $item): SingleFileSourceLocator|null {
-                    $realPath = $item->getRealPath();
-
-                    if (! ($item->isFile() && pathinfo($realPath, PATHINFO_EXTENSION) === 'php')) {
+                    if (! ($item->isFile() && $item->getExtension() === 'php')) {
                         return null;
                     }
 
-                    return new SingleFileSourceLocator($realPath, $this->astLocator);
+                    return new SingleFileSourceLocator($item->getRealPath(), $this->astLocator);
                 },
                 iterator_to_array($this->fileSystemIterator),
             ))));


### PR DESCRIPTION
I think this saves a system call per non PHP file as `getRealPath` is only invoked for php-files after the PR