### PR TITLE
Property from interface is abstract property

### DIFF
--- a/src/Reflection/ReflectionProperty.php
+++ b/src/Reflection/ReflectionProperty.php
@@ -309,7 +309,8 @@ class ReflectionProperty
 
     public function isAbstract(): bool
     {
-        return (bool) ($this->modifiers & ReflectionPropertyAdapter::IS_ABSTRACT_COMPATIBILITY);
+        return (bool) ($this->modifiers & ReflectionPropertyAdapter::IS_ABSTRACT_COMPATIBILITY)
+            || $this->declaringClass->isInterface();
     }
 
     public function isPromoted(): bool

--- a/test/unit/Fixture/PropertyHooks.php
+++ b/test/unit/Fixture/PropertyHooks.php
@@ -164,3 +164,8 @@ class FinalPropertyHooks
         final set => strtolower($value);
     }
 }
+
+interface InterfaceWithProperty
+{
+    public int $abstractPropertyFromInterface { get; set; }
+}

--- a/test/unit/Reflection/ReflectionPropertyTest.php
+++ b/test/unit/Reflection/ReflectionPropertyTest.php
@@ -1021,6 +1021,15 @@ PHP;
         self::assertTrue($hookProperty->isAbstract());
     }
 
+    public function testIsAbstractInInterface(): void
+    {
+        $reflector = new DefaultReflector(new SingleFileSourceLocator(__DIR__ . '/../Fixture/PropertyHooks.php', $this->astLocator));
+        $classInfo = $reflector->reflectClass('Roave\BetterReflectionTest\Fixture\InterfaceWithProperty');
+
+        $abstractProperty = $classInfo->getProperty('abstractPropertyFromInterface');
+        self::assertTrue($abstractProperty->isAbstract());
+    }
+
     public function testNoHooks(): void
     {
         $classInfo = $this->reflector->reflectClass(ExampleClass::class);


### PR DESCRIPTION
Days without bug in property hooks: 0

PHP proof: https://3v4l.org/B8iGK

I took the fix from ReflectionMethod because the logic is the same and it works properly there.