### PR TITLE
fix: some functions falsely detected as generators

### DIFF
--- a/src/Reflection/ReflectionFunctionAbstract.php
+++ b/src/Reflection/ReflectionFunctionAbstract.php
@@ -8,6 +8,8 @@ use PhpParser\Node;
 use PhpParser\Node\Expr\Throw_ as NodeThrow;
 use PhpParser\Node\Expr\Yield_ as YieldNode;
 use PhpParser\Node\Expr\YieldFrom as YieldFromNode;
+use PhpParser\Node\FunctionLike as FunctionLikeNode;
+use PhpParser\Node\Stmt\Class_ as ClassNode;
 use PhpParser\Node\Stmt\ClassMethod as MethodNode;
 use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitor\FindingVisitor;
@@ -360,7 +362,12 @@ trait ReflectionFunctionAbstract
         foreach ($node->getSubNodeNames() as $nodeName) {
             $nodeProperty = $node->$nodeName;
 
-            if ($nodeProperty instanceof Node && $this->nodeIsOrContainsYield($nodeProperty)) {
+            if (
+                $nodeProperty instanceof Node &&
+                ! ($nodeProperty instanceof ClassNode) &&
+                ! ($nodeProperty instanceof FunctionLikeNode) &&
+                $this->nodeIsOrContainsYield($nodeProperty)
+            ) {
                 return true;
             }
 

--- a/test/unit/Reflection/ReflectionFunctionAbstractTest.php
+++ b/test/unit/Reflection/ReflectionFunctionAbstractTest.php
@@ -236,6 +236,9 @@ class ReflectionFunctionAbstractTest extends TestCase
             ['<?php function foo() { $foo->func(yield $foo); }', true],
             ['<?php function foo() { new Foo(yield $foo); }', true],
             ['<?php function foo() { yield from []; }', true],
+            ['<?php function foo() { return fn () => yield $foo; }', false],
+            ['<?php function foo() { return function () { yield $foo; }; }', false],
+            ['<?php function foo() { return new class () { function bar() { yield $foo; } }; }', false],
         ];
     }
 


### PR DESCRIPTION
Relates to phpstan/phpstan-src#3794 and phpstan/phpstan#12462.

@ondrejmirtes asked me to submit an according fix here as well. 

The proposed changes fix functions returning closures, arrow functions or anonymous classes containing yield expressions to be falsely recognized as generators. 
