### PR TITLE
Inline array_map(fn, $arr) and use foreach-loop instead

### DIFF
--- a/src/Reflection/Adapter/ReflectionClass.php
+++ b/src/Reflection/Adapter/ReflectionClass.php
@@ -384,14 +384,12 @@ final class ReflectionClass extends CoreReflectionClass
     {
         $traits = $this->betterReflectionClass->getTraits();
 
-        /** @var list<trait-string> $traitNames */
-        $traitNames = array_map(static fn (BetterReflectionClass $trait): string => $trait->getName(), $traits);
+        $result = [];
+        foreach ($traits as $trait) {
+            $result[$trait->getName()] = new self($trait);
+        }
 
-        /** @psalm-suppress ImpureFunctionCall */
-        return array_combine(
-            $traitNames,
-            array_map(static fn (BetterReflectionClass $trait): self => new self($trait), $traits),
-        );
+        return $result;
     }
 
     /**

--- a/src/Reflection/Adapter/ReflectionMethod.php
+++ b/src/Reflection/Adapter/ReflectionMethod.php
@@ -17,7 +17,6 @@ use Roave\BetterReflection\Reflection\Exception\MethodPrototypeNotFound;
 use Roave\BetterReflection\Reflection\Exception\NoObjectProvided;
 use Roave\BetterReflection\Reflection\ReflectionAttribute as BetterReflectionAttribute;
 use Roave\BetterReflection\Reflection\ReflectionMethod as BetterReflectionMethod;
-use Roave\BetterReflection\Reflection\ReflectionParameter as BetterReflectionParameter;
 use Roave\BetterReflection\Reflector\Exception\IdentifierNotFound;
 use Roave\BetterReflection\Util\FileHelper;
 use Throwable;
@@ -198,10 +197,12 @@ final class ReflectionMethod extends CoreReflectionMethod
      */
     public function getParameters(): array
     {
-        return array_map(
-            static fn (BetterReflectionParameter $parameter): ReflectionParameter => new ReflectionParameter($parameter),
-            $this->betterReflectionMethod->getParameters(),
-        );
+        $parameters = [];
+        foreach ($this->betterReflectionMethod->getParameters() as $parameter) {
+            $parameters[] = new ReflectionParameter($parameter);
+        }
+
+        return $parameters;
     }
 
     /** @psalm-mutation-free */

--- a/src/Reflection/ReflectionClass.php
+++ b/src/Reflection/ReflectionClass.php
@@ -1154,7 +1154,12 @@ class ReflectionClass implements Reflection
      */
     public function getParentClassNames(): array
     {
-        return array_map(static fn (self $parentClass): string => $parentClass->getName(), $this->getParentClasses());
+        $classNames = [];
+        foreach ($this->getParentClasses() as $parentClass) {
+            $classNames[] = $parentClass->getName();
+        }
+
+        return $classNames;
     }
 
     /** @return list<ReflectionClass> */


### PR DESCRIPTION
Based on a perf review togehter with nielsdos (php-src core develoepr) we identified `array_map`, when used with a callback function to be a hotspot in PHPStan analysis, see https://phpc.social/@markusstaab/114301182551454759

I've did some research and used some hack to record the call count of `array_map` when running PHPStan and isolate the following list of [call sites from BetterReflection](https://gist.github.com/staabm/3483fecb637886fab239d1657235b496#file-sorted-log).


the list contains 3 outstanding callers which dominate the call-counts. these occurences have been adjusted with this PR.

⚠️ still work in progress