### PR TITLE
Add `ReflectionEnumCase#hasValueExpression()`

### DIFF
--- a/src/Reflection/ReflectionEnumCase.php
+++ b/src/Reflection/ReflectionEnumCase.php
@@ -87,6 +87,10 @@ class ReflectionEnumCase
         return $this->name;
     }
 
+    /**
+     * While ReflectionEnum::isBacked() is a sufficient check when working with valid PHP code,
+     * with an invalid enum declaration we can still encounter a back enum case with a missing value.
+     */
     public function hasValueExpression(): bool
     {
         return $this->value !== null;

--- a/src/Reflection/ReflectionEnumCase.php
+++ b/src/Reflection/ReflectionEnumCase.php
@@ -87,8 +87,13 @@ class ReflectionEnumCase
         return $this->name;
     }
 
+    public function hasValueExpression(): bool
+    {
+        return $this->value !== null;
+    }
+
     /**
-     * Check ReflectionEnum::isBacked() being true first to avoid throwing exception.
+     * Check self::hasValueExpression() being true first to avoid throwing exception.
      *
      * @throws LogicException
      */
@@ -110,7 +115,7 @@ class ReflectionEnumCase
     }
 
     /**
-     * Check ReflectionEnum::isBacked() being true first to avoid throwing exception.
+     * Check self::hasValueExpression() being true first to avoid throwing exception.
      *
      * @throws LogicException
      */

--- a/test/unit/Fixture/Enums.php
+++ b/test/unit/Fixture/Enums.php
@@ -71,8 +71,3 @@ enum IsDeprecated
 interface InterfaceForEnum
 {
 }
-
-enum InvalidEnum: int
-{
-    case INVALID;
-}

--- a/test/unit/Fixture/Enums.php
+++ b/test/unit/Fixture/Enums.php
@@ -71,3 +71,8 @@ enum IsDeprecated
 interface InterfaceForEnum
 {
 }
+
+enum InvalidEnum: int
+{
+    case INVALID;
+}

--- a/test/unit/Fixture/InvalidEnums.php
+++ b/test/unit/Fixture/InvalidEnums.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Roave\BetterReflectionTest\Fixture;
+
+enum InvalidEnum: int
+{
+    case INVALID;
+}

--- a/test/unit/Reflection/ReflectionEnumCaseTest.php
+++ b/test/unit/Reflection/ReflectionEnumCaseTest.php
@@ -14,6 +14,7 @@ use Roave\BetterReflection\Reflection\ReflectionEnumCase;
 use Roave\BetterReflection\Reflector\DefaultReflector;
 use Roave\BetterReflection\Reflector\Reflector;
 use Roave\BetterReflection\SourceLocator\Ast\Locator;
+use Roave\BetterReflection\SourceLocator\Type\AggregateSourceLocator;
 use Roave\BetterReflection\SourceLocator\Type\SingleFileSourceLocator;
 use Roave\BetterReflectionTest\BetterReflectionSingleton;
 use Roave\BetterReflectionTest\Fixture\Attr;
@@ -36,7 +37,12 @@ class ReflectionEnumCaseTest extends TestCase
         parent::setUp();
 
         $this->astLocator = BetterReflectionSingleton::instance()->astLocator();
-        $this->reflector  = new DefaultReflector(new SingleFileSourceLocator(__DIR__ . '/../Fixture/Enums.php', $this->astLocator));
+        $this->reflector  = new DefaultReflector(
+            new AggregateSourceLocator([
+                new SingleFileSourceLocator(__DIR__ . '/../Fixture/Enums.php', $this->astLocator),
+                new SingleFileSourceLocator(__DIR__ . '/../Fixture/InvalidEnums.php', $this->astLocator),
+            ]),
+        );
     }
 
     /** @return list<array{0: class-string, 1: non-empty-string}> */

--- a/test/unit/Reflection/ReflectionEnumCaseTest.php
+++ b/test/unit/Reflection/ReflectionEnumCaseTest.php
@@ -19,6 +19,7 @@ use Roave\BetterReflectionTest\BetterReflectionSingleton;
 use Roave\BetterReflectionTest\Fixture\Attr;
 use Roave\BetterReflectionTest\Fixture\DocComment;
 use Roave\BetterReflectionTest\Fixture\IntEnum;
+use Roave\BetterReflectionTest\Fixture\InvalidEnum;
 use Roave\BetterReflectionTest\Fixture\IsDeprecated;
 use Roave\BetterReflectionTest\Fixture\PureEnum;
 use Roave\BetterReflectionTest\Fixture\StringEnum;
@@ -45,6 +46,7 @@ class ReflectionEnumCaseTest extends TestCase
             [PureEnum::class, 'ONE'],
             [IntEnum::class, 'TWO'],
             [StringEnum::class, 'THREE'],
+            [InvalidEnum::class, 'INVALID'],
         ];
     }
 
@@ -60,6 +62,33 @@ class ReflectionEnumCaseTest extends TestCase
 
         self::assertInstanceOf(ReflectionEnumCase::class, $caseReflection);
         self::assertSame($caseName, $caseReflection->getName());
+    }
+
+    /** @return list<array{0: class-string, 1: non-empty-string, 2: bool}> */
+    public static function dataHasValueExpression(): array
+    {
+        return [
+            [PureEnum::class, 'ONE', false, false],
+            [InvalidEnum::class, 'INVALID', true, false],
+            [IntEnum::class, 'TWO', true, true],
+            [StringEnum::class, 'THREE', true, true],
+        ];
+    }
+
+    /** @param non-empty-string $caseName */
+    #[DataProvider('dataHasValueExpression')]
+    public function testHasValueExpression(string $enumName, string $caseName, bool $isBacked, bool $hasValue): void
+    {
+        $enumReflection = $this->reflector->reflectClass($enumName);
+
+        self::assertInstanceOf(ReflectionEnum::class, $enumReflection);
+
+        self::assertSame($isBacked, $enumReflection->isBacked());
+
+        $caseReflection = $enumReflection->getCase($caseName);
+
+        self::assertInstanceOf(ReflectionEnumCase::class, $caseReflection);
+        self::assertSame($hasValue, $caseReflection->hasValueExpression());
     }
 
     /** @return list<array{0: class-string, 1: non-empty-string, 2: int|string}> */


### PR DESCRIPTION
Hi @Ocramius 

We encountered an issue in PHPStan when someone analyse some (invalid) PHP code with an invalid backed enum with a case without value, PHPStan is crashing (https://github.com/phpstan/phpstan/issues/7927).

Our strategy would be to introduce a `ReflectionEnumCase::hasValueExpression` method (basically a is valid enum case). And before adding it to the Phpstan/BetterReflection fork, I wanted to know if you would be interested/ok having this method in BetterReflection because it might have some other interest.

I tried added a test case to show the situation.

Feel free to close this PR if the method doesn't interest you.
Thanks !