### PR TITLE
Add ReflectionEnumBackedCase::hasBackingValue

### DIFF
--- a/src/Reflection/Adapter/ReflectionEnumBackedCase.php
+++ b/src/Reflection/Adapter/ReflectionEnumBackedCase.php
@@ -125,6 +125,11 @@ final class ReflectionEnumBackedCase extends CoreReflectionEnumBackedCase
         return new ReflectionEnum($this->betterReflectionEnumCase->getDeclaringEnum());
     }
 
+    public function hasBackingValue(): bool
+    {
+        return $this->betterReflectionEnumCase->hasValueExpression();
+    }
+
     public function getBackingValue(): int|string
     {
         return $this->betterReflectionEnumCase->getValue();

--- a/test/unit/Reflection/Adapter/ReflectionEnumBackedCaseTest.php
+++ b/test/unit/Reflection/Adapter/ReflectionEnumBackedCaseTest.php
@@ -357,6 +357,18 @@ class ReflectionEnumBackedCaseTest extends TestCase
         self::assertSame(123, $reflectionEnumBackedCaseAdapter->getBackingValue());
     }
 
+    public function testHasBackingType(): void
+    {
+        $betterReflectionEnumCase = $this->createMock(BetterReflectionEnumCase::class);
+        $betterReflectionEnumCase
+            ->method('hasValueExpression')
+            ->willReturn(true);
+
+        $reflectionEnumBackedCaseAdapter = new ReflectionEnumBackedCaseAdapter($betterReflectionEnumCase);
+
+        self::assertTrue($reflectionEnumBackedCaseAdapter->hasBackingValue());
+    }
+
     public function testPropertyName(): void
     {
         $betterReflectionEnumCase = $this->createMock(BetterReflectionEnumCase::class);


### PR DESCRIPTION
Sorry @Ocramius, I feel like I missed something in https://github.com/Roave/BetterReflection/pull/1526

PHPStan (and I assume some other code) is working with `ReflectionEnumBackedCase`, because it uses
```
ReflectionEnum::getCases()
```
and since `betterReflectionEnumCase` is not public, I cannot call `hasValueExpression` on it.

So I have two solution in mind:

1) Exposing `ReflectionEnumBackedCase::hasBackingValue` => This PR

2) The other solution would be to modify `ReflectionEnum::getCase()` and `ReflectionEnum::getCases()` to check for `$this->betterReflectionEnum->isBacked()` and/or `$case->hasValueExpression()`, 
https://github.com/Roave/BetterReflection/blob/d9f0f93b6c11d6738df13d8eb8777eb713fda82b/src/Reflection/Adapter/ReflectionEnum.php#L578-L604

This would be PR https://github.com/Roave/BetterReflection/pull/1527

Only one of both PR should be merged