### PR TITLE
`ReflectionProperty#setValue()` always requires 2 arguments

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -6,6 +6,7 @@
     colors="true"
     executionOrder="random"
     cacheDirectory=".phpunit.cache"
+    failOnDeprecation="true"
 >
     <source>
         <include>

--- a/src/Reflection/Adapter/ReflectionClass.php
+++ b/src/Reflection/Adapter/ReflectionClass.php
@@ -600,7 +600,7 @@ final class ReflectionClass extends CoreReflectionClass
             throw new CoreReflectionException(sprintf('Class %s does not have a property named %s', $this->betterReflectionClass->getName(), $name));
         }
 
-        $property->setValue($value);
+        $property->setValue(null, $value);
     }
 
     /**

--- a/test/unit/Reflection/Adapter/ReflectionClassTest.php
+++ b/test/unit/Reflection/Adapter/ReflectionClassTest.php
@@ -728,7 +728,7 @@ class ReflectionClassTest extends TestCase
         $betterReflectionProperty
             ->expects($this->once())
             ->method('setValue')
-            ->with(123);
+            ->with(null, 123);
 
         $betterReflectionClass = $this->createMock(BetterReflectionClass::class);
         $betterReflectionClass

--- a/test/unit/Reflection/Adapter/ReflectionObjectTest.php
+++ b/test/unit/Reflection/Adapter/ReflectionObjectTest.php
@@ -958,7 +958,6 @@ class ReflectionObjectTest extends TestCase
         $betterReflectionObject           = $betterReflectionObjectReflection->newInstanceWithoutConstructor();
 
         $betterReflectionObjectClassPropertyReflection = $betterReflectionObjectReflection->getProperty('reflectionClass');
-        $betterReflectionObjectClassPropertyReflection->setAccessible(true);
         $betterReflectionObjectClassPropertyReflection->setValue($betterReflectionObject, $betterReflectionClass);
 
         $reflectionObjectAdapter = new ReflectionObjectAdapter($betterReflectionObject);
@@ -1067,7 +1066,6 @@ class ReflectionObjectTest extends TestCase
         $betterReflectionObject           = $betterReflectionObjectReflection->newInstanceWithoutConstructor();
 
         $betterReflectionObjectClassPropertyReflection = $betterReflectionObjectReflection->getProperty('reflectionClass');
-        $betterReflectionObjectClassPropertyReflection->setAccessible(true);
         $betterReflectionObjectClassPropertyReflection->setValue($betterReflectionObject, $betterReflectionClass);
 
         $reflectionObjectAdapter = new ReflectionObjectAdapter($betterReflectionObject);

--- a/test/unit/Reflection/ReflectionObjectTest.php
+++ b/test/unit/Reflection/ReflectionObjectTest.php
@@ -151,11 +151,9 @@ class ReflectionObjectTest extends TestCase
         $reflectionObjectReflection = new CoreReflectionObject($classInfo);
 
         $reflectionObjectObjectReflection = $reflectionObjectReflection->getProperty('object');
-        $reflectionObjectObjectReflection->setAccessible(true);
         $reflectionObjectObjectReflection->setValue($classInfo, new stdClass());
 
         $reflectionObjectReflectionClassReflection = $reflectionObjectReflection->getProperty('reflectionClass');
-        $reflectionObjectReflectionClassReflection->setAccessible(true);
         $reflectionObjectReflectionClassReflection->setValue($classInfo, $mockClass);
 
         $this->expectException(InvalidArgumentException::class);
@@ -300,7 +298,6 @@ class ReflectionObjectTest extends TestCase
 
         foreach ($properties as $propertyName => $propertyValue) {
             $mockReflectionClassNodeReflection = $mockReflectionClassReflection->getProperty($propertyName);
-            $mockReflectionClassNodeReflection->setAccessible(true);
             $mockReflectionClassNodeReflection->setValue($mockReflectionClass, $propertyValue);
         }
 
@@ -311,7 +308,6 @@ class ReflectionObjectTest extends TestCase
         // the mocked reflectionclass above
         $reflectionObjectReflection                        = new CoreReflectionObject($reflectionObject);
         $reflectionObjectReflectionClassPropertyReflection = $reflectionObjectReflection->getProperty('reflectionClass');
-        $reflectionObjectReflectionClassPropertyReflection->setAccessible(true);
         $reflectionObjectReflectionClassPropertyReflection->setValue($reflectionObject, $mockReflectionClass);
 
         $reflectionObjectReflectionMethod = $reflectionObjectReflection->getMethod($methodName);

--- a/test/unit/SourceLocator/Ast/Exception/ParseToAstFailureTest.php
+++ b/test/unit/SourceLocator/Ast/Exception/ParseToAstFailureTest.php
@@ -172,7 +172,6 @@ class ParseToAstFailureTest extends TestCase
         $locatedSource = new LocatedSource('<?php abc', 'Whatever');
 
         $filenameProperty = new ReflectionProperty($locatedSource, 'filename');
-        $filenameProperty->setAccessible(true);
         $filenameProperty->setValue($locatedSource, '/foo/bar');
 
         $previous = new Error('Some error message', ['startLine' => 1]);
@@ -209,7 +208,6 @@ class ParseToAstFailureTest extends TestCase
         $locatedSource = new LocatedSource('<?php abc', 'Whatever');
 
         $filenameProperty = new ReflectionProperty($locatedSource, 'filename');
-        $filenameProperty->setAccessible(true);
         $filenameProperty->setValue($locatedSource, '/foo/bar');
 
         $previous = new Exception('Unknown error');

--- a/test/unit/SourceLocator/SourceStubber/PhpStormStubsSourceStubberTest.php
+++ b/test/unit/SourceLocator/SourceStubber/PhpStormStubsSourceStubberTest.php
@@ -768,14 +768,17 @@ class PhpStormStubsSourceStubberTest extends TestCase
         $stubDirectoryReflection->setValue($sourceStubber, __DIR__ . '/../../Fixture');
 
         $classMapReflection = $stubberReflection->getProperty('classMap');
+
         $classMapValue                                                     = $classMapReflection->getValue();
         $classMapValue['roave\betterreflectiontest\fixture\fakeconstants'] = 'fakeconstants/FakeConstantsStub.php';
         $classMapReflection->setValue($classMapReflection, $classMapValue);
 
         $constantMapReflection = $stubberReflection->getProperty('constantMap');
+
         $constantMapValue                                                      = $constantMapReflection->getValue();
         $constantMapValue['define_constant']                                   = 'fakeconstants/FakeConstantsStub.php';
         $constantMapValue['roave\betterreflectiontest\fixture\const_constant'] = 'fakeconstants/FakeConstantsStub.php';
+
         $constantMapReflection->setValue($constantMapReflection, $constantMapValue);
 
         $classConstantStub = $sourceStubber->generateClassStub('Roave\BetterReflectionTest\Fixture\FakeConstants');

--- a/test/unit/SourceLocator/SourceStubber/PhpStormStubsSourceStubberTest.php
+++ b/test/unit/SourceLocator/SourceStubber/PhpStormStubsSourceStubberTest.php
@@ -765,17 +765,14 @@ class PhpStormStubsSourceStubberTest extends TestCase
         $stubberReflection = new CoreReflectionClass($sourceStubber);
 
         $stubDirectoryReflection = $stubberReflection->getProperty('stubsDirectory');
-        $stubDirectoryReflection->setAccessible(true);
         $stubDirectoryReflection->setValue($sourceStubber, __DIR__ . '/../../Fixture');
 
         $classMapReflection = $stubberReflection->getProperty('classMap');
-        $classMapReflection->setAccessible(true);
         $classMapValue                                                     = $classMapReflection->getValue();
         $classMapValue['roave\betterreflectiontest\fixture\fakeconstants'] = 'fakeconstants/FakeConstantsStub.php';
         $classMapReflection->setValue($classMapReflection, $classMapValue);
 
         $constantMapReflection = $stubberReflection->getProperty('constantMap');
-        $constantMapReflection->setAccessible(true);
         $constantMapValue                                                      = $constantMapReflection->getValue();
         $constantMapValue['define_constant']                                   = 'fakeconstants/FakeConstantsStub.php';
         $constantMapValue['roave\betterreflectiontest\fixture\const_constant'] = 'fakeconstants/FakeConstantsStub.php';

--- a/test/unit/SourceLocator/Type/AnonymousClassObjectSourceLocatorTest.php
+++ b/test/unit/SourceLocator/Type/AnonymousClassObjectSourceLocatorTest.php
@@ -165,7 +165,6 @@ class AnonymousClassObjectSourceLocatorTest extends TestCase
             ->willReturn(0);
 
         $coreReflectionPropertyInSourceLocatatorReflection = $sourceLocatorReflection->getProperty('coreClassReflection');
-        $coreReflectionPropertyInSourceLocatatorReflection->setAccessible(true);
         $coreReflectionPropertyInSourceLocatatorReflection->setValue($sourceLocator, $coreReflectionPropertyMock);
 
         $this->expectException(NoAnonymousClassOnLine::class);
@@ -262,7 +261,6 @@ class AnonymousClassObjectSourceLocatorTest extends TestCase
 
         $sourceLocatorReflection                            = new CoreReflectionClass($sourceLocator);
         $sourceLocatorReflectionCoreClassReflectionProperty = $sourceLocatorReflection->getProperty('coreClassReflection');
-        $sourceLocatorReflectionCoreClassReflectionProperty->setAccessible(true);
         $sourceLocatorReflectionCoreClassReflectionProperty->setValue($sourceLocator, $sourceLocatorReflectionCoreClassReflectionPropertyValue);
 
         $this->expectException(InvalidFileLocation::class);

--- a/test/unit/SourceLocator/Type/AutoloadSourceLocatorTest.php
+++ b/test/unit/SourceLocator/Type/AutoloadSourceLocatorTest.php
@@ -345,7 +345,7 @@ class AutoloadSourceLocatorTest extends TestCase
         $type           = new IdentifierType();
         $typeReflection = new ReflectionObject($type);
         $prop           = $typeReflection->getProperty('name');
-        $prop->setAccessible(true);
+
         $prop->setValue($type, 'nonsense');
 
         $identifier = new Identifier('foo', $type);

--- a/test/unit/SourceLocator/Type/ClosureSourceLocatorTest.php
+++ b/test/unit/SourceLocator/Type/ClosureSourceLocatorTest.php
@@ -141,7 +141,6 @@ class ClosureSourceLocatorTest extends TestCase
             ->willReturn(0);
 
         $coreReflectionPropertyInSourceLocatatorReflection = $sourceLocatorReflection->getProperty('coreFunctionReflection');
-        $coreReflectionPropertyInSourceLocatatorReflection->setAccessible(true);
         $coreReflectionPropertyInSourceLocatatorReflection->setValue($sourceLocator, $coreReflectionPropertyMock);
 
         $this->expectException(NoClosureOnLine::class);
@@ -221,7 +220,6 @@ class ClosureSourceLocatorTest extends TestCase
 
         $sourceLocatorReflection                               = new CoreReflectionClass($sourceLocator);
         $sourceLocatorReflectionCoreFunctionReflectionProperty = $sourceLocatorReflection->getProperty('coreFunctionReflection');
-        $sourceLocatorReflectionCoreFunctionReflectionProperty->setAccessible(true);
         $sourceLocatorReflectionCoreFunctionReflectionProperty->setValue($sourceLocator, $sourceLocatorReflectionCoreFunctionReflectionPropertyValue);
 
         $this->expectException(InvalidFileLocation::class);


### PR DESCRIPTION
Ref: https://www.php.net/manual/en/reflectionproperty.setvalue.php#refsect1-reflectionproperty.setvalue-changelog

In `ext-reflection`, usage with a single argument is deprecated.

Fixes #1537