### PR TITLE
Fixed `ReflectionMethod::isGenerator()` to work on class methods too

### DIFF
--- a/src/Reflection/ReflectionFunction.php
+++ b/src/Reflection/ReflectionFunction.php
@@ -46,9 +46,8 @@ class ReflectionFunction implements Reflection
 
         $isClosure = $node instanceof Node\Expr\Closure || $node instanceof Node\Expr\ArrowFunction;
 
-        $this->isStatic    = $isClosure && $node->static;
-        $this->isClosure   = $isClosure;
-        $this->isGenerator = $this->nodeIsOrContainsYield($node);
+        $this->isStatic  = $isClosure && $node->static;
+        $this->isClosure = $isClosure;
     }
 
     /** @throws IdentifierNotFound */

--- a/src/Reflection/ReflectionFunctionAbstract.php
+++ b/src/Reflection/ReflectionFunctionAbstract.php
@@ -108,6 +108,7 @@ trait ReflectionFunctionAbstract
         $this->attributes       = ReflectionAttributeHelper::createAttributes($this->reflector, $this, $node->attrGroups);
         $this->docComment       = GetLastDocComment::forNode($node);
         $this->couldThrow       = $this->computeCouldThrow($node);
+        $this->isGenerator      = $this->nodeIsOrContainsYield($node);
 
         $startLine = $node->getStartLine();
         if ($startLine === -1) {

--- a/test/unit/Reflection/ReflectionMethodTest.php
+++ b/test/unit/Reflection/ReflectionMethodTest.php
@@ -906,4 +906,24 @@ PHP;
         self::assertNotNull($hookReflection);
         self::assertSame($isFinal, $hookReflection->isFinal());
     }
+
+    public function testIsGenerator(): void
+    {
+        $php = <<<'PHP'
+            <?php
+            class Foo
+            {
+                public function boo()
+                {
+                    yield;
+                }
+            }
+        PHP;
+
+        $reflector        = new DefaultReflector(new StringSourceLocator($php, $this->astLocator));
+        $classReflection  = $reflector->reflectClass('Foo');
+        $methodReflection = $classReflection->getMethod('boo');
+
+        self::assertTrue($methodReflection->isGenerator());
+    }
 }


### PR DESCRIPTION
I've made only a small unit test because it's already tested for `ReflectionFunctionAbstract`: https://github.com/Roave/BetterReflection/blob/6.67.x/test/unit/Reflection/ReflectionFunctionAbstractTest.php#L219-L253