### PR TITLE
Test deprecated constant via `define()`

### DIFF
--- a/test/unit/SourceLocator/SourceStubber/PhpStormStubsSourceStubberTest.php
+++ b/test/unit/SourceLocator/SourceStubber/PhpStormStubsSourceStubberTest.php
@@ -558,6 +558,28 @@ class PhpStormStubsSourceStubberTest extends TestCase
         self::assertStringEndsWith(";\n", $stub->getStub());
     }
 
+    public function testStubForConstantDeclaredByDefineThatIsDeprecated(): void
+    {
+        $stubData = $this->sourceStubber->generateConstantStub('E_STRICT');
+
+        self::assertStringContainsString(
+            "define('E_STRICT', 2048);",
+            $stubData->getStub(),
+        );
+
+        if (PHP_VERSION_ID >= 80400) {
+            self::assertStringContainsString(
+                '@deprecated 8.4',
+                $stubData->getStub(),
+            );
+        } else {
+            self::assertStringNotContainsString(
+                '@deprecated 8.4',
+                $stubData->getStub(),
+            );
+        }
+    }
+
     public function testStubForConstantDeclaredByConst(): void
     {
         $stub = $this->sourceStubber->generateConstantStub('ast\AST_ARG_LIST');


### PR DESCRIPTION
while hunting a bug I suspected BetterReflection would not properly see constants as deprecated if PHPStorm stubs contain it.

seems I was wrong,...  but I think the test is still useful, so I figured I would submit it.

background: https://php.watch/versions/8.4/E_STRICT-deprecated