### PR TITLE
Fixed `ReflectionClass::getInterfaceClassNames()` to include the implicit `UnitEnum`, `BackedEnum` and `Stringable`

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="6.4.0@04f312ac6ea48ba1c3e5db4d815bf6d74641c0ee">
+<files psalm-version="6.15.1@28dc127af1b5aecd52314f6f645bafc10d0e11f9">
   <file src="src/Reflection/Attribute/ReflectionAttributeHelper.php">
     <ImpureMethodCall>
       <code><![CDATA[toLowerString]]></code>
@@ -96,8 +96,6 @@
       <code><![CDATA[push]]></code>
       <code><![CDATA[push]]></code>
       <code><![CDATA[push]]></code>
-      <code><![CDATA[reflectClass]]></code>
-      <code><![CDATA[reflectClass]]></code>
       <code><![CDATA[reflectClass]]></code>
       <code><![CDATA[reflectClass]]></code>
       <code><![CDATA[reflectClass]]></code>

--- a/src/Reflection/ReflectionClass.php
+++ b/src/Reflection/ReflectionClass.php
@@ -303,8 +303,9 @@ class ReflectionClass implements Reflection
             return $this->parentClassName;
         }
 
-        if ($this->implementsClassNames !== []) {
-            return $this->implementsClassNames[0];
+        $implementsClassName = $this->getInterfaceClassNames();
+        if ($implementsClassName !== []) {
+            return $implementsClassName[0];
         }
 
         return 'class';
@@ -1298,17 +1299,21 @@ class ReflectionClass implements Reflection
     }
 
     /**
-     * @param array<class-string, self> $interfaces
+     * @param list<class-string> $interfaceClassNames
      *
-     * @return array<class-string, self>
+     * @return list<class-string>
      */
-    private function addStringableInterface(array $interfaces): array
+    private function addStringableInterfaceClassName(array $interfaceClassNames): array
     {
         /** @psalm-var class-string $stringableClassName */
         $stringableClassName = Stringable::class;
 
-        if (array_key_exists($stringableClassName, $interfaces) || ($this->isInterface && $this->getName() === $stringableClassName)) {
-            return $interfaces;
+        if ($this->isInterface && $this->getName() === $stringableClassName) {
+            return $interfaceClassNames;
+        }
+
+        if (in_array($stringableClassName, $interfaceClassNames, true)) {
+            return $interfaceClassNames;
         }
 
         $methods = $this->immediateMethods;
@@ -1322,7 +1327,7 @@ class ReflectionClass implements Reflection
                     $stringableInterfaceReflection = $this->reflector->reflectClass($stringableClassName);
 
                     if ($stringableInterfaceReflection->isInternal()) {
-                        $interfaces[$stringableClassName] = $stringableInterfaceReflection;
+                        $interfaceClassNames[] = $stringableClassName;
                     }
                 } catch (IdentifierNotFound) {
                     // Stringable interface does not exist on target PHP version
@@ -1333,28 +1338,25 @@ class ReflectionClass implements Reflection
             }
         }
 
-        return $interfaces;
+        return $interfaceClassNames;
     }
 
     /**
-     * @param array<class-string, self> $interfaces
+     * @param list<class-string> $interfaceClassNames
      *
-     * @return array<class-string, self>
-     *
-     * @psalm-suppress MoreSpecificReturnType
+     * @return list<class-string>
      */
-    private function addEnumInterfaces(array $interfaces): array
+    private function addEnumInterfaceClassNames(array $interfaceClassNames): array
     {
         assert($this->isEnum === true);
 
-        $interfaces[UnitEnum::class] = $this->reflector->reflectClass(UnitEnum::class);
+        $interfaceClassNames[] = UnitEnum::class;
 
         if ($this->isBackedEnum) {
-            $interfaces[BackedEnum::class] = $this->reflector->reflectClass(BackedEnum::class);
+            $interfaceClassNames[] = BackedEnum::class;
         }
 
-        /** @psalm-suppress LessSpecificReturnStatement */
-        return $interfaces;
+        return $interfaceClassNames;
     }
 
     /** @return list<trait-string> */
@@ -1574,7 +1576,13 @@ class ReflectionClass implements Reflection
     /** @return list<class-string> */
     public function getInterfaceClassNames(): array
     {
-        return $this->implementsClassNames;
+        $implementsClassNames = $this->implementsClassNames;
+
+        if ($this->isEnum) {
+            $implementsClassNames = $this->addEnumInterfaceClassNames($implementsClassNames);
+        }
+
+        return $this->addStringableInterfaceClassName($implementsClassNames);
     }
 
     /**
@@ -1610,19 +1618,15 @@ class ReflectionClass implements Reflection
             return [];
         }
 
-        $interfaces = array_combine(
-            $this->implementsClassNames,
+        $implementsClassName = $this->getInterfaceClassNames();
+
+        return array_combine(
+            $implementsClassName,
             array_map(
                 fn (string $interfaceClassName): ReflectionClass => $this->reflector->reflectClass($interfaceClassName),
-                $this->implementsClassNames,
+                $implementsClassName,
             ),
         );
-
-        if ($this->isEnum) {
-            $interfaces = $this->addEnumInterfaces($interfaces);
-        }
-
-        return $this->addStringableInterface($interfaces);
     }
 
     /**
@@ -1755,21 +1759,15 @@ class ReflectionClass implements Reflection
             return array_slice($this->getInterfacesHierarchy(AlreadyVisitedClasses::createEmpty()), 1);
         }
 
-        $interfaces = array_merge(
+        return array_merge(
             [],
             ...array_map(
                 fn (string $interfaceClassName): array => $this->reflector
                     ->reflectClass($interfaceClassName)
                     ->getInterfacesHierarchy(AlreadyVisitedClasses::createEmpty()),
-                $this->implementsClassNames,
+                $this->getInterfaceClassNames(),
             ),
         );
-
-        if ($this->isEnum) {
-            $interfaces = $this->addEnumInterfaces($interfaces);
-        }
-
-        return $this->addStringableInterface($interfaces);
     }
 
     /**
@@ -1797,7 +1795,7 @@ class ReflectionClass implements Reflection
             }
         }
 
-        return $this->addStringableInterface($interfaces);
+        return $interfaces;
     }
 
     /**

--- a/test/unit/Reflection/ReflectionClassTest.php
+++ b/test/unit/Reflection/ReflectionClassTest.php
@@ -509,12 +509,12 @@ class ReflectionClassTest extends TestCase
             [
                 __DIR__ . '/../Fixture/Enums.php',
                 IntEnum::class,
-                ['Roave\BetterReflectionTest\Fixture\InterfaceForEnum'],
+                ['Roave\BetterReflectionTest\Fixture\InterfaceForEnum', UnitEnum::class, BackedEnum::class],
             ],
             [
                 __DIR__ . '/../Fixture/Enums.php',
                 Fixture\IsDeprecated::class,
-                [],
+                [UnitEnum::class],
             ],
         ];
     }
@@ -1865,6 +1865,7 @@ PHP;
 
         self::assertSame([InterfaceForEnum::class, UnitEnum::class], $classInfo->getInterfaceNames());
         self::assertArrayHasKey(UnitEnum::class, $classInfo->getImmediateInterfaces());
+        self::assertContains(UnitEnum::class, $classInfo->getInterfaceClassNames());
     }
 
     public function testGetInterfaceNamesForBackedEnum(): void
@@ -1878,7 +1879,9 @@ PHP;
 
         self::assertSame([InterfaceForEnum::class, UnitEnum::class, BackedEnum::class], $classInfo->getInterfaceNames());
         self::assertArrayHasKey(UnitEnum::class, $classInfo->getImmediateInterfaces());
+        self::assertContains(UnitEnum::class, $classInfo->getInterfaceClassNames());
         self::assertArrayHasKey(BackedEnum::class, $classInfo->getImmediateInterfaces());
+        self::assertContains(BackedEnum::class, $classInfo->getInterfaceClassNames());
     }
 
     public function testGetInterfaces(): void
@@ -2761,26 +2764,32 @@ PHP;
 
         $classImplementingStringable = $reflector->reflectClass('ClassHasStringable');
         self::assertContains(Stringable::class, $classImplementingStringable->getInterfaceNames());
+        self::assertContains(Stringable::class, $classImplementingStringable->getInterfaceClassNames());
         self::assertArrayHasKey(Stringable::class, $classImplementingStringable->getImmediateInterfaces());
 
         $classNotImplementingStringable = $reflector->reflectClass('ClassHasStringableAutomatically');
         self::assertContains(Stringable::class, $classNotImplementingStringable->getInterfaceNames());
+        self::assertContains(Stringable::class, $classNotImplementingStringable->getInterfaceClassNames());
         self::assertArrayHasKey(Stringable::class, $classNotImplementingStringable->getImmediateInterfaces());
 
         $classNotImplementingStringable = $reflector->reflectClass('ClassHasStringableAutomaticallyWithLowercasedMethodName');
         self::assertContains(Stringable::class, $classNotImplementingStringable->getInterfaceNames());
+        self::assertContains(Stringable::class, $classNotImplementingStringable->getInterfaceClassNames());
         self::assertArrayHasKey(Stringable::class, $classNotImplementingStringable->getImmediateInterfaces());
 
         $interfaceExtendingStringable = $reflector->reflectClass('InterfaceHasStringable');
         self::assertContains(Stringable::class, $interfaceExtendingStringable->getInterfaceNames());
+        self::assertContains(Stringable::class, $interfaceExtendingStringable->getInterfaceClassNames());
         self::assertArrayHasKey(Stringable::class, $interfaceExtendingStringable->getImmediateInterfaces());
 
         $interfaceNotExtendingStringable = $reflector->reflectClass('InterfaceHasStringableAutomatically');
         self::assertContains(Stringable::class, $interfaceNotExtendingStringable->getInterfaceNames());
+        self::assertContains(Stringable::class, $interfaceNotExtendingStringable->getInterfaceClassNames());
         self::assertArrayHasKey(Stringable::class, $interfaceNotExtendingStringable->getImmediateInterfaces());
 
         $stringable = $reflector->reflectClass('Stringable');
         self::assertNotContains(Stringable::class, $stringable->getInterfaceNames());
+        self::assertNotContains(Stringable::class, $stringable->getInterfaceClassNames());
         self::assertArrayNotHasKey(Stringable::class, $stringable->getImmediateInterfaces());
     }
 


### PR DESCRIPTION
`UnitEnum`, `BackedEnum` and `Stringable` were missing