### PR TITLE
Compile closures and first-class callables in constant expressions (PHP 8.5)

### DIFF
--- a/src/NodeCompiler/CompileNodeToValue.php
+++ b/src/NodeCompiler/CompileNodeToValue.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace Roave\BetterReflection\NodeCompiler;
 
+use Closure;
 use PhpParser\ConstExprEvaluator;
 use PhpParser\Node;
+use PhpParser\PrettyPrinter\Standard as PrettyPrinter;
 use Roave\BetterReflection\Reflection\ReflectionClass;
 use Roave\BetterReflection\Reflection\ReflectionClassConstant;
 use Roave\BetterReflection\Reflection\ReflectionEnum;
@@ -14,6 +16,7 @@ use Roave\BetterReflection\Reflector\Exception\IdentifierNotFound;
 use Roave\BetterReflection\Util\FileHelper;
 
 use function assert;
+use function class_exists;
 use function constant;
 use function defined;
 use function dirname;
@@ -167,6 +170,17 @@ class CompileNodeToValue
                 return (object) $this($node->expr, $context)->value;
             }
 
+            if ($node instanceof Node\Expr\Closure) {
+                return $this->compileClosureDeclaration($node, $context);
+            }
+
+            if (
+                ($node instanceof Node\Expr\FuncCall || $node instanceof Node\Expr\StaticCall)
+                && $node->isFirstClassCallable()
+            ) {
+                return $this->compileClosureDeclaration($node, $context);
+            }
+
             throw Exception\UnableToCompileNode::forUnRecognizedExpressionInContext($node, $context);
         });
 
@@ -174,6 +188,43 @@ class CompileNodeToValue
         $value = $constExprEvaluator->evaluateDirectly($node);
 
         return new CompiledValue($value, $constantName);
+    }
+
+    /**
+     * Compile a closure or a first-class callable declared in a constant expression (PHP 8.5+)
+     * into a real Closure, like native reflection does.
+     *
+     * The language guarantees such closures are static and capture no variables,
+     * so evaluating the declaration itself executes no user code.
+     */
+    private function compileClosureDeclaration(Node\Expr\Closure|Node\Expr\FuncCall|Node\Expr\StaticCall $node, CompilerContext $context): Closure
+    {
+        if ($node instanceof Node\Expr\StaticCall && $node->class instanceof Node\Name) {
+            $className   = $this->resolveClassName($node->class->toString(), $context);
+            $node        = clone $node;
+            $node->class = new Node\Name\FullyQualified($className);
+        }
+
+        $code = (new PrettyPrinter())->prettyPrintExpr($node);
+
+        $namespace = $context->getNamespace();
+
+        // The namespace wrapper keeps the fallback to global scope for unqualified function calls
+        $code = $namespace !== null && $namespace !== ''
+            ? sprintf('namespace %s; return %s;', $namespace, $code)
+            : sprintf('return %s;', $code);
+
+        $closure = eval($code);
+        assert($closure instanceof Closure);
+
+        $className = $context->getClass()?->getName();
+
+        // Bind the class scope like native reflection does, but never trigger autoloading
+        if ($className !== null && class_exists($className, false)) {
+            return Closure::bind($closure, null, $className) ?? $closure;
+        }
+
+        return $closure;
     }
 
     private function getEnumPropertyValue(Node\Expr\PropertyFetch $node, CompilerContext $context): mixed

--- a/src/Reflection/ReflectionClass.php
+++ b/src/Reflection/ReflectionClass.php
@@ -1075,7 +1075,7 @@ class ReflectionClass implements Reflection
     public function getDefaultProperties(): array
     {
         return array_map(
-            static fn (ReflectionProperty $property) => $property->getDefaultValue(),
+            static fn (ReflectionProperty $property): mixed => $property->getDefaultValue(),
             $this->getProperties(),
         );
     }

--- a/src/Reflection/ReflectionObject.php
+++ b/src/Reflection/ReflectionObject.php
@@ -253,7 +253,7 @@ class ReflectionObject extends ReflectionClass
     public function getDefaultProperties(): array
     {
         return array_map(
-            static fn (ReflectionProperty $property) => $property->getDefaultValue(),
+            static fn (ReflectionProperty $property): mixed => $property->getDefaultValue(),
             array_filter($this->getProperties(), static fn (ReflectionProperty $property): bool => $property->isDefault()),
         );
     }

--- a/src/Reflection/ReflectionParameter.php
+++ b/src/Reflection/ReflectionParameter.php
@@ -366,17 +366,12 @@ class ReflectionParameter
     /**
      * Get the default value of the parameter.
      *
-     * @return scalar|array<scalar>|null
-     *
      * @throws LogicException
      * @throws UnableToCompileNode
      */
-    public function getDefaultValue(): string|int|float|bool|array|null
+    public function getDefaultValue(): mixed
     {
-        /** @psalm-var scalar|array<scalar>|null $value */
-        $value = $this->getCompiledDefaultValue()->value;
-
-        return $value;
+        return $this->getCompiledDefaultValue()->value;
     }
 
     /**

--- a/src/Reflection/ReflectionProperty.php
+++ b/src/Reflection/ReflectionProperty.php
@@ -374,10 +374,8 @@ class ReflectionProperty
     /**
      * Get the default value of the property (as defined before constructor is
      * called, when the property is defined)
-     *
-     * @return scalar|array<scalar>|null
      */
-    public function getDefaultValue(): string|int|float|bool|array|null
+    public function getDefaultValue(): mixed
     {
         if ($this->default === null) {
             return null;
@@ -393,10 +391,7 @@ class ReflectionProperty
             );
         }
 
-        /** @psalm-var scalar|array<scalar>|null $value */
-        $value = $this->compiledDefaultValue->value;
-
-        return $value;
+        return $this->compiledDefaultValue->value;
     }
 
     public function isDeprecated(): bool

--- a/src/Reflection/StringCast/ReflectionParameterStringCast.php
+++ b/src/Reflection/StringCast/ReflectionParameterStringCast.php
@@ -54,6 +54,7 @@ final class ReflectionParameterStringCast
             return '';
         }
 
+        /** @var mixed $defaultValue */
         $defaultValue = $parameterReflection->getDefaultValue();
 
         if (is_array($defaultValue)) {

--- a/test/unit/Fixture/AttributesWithClosures.php
+++ b/test/unit/Fixture/AttributesWithClosures.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Roave\BetterReflectionTest\Fixture;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_ALL | Attribute::IS_REPEATABLE)]
+class AttrWithCallback
+{
+    public function __construct(public mixed $callback)
+    {
+    }
+}
+
+#[AttrWithCallback(static function (int $value): int {
+    return $value * 2;
+})]
+#[AttrWithCallback(callback: static function (string $value): string {
+    return strtolower($value);
+})]
+#[AttrWithCallback(strtoupper(...))]
+class ClassWithClosuresInAttributes
+{
+    public function methodWithClosureInParameterDefault(
+        mixed $callback = static function (): string {
+            return 'default';
+        },
+    ): void {
+    }
+}
+
+#[AttrWithCallback(static function (): string {
+    return self::secret();
+})]
+class ClassWithScopedClosureInAttribute
+{
+    private static function secret(): string
+    {
+        return 'scoped';
+    }
+}

--- a/test/unit/NodeCompiler/CompileNodeToValueTest.php
+++ b/test/unit/NodeCompiler/CompileNodeToValueTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Roave\BetterReflectionTest\NodeCompiler;
 
 use BadMethodCallException;
+use Closure;
 use PhpParser\Node;
 use PhpParser\Node\Expr\ConstFetch;
 use PhpParser\Node\Expr\Yield_;
@@ -1131,6 +1132,18 @@ PHP
         $getHookParameterAttribute = $getHookParameter->getAttributes()[0];
 
         self::assertSame($expectedValue, $getHookParameterAttribute->getArguments()[0]);
+    }
+
+    public function testClosureInParameterDefault(): void
+    {
+        $reflector = new DefaultReflector(new SingleFileSourceLocator(self::realPath(__DIR__ . '/../Fixture/AttributesWithClosures.php'), $this->astLocator));
+        $class     = $reflector->reflectClass('Roave\BetterReflectionTest\Fixture\ClassWithClosuresInAttributes');
+        $parameter = $class->getMethod('methodWithClosureInParameterDefault')->getParameter('callback');
+
+        $default = $parameter->getDefaultValue();
+
+        self::assertInstanceOf(Closure::class, $default);
+        self::assertSame('default', $default());
     }
 
     public function testObjectCast(): void

--- a/test/unit/Reflection/ReflectionAttributeTest.php
+++ b/test/unit/Reflection/ReflectionAttributeTest.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace Roave\BetterReflectionTest\Reflection;
 
 use Attribute;
+use Closure;
 use PhpParser\Node;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\RequiresPhp;
 use PHPUnit\Framework\TestCase;
 use Roave\BetterReflection\Reflection\ReflectionAttribute;
 use Roave\BetterReflection\Reflection\ReflectionClass;
@@ -18,6 +20,7 @@ use Roave\BetterReflection\SourceLocator\Type\SingleFileSourceLocator;
 use Roave\BetterReflectionTest\BetterReflectionSingleton;
 use Roave\BetterReflectionTest\Fixture\AnotherAttr;
 use Roave\BetterReflectionTest\Fixture\Attr;
+use Roave\BetterReflectionTest\Fixture\AttrWithCallback;
 use Roave\BetterReflectionTest\Fixture\ClassWithAttributes;
 use Roave\BetterReflectionTest\Fixture\ClassWithAttributesWithArguments;
 use Roave\BetterReflectionTest\Fixture\ClassWithRepeatedAttributes;
@@ -121,6 +124,43 @@ class ReflectionAttributeTest extends TestCase
         self::assertCount(count($expectedArguments), $attributes[0]->getArgumentsExpressions());
         self::assertContainsOnlyInstancesOf(Node\Expr::class, $attributes[0]->getArgumentsExpressions());
         self::assertSame($expectedArguments, $attributes[0]->getArguments());
+    }
+
+    public function testGetArgumentsWithClosures(): void
+    {
+        $reflector       = new DefaultReflector(new SingleFileSourceLocator(__DIR__ . '/../Fixture/AttributesWithClosures.php', $this->astLocator));
+        $classReflection = $reflector->reflectClass('Roave\BetterReflectionTest\Fixture\ClassWithClosuresInAttributes');
+        $attributes      = $classReflection->getAttributesByName(AttrWithCallback::class);
+
+        self::assertCount(3, $attributes);
+
+        $closure = $attributes[0]->getArguments()[0];
+        self::assertInstanceOf(Closure::class, $closure);
+        self::assertSame(42, $closure(21));
+
+        $namedArgumentClosure = $attributes[1]->getArguments()['callback'];
+        self::assertInstanceOf(Closure::class, $namedArgumentClosure);
+        self::assertSame('abc', $namedArgumentClosure('ABC'));
+
+        $firstClassCallable = $attributes[2]->getArguments()[0];
+        self::assertInstanceOf(Closure::class, $firstClassCallable);
+        self::assertSame('ABC', $firstClassCallable('abc'));
+    }
+
+    #[RequiresPhp('>= 8.5.0')]
+    public function testGetArgumentsWithClosureBoundToDeclaringClass(): void
+    {
+        require_once __DIR__ . '/../Fixture/AttributesWithClosures.php';
+
+        $reflector       = new DefaultReflector(new SingleFileSourceLocator(__DIR__ . '/../Fixture/AttributesWithClosures.php', $this->astLocator));
+        $classReflection = $reflector->reflectClass('Roave\BetterReflectionTest\Fixture\ClassWithScopedClosureInAttribute');
+        $attributes      = $classReflection->getAttributesByName(AttrWithCallback::class);
+
+        self::assertCount(1, $attributes);
+
+        $closure = $attributes[0]->getArguments()[0];
+        self::assertInstanceOf(Closure::class, $closure);
+        self::assertSame('scoped', $closure());
     }
 
     public function testGetTargetWithClass(): void


### PR DESCRIPTION
## Problem

PHP 8.5 allows static closures and first-class callables in constant expressions ([RFC](https://wiki.php.net/rfc/closures_in_const_expr)), for example in attribute arguments:

```php
#[Assert\Callback(static function (self $object, ExecutionContextInterface $context): void {
    // ...
})]
readonly class CreatedAt { /* ... */ }
```

`CompileNodeToValue` does not recognize `Expr\Closure` and first-class-callable nodes. Any call to `ReflectionAttribute::getArguments()` (or `ReflectionParameter::getDefaultValue()`, etc.) on such code throws:

```
Unable to compile expression in class ...: unrecognized node type PhpParser\Node\Expr\Closure
```

Real-world report: shipmonk-rnd/dead-code-detector#404 (PHPStan extensions crash via the bundled fork of this library). Downstream mitigation: shipmonk-rnd/dead-code-detector#405. Fork alternative (given the design-invariant objection below): ondrejmirtes/BetterReflection#44.

## Fix

Compile these nodes into real `Closure` instances, like native reflection does:

- Pretty-print the node and `eval()` it inside the declaring namespace. The language guarantees const-expr closures are **static and capture no variables**, so evaluating the declaration itself executes no user code (unlike `new` initializers, which stay rejected).
- Bind the declaring class scope (`Closure::bind`) so `self::` works inside the body, like at runtime — but only when the class is already loaded; autoloading is never triggered.
- Resolve `self`/`parent`/`static` in first-class callables (`self::foo(...)`) before printing.

`ReflectionParameter::getDefaultValue()` and `ReflectionProperty::getDefaultValue()` are widened to `mixed`, because a default value can now be a `Closure`. Native reflection declares `mixed` there as well (the adapters already do).

## BC check

The `Check Backward Compatibility` job fails on the two `getDefaultValue()` return types (narrow union to `mixed`). This is intentional: a default value can legally be a `Closure` since PHP 8.5, so the narrow type would produce a `TypeError` instead. I see no way to support this without the widening; happy to adjust if you prefer another approach (e.g. a dedicated exception instead of the type change).

Note: arrow functions need no handling — PHP 8.5 rejects them in constant expressions.

## Tests

The new tests in `ReflectionAttributeTest` and `CompileNodeToValueTest` fail on current 6.73.x with the exact error above and pass with this change. The scope-binding test requires PHP 8.5 (the fixture must be natively loadable); the rest also run on PHP 8.4, since only the analyzed code needs 8.5 syntax.

Co-Authored-By: Claude Code
